### PR TITLE
feat(home): improve server switch indication

### DIFF
--- a/lib/screens/home/home_appbar.dart
+++ b/lib/screens/home/home_appbar.dart
@@ -140,41 +140,48 @@ class HomeAppBar extends StatelessWidget implements PreferredSizeWidget {
                 : convertColor(serversProvider.colors, Colors.red)
             : Colors.grey,
       ),
-      title: Row(
-        mainAxisAlignment: MainAxisAlignment.spaceBetween,
-        children: [
-          GestureDetector(
-            onTap: openSwitchServerModal,
-            child: serversProvider.selectedServer != null
-                ? Column(
-                    mainAxisAlignment: MainAxisAlignment.center,
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [
-                      Text(
-                        serversProvider.selectedServer!.alias,
-                        style: const TextStyle(fontSize: 20),
-                      ),
-                      Text(
-                        serversProvider.selectedServer!.address,
-                        style: TextStyle(
-                          color: Theme.of(context).listTileTheme.textColor,
-                          fontSize: 14,
+      title: InkWell(
+        onTap: openSwitchServerModal,
+        borderRadius: BorderRadius.circular(8),
+        child: Padding(
+          padding: const EdgeInsets.symmetric(vertical: 8, horizontal: 12),
+          child: Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              Expanded(
+                child: serversProvider.selectedServer != null
+                    ? Column(
+                        mainAxisAlignment: MainAxisAlignment.center,
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          Text(
+                            serversProvider.selectedServer!.alias,
+                            style: const TextStyle(fontSize: 20),
+                          ),
+                          Text(
+                            serversProvider.selectedServer!.address,
+                            style: TextStyle(
+                              color: Theme.of(context).listTileTheme.textColor,
+                              fontSize: 14,
+                            ),
+                          ),
+                        ],
+                      )
+                    : Text(
+                        AppLocalizations.of(context)!.noServerSelected,
+                        overflow: TextOverflow.ellipsis,
+                        style: const TextStyle(
+                          fontWeight: FontWeight.bold,
                         ),
                       ),
-                    ],
-                  )
-                : SizedBox(
-                    width: width - 128,
-                    child: Text(
-                      AppLocalizations.of(context)!.noServerSelected,
-                      overflow: TextOverflow.ellipsis,
-                      style: const TextStyle(
-                        fontWeight: FontWeight.bold,
-                      ),
-                    ),
-                  ),
+              ),
+              Icon(
+                Icons.sync_alt_rounded,
+                color: Theme.of(context).listTileTheme.textColor,
+              ),
+            ],
           ),
-        ],
+        ),
       ),
       actions: [
         PopupMenuButton(

--- a/lib/screens/home/home_appbar.dart
+++ b/lib/screens/home/home_appbar.dart
@@ -29,8 +29,6 @@ class HomeAppBar extends StatelessWidget implements PreferredSizeWidget {
     final statusProvider = Provider.of<StatusProvider>(context);
     final appConfigProvider = Provider.of<AppConfigProvider>(context);
 
-    final width = MediaQuery.of(context).size.width;
-
     Future<void> refresh() async {
       final process = ProcessModal(context: context);
       process.open(AppLocalizations.of(context)!.refreshingData);


### PR DESCRIPTION
## Overview
This PR enhances the visual indication for the server switching functionality .

## Changes
- Use InkWell
- Add `sync_alt_rounded` icon
- Positioned the icon on the right side

![home](https://github.com/user-attachments/assets/846ddfd9-fcdb-4424-a999-4610daf1051e)


