### PR TITLE
fix(database): change logsPerQuery type from int to double

### DIFF
--- a/lib/models/repository/database.dart
+++ b/lib/models/repository/database.dart
@@ -98,7 +98,7 @@ class AppDbData {
       language: map['language']! as String,
       overrideSslCheck: map['overrideSslCheck']! as int,
       reducedDataCharts: map['reducedDataCharts']! as int,
-      logsPerQuery: map['logsPerQuery']! as int,
+      logsPerQuery: (map['logsPerQuery']! as num).toDouble(),
       passCode: map['passCode'] as String?,
       useBiometricAuth: map['useBiometricAuth']! as int,
       importantInfoReaden: map['importantInfoReaden']! as int,
@@ -133,7 +133,7 @@ class AppDbData {
   final String language;
   final int overrideSslCheck;
   final int reducedDataCharts;
-  final int logsPerQuery;
+  final double logsPerQuery;
   final String? passCode;
   final int useBiometricAuth;
   final int importantInfoReaden;


### PR DESCRIPTION
## Description
This PR fixes an issue where the app crashes on startup due to a type mismatch when reading the `logsPerQuery` field from the database.  

###  Fix
- Updated the `fromMap` method to use `(map['logsPerQuery']! as num).toDouble()` instead of `as int`.  
