### PR TITLE
fix(status_update_service):prevent null check error by capturing current server state

### DIFF
--- a/lib/services/status_update_service.dart
+++ b/lib/services/status_update_service.dart
@@ -136,13 +136,14 @@ class StatusUpdateService {
         return;
       }
 
-      if (_serversProvider.selectedServer == null) {
+      final currentServer = _serversProvider.selectedServer;
+      if (currentServer == null) {
         timer?.cancel();
         return;
       }
+      final selectedUrlBefore = currentServer.address;
 
       final apiGateway = _serversProvider.selectedApiGateway;
-      final selectedUrlBefore = _serversProvider.selectedServer!.address;
       final statusResult = await apiGateway?.realtimeStatus();
 
       if (statusResult?.result == APiResponseType.success) {
@@ -155,7 +156,7 @@ class StatusUpdateService {
           _statusProvider.setIsServerConnected(true);
         }
       } else {
-        if (selectedUrlBefore == _serversProvider.selectedServer!.address) {
+        if (selectedUrlBefore == currentServer.address) {
           if (_statusProvider.isServerConnected) {
             _statusProvider.setIsServerConnected(false);
           }
@@ -178,13 +179,14 @@ class StatusUpdateService {
   // ----------------------------------------
   void _setupOverTimeDataTimer() {
     Future<void> timerFn({Timer? timer}) async {
-      if (_serversProvider.selectedServer == null) {
+      final currentServer = _serversProvider.selectedServer;
+      if (currentServer == null) {
         timer?.cancel();
         return;
       }
+      final statusUrlBefore = currentServer.address;
 
       final apiGateway = _serversProvider.selectedApiGateway;
-      final statusUrlBefore = _serversProvider.selectedServer!.address;
       final statusResult = await apiGateway?.fetchOverTimeData();
 
       if (statusResult?.result == APiResponseType.success) {
@@ -201,7 +203,7 @@ class StatusUpdateService {
           _statusProvider.setIsServerConnected(true);
         }
       } else {
-        if (statusUrlBefore == _serversProvider.selectedServer!.address) {
+        if (statusUrlBefore == currentServer.address) {
           if (_statusProvider.isServerConnected) {
             _statusProvider.setIsServerConnected(false);
           }

--- a/test/ut/services/status_update_service_test.dart
+++ b/test/ut/services/status_update_service_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/annotations.dart';
@@ -144,6 +146,64 @@ void main() async {
         verifyNever(mockStatusProvider.setOvertimeData(any)).called(0);
         expect(statusUpdateService.isAutoRefreshRunning, true);
       });
+    });
+
+    test(
+        'startAutoRefresh should not raise a type error when selectedServer becomes null during asynchronous processing in _setupStatusDataTimer',
+        () async {
+      when(mockApiGatewayV6.realtimeStatus()).thenAnswer((_) async {
+        when(mockServersProvider.selectedServer).thenReturn(null);
+        return RealtimeStatusResponse(
+          result: APiResponseType.socket,
+        );
+      });
+
+      when(mockStatusProvider.isServerConnected).thenReturn(true);
+      when(mockStatusProvider.getStatusLoading).thenReturn(LoadStatus.loading);
+      when(mockStatusProvider.getOvertimeDataLoadStatus).thenReturn(0);
+
+      Object? caughtError;
+
+      await runZonedGuarded(() async {
+        statusUpdateService.startAutoRefresh();
+        await Future.delayed(const Duration(seconds: 1));
+      }, (error, stackTrace) {
+        caughtError = error;
+      });
+
+      // No raised error
+      expect(caughtError, isNull);
+
+      statusUpdateService.dispose();
+    });
+
+    test(
+        'startAutoRefresh should not raise a type error when selectedServer becomes null during asynchronous processing in _setupOverTimeDataTimer',
+        () async {
+      when(mockApiGatewayV6.fetchOverTimeData()).thenAnswer((_) async {
+        when(mockServersProvider.selectedServer).thenReturn(null);
+        return FetchOverTimeDataResponse(
+          result: APiResponseType.socket,
+        );
+      });
+
+      when(mockStatusProvider.isServerConnected).thenReturn(true);
+      when(mockStatusProvider.getStatusLoading).thenReturn(LoadStatus.loading);
+      when(mockStatusProvider.getOvertimeDataLoadStatus).thenReturn(0);
+
+      Object? caughtError;
+
+      await runZonedGuarded(() async {
+        statusUpdateService.startAutoRefresh();
+        await Future.delayed(const Duration(seconds: 1));
+      }, (error, stackTrace) {
+        caughtError = error;
+      });
+
+      // No raised error
+      expect(caughtError, isNull);
+
+      statusUpdateService.dispose();
     });
 
     test('refreshOnce should succeed', () async {

--- a/test/ut/services/status_update_service_test.dart
+++ b/test/ut/services/status_update_service_test.dart
@@ -92,38 +92,41 @@ void main() async {
       );
     });
 
-    test('startAutoRefresh starts refreshing automatically on first run', () {
-      when(mockAppConfigProvider.getAutoRefreshTime).thenReturn(1);
+    test('startAutoRefresh starts refreshing automatically on first run',
+        () async {
+      when(mockAppConfigProvider.getAutoRefreshTime).thenReturn(5);
 
       statusUpdateService.startAutoRefresh();
 
       // sleep for 2 seconds to allow the timer to run
-      Future.delayed(const Duration(seconds: 2), () {
-        verify(mockAppConfigProvider.getAutoRefreshTime).called(3);
-        verify(mockStatusProvider.setRealtimeStatus(any)).called(1);
-        verify(mockStatusProvider.setOvertimeData(any)).called(1);
-        expect(statusUpdateService.isAutoRefreshRunning, true);
-      });
+      await Future.delayed(const Duration(seconds: 1));
+      verify(mockAppConfigProvider.getAutoRefreshTime).called(3);
+      verify(mockStatusProvider.setRealtimeStatus(any)).called(1);
+      verify(mockStatusProvider.setOvertimeData(any)).called(1);
+      expect(statusUpdateService.isAutoRefreshRunning, true);
+
+      statusUpdateService.dispose();
     });
 
     test(
         'startAutoRefresh does not start refreshing automatically on second run',
-        () {
-      when(mockAppConfigProvider.getAutoRefreshTime).thenReturn(1);
+        () async {
+      when(mockAppConfigProvider.getAutoRefreshTime).thenReturn(5);
 
       statusUpdateService.startAutoRefresh();
       statusUpdateService.startAutoRefresh();
-      Future.delayed(const Duration(seconds: 2), () {
-        verify(mockAppConfigProvider.getAutoRefreshTime).called(3);
-        verify(mockStatusProvider.setRealtimeStatus(any)).called(1);
-        verify(mockStatusProvider.setOvertimeData(any)).called(1);
-        expect(statusUpdateService.isAutoRefreshRunning, true);
-      });
+      await Future.delayed(const Duration(seconds: 1));
+      verify(mockAppConfigProvider.getAutoRefreshTime).called(3);
+      verify(mockStatusProvider.setRealtimeStatus(any)).called(1);
+      verify(mockStatusProvider.setOvertimeData(any)).called(1);
+      expect(statusUpdateService.isAutoRefreshRunning, true);
+
+      statusUpdateService.dispose();
     });
 
     test(
         'startAutoRefresh should fail when fetching data from the server fails',
-        () {
+        () async {
       when(mockApiGatewayV6.realtimeStatus()).thenAnswer(
         (_) async => RealtimeStatusResponse(
           result: APiResponseType.socket,
@@ -140,12 +143,13 @@ void main() async {
       when(mockStatusProvider.getOvertimeDataLoadStatus).thenReturn(0);
 
       statusUpdateService.startAutoRefresh();
-      Future.delayed(const Duration(seconds: 2), () {
-        verify(mockAppConfigProvider.getAutoRefreshTime).called(3);
-        verifyNever(mockStatusProvider.setRealtimeStatus(any)).called(0);
-        verifyNever(mockStatusProvider.setOvertimeData(any)).called(0);
-        expect(statusUpdateService.isAutoRefreshRunning, true);
-      });
+      await Future.delayed(const Duration(seconds: 1));
+      verify(mockAppConfigProvider.getAutoRefreshTime).called(3);
+      verifyNever(mockStatusProvider.setRealtimeStatus(any)).called(0);
+      verifyNever(mockStatusProvider.setOvertimeData(any)).called(0);
+      expect(statusUpdateService.isAutoRefreshRunning, true);
+
+      statusUpdateService.dispose();
     });
 
     test(


### PR DESCRIPTION
## Overview
Fixes a null check error by ensuring asynchronous operations always reference the correct server instance.

## Changes

- Captured the current server state in a local variable before async processing.
- Compared the captured server address with the current one before applying state updates.

