### PR TITLE
feat(ui): convert LanguageScreen & ThemeScreen to stateless, fix back gesture behavior (Mobile layout is not yet)

### DIFF
--- a/lib/screens/servers/servers.dart
+++ b/lib/screens/servers/servers.dart
@@ -117,15 +117,6 @@ class _ServersPageState extends State<ServersPage> {
     }
 
     return PopScope(
-      onPopInvokedWithResult: (didPop, result) async {
-        if (serversProvider.selectedServer == null) {
-          appConfigProvider.setSelectedTab(0);
-        }
-
-        if (didPop) {
-          return;
-        }
-      },
       child: Scaffold(
         appBar: AppBar(
           title: Text(AppLocalizations.of(context)!.servers),

--- a/lib/screens/settings/app_settings/language_screen.dart
+++ b/lib/screens/settings/app_settings/language_screen.dart
@@ -6,43 +6,35 @@ import 'package:pi_hole_client/providers/app_config_provider.dart';
 import 'package:pi_hole_client/widgets/custom_radio.dart';
 import 'package:provider/provider.dart';
 
-class LanguageScreen extends StatefulWidget {
+class LanguageScreen extends StatelessWidget {
   const LanguageScreen({super.key});
-
-  @override
-  State<LanguageScreen> createState() => _LanguageScreenState();
-}
-
-class _LanguageScreenState extends State<LanguageScreen> {
-  int _selectedItem = 0;
-
-  @override
-  void initState() {
-    _selectedItem = Provider.of<AppConfigProvider>(context, listen: false)
-        .selectedLanguageNumber;
-    super.initState();
-  }
 
   @override
   Widget build(BuildContext context) {
     final appConfigProvider = Provider.of<AppConfigProvider>(context);
 
-    return Scaffold(
-      appBar: AppBar(
-        title: Text(AppLocalizations.of(context)!.language),
-      ),
-      body: SafeArea(
-        child: ListView(
-          children: [
-            // System language
-            // Other languages
-            ...(languageOptions..sort((a, b) => a.key.compareTo(b.key)))
-                .map((languageOption) {
+    // Create a sorted copy of languageOptions.
+    final sortedLanguageOptions = List.from(languageOptions)
+      ..sort((a, b) => a.key.compareTo(b.key));
+
+    return WillPopScope(
+      // Ensures the system back gesture (or physical back button) navigates back to the Settings screen.
+      // Without this, the gesture back may cause the app to exit/close.
+      // Note: Using PopScope instead does not return to Settings and causes the app to close.
+      onWillPop: () async {
+        return true;
+      },
+      child: Scaffold(
+        appBar: AppBar(
+          title: Text(AppLocalizations.of(context)!.language),
+        ),
+        body: SafeArea(
+          child: ListView(
+            children: sortedLanguageOptions.map((languageOption) {
               return Material(
                 color: Colors.transparent,
                 child: InkWell(
                   onTap: () {
-                    setState(() => _selectedItem = languageOption.index);
                     appConfigProvider.setSelectedLanguage(languageOption.key);
                   },
                   child: Padding(
@@ -57,7 +49,7 @@ class _LanguageScreenState extends State<LanguageScreen> {
                       ),
                       trailing: CustomRadio(
                         value: languageOption.index,
-                        groupValue: _selectedItem,
+                        groupValue: appConfigProvider.selectedLanguageNumber,
                         backgroundColor:
                             Theme.of(context).dialogTheme.backgroundColor!,
                       ),
@@ -65,8 +57,8 @@ class _LanguageScreenState extends State<LanguageScreen> {
                   ),
                 ),
               );
-            }),
-          ],
+            }).toList(),
+          ),
         ),
       ),
     );

--- a/lib/screens/settings/app_settings/theme_screen.dart
+++ b/lib/screens/settings/app_settings/theme_screen.dart
@@ -5,22 +5,8 @@ import 'package:pi_hole_client/providers/app_config_provider.dart';
 import 'package:pi_hole_client/widgets/custom_radio.dart';
 import 'package:provider/provider.dart';
 
-class ThemeScreen extends StatefulWidget {
+class ThemeScreen extends StatelessWidget {
   const ThemeScreen({super.key});
-
-  @override
-  State<ThemeScreen> createState() => _ThemeScreenState();
-}
-
-class _ThemeScreenState extends State<ThemeScreen> {
-  int _selectedItem = 0;
-
-  @override
-  void initState() {
-    _selectedItem = Provider.of<AppConfigProvider>(context, listen: false)
-        .selectedThemeNumber;
-    super.initState();
-  }
 
   Widget _buildThemeRow(
     BuildContext context, {
@@ -33,7 +19,6 @@ class _ThemeScreenState extends State<ThemeScreen> {
       color: Colors.transparent,
       child: InkWell(
         onTap: () {
-          setState(() => _selectedItem = value);
           appConfigProvider.setSelectedTheme(value);
         },
         child: Padding(
@@ -49,7 +34,7 @@ class _ThemeScreenState extends State<ThemeScreen> {
             ),
             trailing: CustomRadio(
               value: value,
-              groupValue: _selectedItem,
+              groupValue: appConfigProvider.selectedThemeNumber,
               backgroundColor: Theme.of(context).dialogTheme.backgroundColor!,
             ),
           ),
@@ -62,35 +47,43 @@ class _ThemeScreenState extends State<ThemeScreen> {
   Widget build(BuildContext context) {
     final appConfigProvider = Provider.of<AppConfigProvider>(context);
 
-    return Scaffold(
-      appBar: AppBar(
-        title: Text(AppLocalizations.of(context)!.theme),
-      ),
-      body: SafeArea(
-        child: ListView(
-          children: [
-            _buildThemeRow(
-              context,
-              icon: Icons.phone_android_rounded,
-              text: AppLocalizations.of(context)!.systemTheme,
-              value: 0,
-              appConfigProvider: appConfigProvider,
-            ),
-            _buildThemeRow(
-              context,
-              icon: Icons.light_mode_rounded,
-              text: AppLocalizations.of(context)!.light,
-              value: 1,
-              appConfigProvider: appConfigProvider,
-            ),
-            _buildThemeRow(
-              context,
-              icon: Icons.dark_mode_rounded,
-              text: AppLocalizations.of(context)!.dark,
-              value: 2,
-              appConfigProvider: appConfigProvider,
-            ),
-          ],
+    return WillPopScope(
+      // Ensures the system back gesture (or physical back button) navigates back to the Settings screen.
+      // Without this, the gesture back may cause the app to exit/close.
+      // Note: Using PopScope instead does not return to Settings and causes the app to close.
+      onWillPop: () async {
+        return true;
+      },
+      child: Scaffold(
+        appBar: AppBar(
+          title: Text(AppLocalizations.of(context)!.theme),
+        ),
+        body: SafeArea(
+          child: ListView(
+            children: [
+              _buildThemeRow(
+                context,
+                icon: Icons.phone_android_rounded,
+                text: AppLocalizations.of(context)!.systemTheme,
+                value: 0,
+                appConfigProvider: appConfigProvider,
+              ),
+              _buildThemeRow(
+                context,
+                icon: Icons.light_mode_rounded,
+                text: AppLocalizations.of(context)!.light,
+                value: 1,
+                appConfigProvider: appConfigProvider,
+              ),
+              _buildThemeRow(
+                context,
+                icon: Icons.dark_mode_rounded,
+                text: AppLocalizations.of(context)!.dark,
+                value: 2,
+                appConfigProvider: appConfigProvider,
+              ),
+            ],
+          ),
         ),
       ),
     );


### PR DESCRIPTION
## Overview
- Converted LanguageScreen and ThemeScreen to StatelessWidgets
- Added WillPopScope to ensure the Android back gesture (system back navigation) correctly navigates back to the Settings screen on smartphones.
(Tablet layout is not yet supported.)

## Remarks
This PR only applies to smartphone layouts.
Tablet layout adjustments for WillPopScope are not yet included and require further consideration.

## Related Issue
#158 