### PR TITLE
fix(edit_server): temporarily disable the changes

### DIFF
--- a/lib/screens/servers/add_server_fullscreen.dart
+++ b/lib/screens/servers/add_server_fullscreen.dart
@@ -646,14 +646,16 @@ class _AddServerFullscreenState extends State<AddServerFullscreen> {
                   padding: const EdgeInsets.symmetric(vertical: 10),
                   width: double.maxFinite,
                   child: SegmentedButton<ConnectionType>(
-                    segments: const [
+                    segments: [
                       ButtonSegment(
                         value: ConnectionType.http,
-                        label: Text('HTTP'),
+                        label: const Text('HTTP'),
+                        enabled: widget.server != null ? false : true,
                       ),
                       ButtonSegment(
                         value: ConnectionType.https,
-                        label: Text('HTTPS'),
+                        label: const Text('HTTPS'),
+                        enabled: widget.server != null ? false : true,
                       ),
                     ],
                     selected: <ConnectionType>{connectionType},
@@ -727,14 +729,16 @@ class _AddServerFullscreenState extends State<AddServerFullscreen> {
                   padding: const EdgeInsets.symmetric(vertical: 10),
                   width: double.maxFinite,
                   child: SegmentedButton<String>(
-                    segments: const [
+                    segments: [
                       ButtonSegment(
                         value: SupportedApiVersions.v5,
-                        label: Text(SupportedApiVersions.v5),
+                        label: const Text(SupportedApiVersions.v5),
+                        enabled: widget.server != null ? false : true,
                       ),
                       ButtonSegment(
                         value: SupportedApiVersions.v6,
-                        label: Text(SupportedApiVersions.v6),
+                        label: const Text(SupportedApiVersions.v6),
+                        enabled: widget.server != null ? false : true,
                       ),
                     ],
                     selected: <String>{piHoleVersion},


### PR DESCRIPTION
### Temporarily Disable the Changes  

This update temporarily disables updates for HTTP/HTTPS and v5/v6.  

A fundamental solution will be implemented in #109 

Allowed modifications only for server name and password now.

**Changes:**  
- Disabled updates for HTTP/HTTPS and v5/v6 to prevent unintended modifications.  
- This is a temporary measure until a proper fix is applied.  

**Next Steps:**  
- Implement a fundamental solution in #109 

![edit](https://github.com/user-attachments/assets/2fce0d80-67ae-4ebd-a2ee-c0485ebafe00)
