### PR TITLE
fix(debian): resolve dpkg warning when removing piholeclient

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -131,6 +131,9 @@ jobs:
       - name: Install flutter_to_debian
         run: dart pub global activate flutter_to_debian
 
+      - name: Add executable permissions to debian/scripts/postrm
+        run: chmod +x debian/scripts/postrm
+
       - name: Generate .deb package
         run: flutter_to_debian
 

--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@
 - [🌟 Recommended lists](#-recommended-lists)
 - [💖 Donations](#-donations)
 - [🛠️ Development](#️-development)
+- [📦 Install](#-install)
 - [⚖️ License](#️-license)
 - [🖋️ Credits](#️-credits)
 
@@ -130,6 +131,12 @@ This guide includes:
 - Compiling production builds for different platforms
 - Code quality and analysis
 - CI/CD secrets management and workflows
+
+## 📦 Install
+
+For installation instructions, please refer to the following document:
+
+📖 **[Installation Guide](docs/install.md)**
 
 ## ⚖️ License
 

--- a/README.md
+++ b/README.md
@@ -60,11 +60,6 @@
 - [🌟 Recommended lists](#-recommended-lists)
 - [💖 Donations](#-donations)
 - [🛠️ Development](#️-development)
-  - [Prepare the development environment](#prepare-the-development-environment)
-  - [Compile the production build](#compile-the-production-build)
-  - [Code Quality and Analysis](#code-quality-and-analysis)
-  - [CI/CD Secrets Management](#cicd-secrets-management)
-  - [CI/CD Workflow](#cicd-workflow)
 - [⚖️ License](#️-license)
 - [🖋️ Credits](#️-credits)
 
@@ -125,97 +120,16 @@ can [become a sponsor on GitHub](https://github.com/sponsors/tsutsu3), or
 
 ## 🛠️ Development
 
-### Prepare the development environment
+For development setup and build instructions, please refer to the following document:
 
-1. Clone the repository
-2. Run `flutter pub get`
-3. Clone the `.env.sample` file and name it `.env`
-4. On the `SENTRY_DSN` variable assign it's value
-5. Inside the `android` folder, clone the `key.properties.sample` file and
-   name it `key.properties`
-6. Open the file and fill the variables with the corresponding values
-7. Store your `keystore.jks` file inside `android/app`
+📖 **[Development Guide](docs/development.md)**
 
-### Compile the production build
+This guide includes:
 
-#### Common
-
-Run these commands as needed whenever you update the images.
-
-1. Run `dart run flutter_launcher_icons`
-2. Run `dart run flutter_native_splash:create`
-
-#### Android
-
-1. Run `flutter clean`
-2. Run `flutter pub get`
-3. Run `flutter build apk --release` to build the .apk file
-4. Run `flutter build appbundle --release` to build the .aab file
-
-#### macOS
-
-1. Run `flutter clean`
-2. Run `flutter pub get`
-3. Run `flutter build macos --release` to build the .app file
-
-#### Linux
-
-First, install the required dependencies:
-
-```bash
-sudo apt install libcurl4-openssl-dev libsecret-1-dev libjsoncpp-dev
-```
-
-Then, follow these steps to build the Linux executable:
-
-1. Run `flutter clean`
-2. Run `flutter pub get`
-3. Run `flutter build linux --release` to build the Linux executable
-4. If you want to build also the .deb file do this:
-   1. Run `dart pub global activate flutter_to_debian` to install the utility
-      that will build the .deb file
-   2. Run `flutter_to_debian`
-
-#### Windows
-
-1. Run `flutter clean`
-2. Run `flutter pub get`
-3. Run `flutter build windows --release` to build the Windows executable
-4. Install the [InnoSetup](https://jrsoftware.org/isdl.php) software you don't
-   have it
-5. Run `iscc /Q windows/innosetup_installer_builder.iss` to generate the
-   Windows installer
-
-### Code Quality and Analysis
-
-To ensure code quality and identify potential issues, perform the following
-analysis steps:
-
-1. **Analyze Code**
-
-   Analyze the project to catch syntax errors, type issues, and other code problems:
-
-   ```bash
-   flutter analyze
-   ```
-
-### CI/CD Secrets Management
-
-To store and manage secrets required for GitHub Actions, refer to the
-dedicated documentation:
-
-📖 **[Managing CI/CD Secrets](docs/ci-secrets.md)**
-
-This document covers:
-
-- Required secrets for GCP authentication and secure builds.
-- Encoding and storing files as GitHub Secrets.
-
-### CI/CD Workflow
-
-The CI/CD process is outlined in the following documentation:
-
-📖 **[CI/CD Workflow](docs/ci-flow.md)**
+- Setting up the development environment
+- Compiling production builds for different platforms
+- Code quality and analysis
+- CI/CD secrets management and workflows
 
 ## ⚖️ License
 

--- a/debian/scripts/postrm
+++ b/debian/scripts/postrm
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 set -e
 
 case "$1" in

--- a/debian/scripts/postrm
+++ b/debian/scripts/postrm
@@ -1,0 +1,11 @@
+#!/bin/sh
+set -e
+
+case "$1" in
+    remove)
+        if [ -d "/usr/local/lib/PiHoleClient" ]; then
+            rm -rf /usr/local/lib/PiHoleClient
+        fi
+        ;;
+esac
+exit 0

--- a/debian/scripts/preinst
+++ b/debian/scripts/preinst
@@ -1,0 +1,25 @@
+#!/bin/bash
+echo "
+⚠️  ⚠️  ⚠️  Warning!"
+echo "
+The creator of a debian package has 100% access to every parts of the system it's installed"
+echo "
+Maintainer: tsutsu3"
+echo "
+Description: Pi-hole control app"
+
+echo "
+Sure you want to proceed with the installation of this package (yes/no) ?:"
+read choice
+
+if [[ "$choice" != "yes" ]]; then
+    #pwd # /home/user/foo
+    exit 1
+else
+    echo "proceeding..."
+    if [ $(("${2//.}")) -le 103 ]; then
+        if [ -e /var/lib/dpkg/info/PiHoleClient.list ]; then
+            rm /var/lib/dpkg/info/PiHoleClient.*
+        fi
+    fi
+fi

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,0 +1,93 @@
+## 🛠️ Development
+
+### Prepare the development environment
+
+1. Clone the repository
+2. Run `flutter pub get`
+3. Clone the `.env.sample` file and name it `.env`
+4. On the `SENTRY_DSN` variable assign it's value
+5. Inside the `android` folder, clone the `key.properties.sample` file and
+   name it `key.properties`
+6. Open the file and fill the variables with the corresponding values
+7. Store your `keystore.jks` file inside `android/app`
+
+### Compile the production build
+
+#### Common
+
+Run these commands as needed whenever you update the images.
+
+1. Run `dart run flutter_launcher_icons`
+2. Run `dart run flutter_native_splash:create`
+
+#### Android
+
+1. Run `flutter clean`
+2. Run `flutter pub get`
+3. Run `flutter build apk --release` to build the .apk file
+4. Run `flutter build appbundle --release` to build the .aab file
+
+#### macOS
+
+1. Run `flutter clean`
+2. Run `flutter pub get`
+3. Run `flutter build macos --release` to build the .app file
+
+#### Linux
+
+First, install the required dependencies:
+
+```bash
+sudo apt install libcurl4-openssl-dev libsecret-1-dev libjsoncpp-dev
+```
+
+Then, follow these steps to build the Linux executable:
+
+1. Run `flutter clean`
+2. Run `flutter pub get`
+3. Run `flutter build linux --release` to build the Linux executable
+4. If you want to build also the .deb file do this:
+   1. Run `dart pub global activate flutter_to_debian` to install the utility
+      that will build the .deb file
+   2. Run `flutter_to_debian`
+
+#### Windows
+
+1. Run `flutter clean`
+2. Run `flutter pub get`
+3. Run `flutter build windows --release` to build the Windows executable
+4. Install the [InnoSetup](https://jrsoftware.org/isdl.php) software you don't
+   have it
+5. Run `iscc /Q windows/innosetup_installer_builder.iss` to generate the
+   Windows installer
+
+### Code Quality and Analysis
+
+To ensure code quality and identify potential issues, perform the following
+analysis steps:
+
+1. **Analyze Code**
+
+   Analyze the project to catch syntax errors, type issues, and other code problems:
+
+   ```bash
+   flutter analyze
+   ```
+
+### CI/CD Secrets Management
+
+To store and manage secrets required for GitHub Actions, refer to the
+dedicated documentation:
+
+📖 **[Managing CI/CD Secrets](./ci-secrets)**
+
+This document covers:
+
+- Required secrets for GCP authentication and secure builds.
+- Encoding and storing files as GitHub Secrets.
+
+### CI/CD Workflow
+
+The CI/CD process is outlined in the following documentation:
+
+📖 **[CI/CD Workflow](./ci-flow.md)**

--- a/docs/install.md
+++ b/docs/install.md
@@ -9,34 +9,6 @@
    sudo dpkg -i PiHoleClient_<version>_Linux_amd64.deb
    ```
 
-> [!CAUTION]
-> If a version ≤ **v1.0.3** is installed, attempting to install a newer version
-> may result in the following error:
->
-> ```bash
-> dpkg: warning: old piholeclient package post-removal script subprocess returned error exit status 2
-> dpkg: trying script from the new package instead...
-> dpkg (subprocess): unable to execute new piholeclient package post-removal script (/var/lib/dpkg/tmp.ci/postrm): No such file or directory
-> dpkg: error processing archive PiHoleClient_1.0.3_Linux_amd64.deb (--install):
->  new piholeclient package post-removal script subprocess returned error exit status 2
-> ```
->
-> ### Resolution
->
-> 1. Remove the problematic files:
->
->    ```bash
->    sudo rm /var/lib/dpkg/info/piholeclient.*
->    ```
->
-> 2. Reinstall the package:
->
->    ```bash
->    sudo dpkg -i PiHoleClient_<version>_Linux_amd64.deb
->    ```
->
-> This ensures `dpkg` does not attempt to execute the missing **post-removal script** and allows the installation to proceed.
-
 ### Windows
 
 1. Download the Windows installer from the releases page.

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,0 +1,43 @@
+## 📦 Installation Guide
+
+### Linux
+
+1. Download the `.deb` package from the releases page.
+2. Install it using:
+
+   ```bash
+   sudo dpkg -i PiHoleClient_<version>_Linux_amd64.deb
+   ```
+
+> [!CAUTION]
+> If a version ≤ **v1.0.3** is installed, attempting to install a newer version
+> may result in the following error:
+>
+> ```bash
+> dpkg: warning: old piholeclient package post-removal script subprocess returned error exit status 2
+> dpkg: trying script from the new package instead...
+> dpkg (subprocess): unable to execute new piholeclient package post-removal script (/var/lib/dpkg/tmp.ci/postrm): No such file or directory
+> dpkg: error processing archive PiHoleClient_1.0.3_Linux_amd64.deb (--install):
+>  new piholeclient package post-removal script subprocess returned error exit status 2
+> ```
+>
+> ### Resolution
+>
+> 1. Remove the problematic files:
+>
+>    ```bash
+>    sudo rm /var/lib/dpkg/info/piholeclient.*
+>    ```
+>
+> 2. Reinstall the package:
+>
+>    ```bash
+>    sudo dpkg -i PiHoleClient_<version>_Linux_amd64.deb
+>    ```
+>
+> This ensures `dpkg` does not attempt to execute the missing **post-removal script** and allows the installation to proceed.
+
+### Windows
+
+1. Download the Windows installer from the releases page.
+2. Run the `.exe` installer and follow the instructions.


### PR DESCRIPTION
## Summary

- Add preinst
- Add postrm
- Add installation guide

## Check

- [x]  No warning when update
- [x]  No warning when running: `sudo dpkg -i piholeclinet`

## Artifact

https://github.com/tsutsu3/pi-hole-client/actions/runs/13871215791/artifacts/2757301494