### PR TITLE
fix(status_update_service): reduce excessive web sessions on Pi-hole v6

### DIFF
--- a/lib/gateways/v6/api_gateway_v6.dart
+++ b/lib/gateways/v6/api_gateway_v6.dart
@@ -159,6 +159,7 @@ class ApiGatewayV6 implements ApiGateway {
       );
 
       if (status.statusCode == 200) {
+        logger.i('Login successful with new session ID');
         final statusParsed = Session.fromJson(jsonDecode(status.body));
         await _server.sm.save(statusParsed.session.sid);
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -31,10 +31,10 @@ import 'package:window_size/window_size.dart';
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
-  await windowManager.ensureInitialized();
   await SystemChrome.setEnabledSystemUIMode(SystemUiMode.edgeToEdge);
 
   if (Platform.isWindows || Platform.isLinux || Platform.isMacOS) {
+    await windowManager.ensureInitialized();
     await windowManager.setMinimumSize(const Size(300, 300));
     setWindowMinSize(const Size(500, 500));
   }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -26,13 +26,16 @@ import 'package:provider/provider.dart';
 import 'package:sentry_flutter/sentry_flutter.dart';
 import 'package:sqflite_common_ffi/sqflite_ffi.dart';
 import 'package:vibration/vibration.dart';
+import 'package:window_manager/window_manager.dart';
 import 'package:window_size/window_size.dart';
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
+  await windowManager.ensureInitialized();
   await SystemChrome.setEnabledSystemUIMode(SystemUiMode.edgeToEdge);
 
   if (Platform.isWindows || Platform.isLinux || Platform.isMacOS) {
+    await windowManager.setMinimumSize(const Size(300, 300));
     setWindowMinSize(const Size(500, 500));
   }
 

--- a/lib/services/status_update_service.dart
+++ b/lib/services/status_update_service.dart
@@ -49,6 +49,7 @@ class StatusUpdateService {
   }
 
   void dispose() {
+    logger.d('Disposing Status Update Service');
     _stopAutoRefresh();
   }
 

--- a/lib/services/status_update_service.dart
+++ b/lib/services/status_update_service.dart
@@ -49,8 +49,10 @@ class StatusUpdateService {
   }
 
   void dispose() {
-    logger.d('Disposing Status Update Service');
-    _stopAutoRefresh();
+    if (_isAutoRefreshRunning) {
+      logger.d('Disposing Status Update Service');
+      _stopAutoRefresh();
+    }
   }
 
   /// Start timer for auto refresh

--- a/linux/flutter/generated_plugin_registrant.cc
+++ b/linux/flutter/generated_plugin_registrant.cc
@@ -8,9 +8,11 @@
 
 #include <dynamic_color/dynamic_color_plugin.h>
 #include <flutter_secure_storage_linux/flutter_secure_storage_linux_plugin.h>
+#include <screen_retriever_linux/screen_retriever_linux_plugin.h>
 #include <sentry_flutter/sentry_flutter_plugin.h>
 #include <sqlite3_flutter_libs/sqlite3_flutter_libs_plugin.h>
 #include <url_launcher_linux/url_launcher_plugin.h>
+#include <window_manager/window_manager_plugin.h>
 #include <window_size/window_size_plugin.h>
 
 void fl_register_plugins(FlPluginRegistry* registry) {
@@ -20,6 +22,9 @@ void fl_register_plugins(FlPluginRegistry* registry) {
   g_autoptr(FlPluginRegistrar) flutter_secure_storage_linux_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "FlutterSecureStorageLinuxPlugin");
   flutter_secure_storage_linux_plugin_register_with_registrar(flutter_secure_storage_linux_registrar);
+  g_autoptr(FlPluginRegistrar) screen_retriever_linux_registrar =
+      fl_plugin_registry_get_registrar_for_plugin(registry, "ScreenRetrieverLinuxPlugin");
+  screen_retriever_linux_plugin_register_with_registrar(screen_retriever_linux_registrar);
   g_autoptr(FlPluginRegistrar) sentry_flutter_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "SentryFlutterPlugin");
   sentry_flutter_plugin_register_with_registrar(sentry_flutter_registrar);
@@ -29,6 +34,9 @@ void fl_register_plugins(FlPluginRegistry* registry) {
   g_autoptr(FlPluginRegistrar) url_launcher_linux_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "UrlLauncherPlugin");
   url_launcher_plugin_register_with_registrar(url_launcher_linux_registrar);
+  g_autoptr(FlPluginRegistrar) window_manager_registrar =
+      fl_plugin_registry_get_registrar_for_plugin(registry, "WindowManagerPlugin");
+  window_manager_plugin_register_with_registrar(window_manager_registrar);
   g_autoptr(FlPluginRegistrar) window_size_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "WindowSizePlugin");
   window_size_plugin_register_with_registrar(window_size_registrar);

--- a/linux/flutter/generated_plugins.cmake
+++ b/linux/flutter/generated_plugins.cmake
@@ -5,9 +5,11 @@
 list(APPEND FLUTTER_PLUGIN_LIST
   dynamic_color
   flutter_secure_storage_linux
+  screen_retriever_linux
   sentry_flutter
   sqlite3_flutter_libs
   url_launcher_linux
+  window_manager
   window_size
 )
 

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -12,10 +12,12 @@ import local_auth_darwin
 import mobile_scanner
 import package_info_plus
 import path_provider_foundation
+import screen_retriever_macos
 import sentry_flutter
 import sqflite_darwin
 import sqlite3_flutter_libs
 import url_launcher_macos
+import window_manager
 import window_size
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
@@ -26,9 +28,11 @@ func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   MobileScannerPlugin.register(with: registry.registrar(forPlugin: "MobileScannerPlugin"))
   FPPPackageInfoPlusPlugin.register(with: registry.registrar(forPlugin: "FPPPackageInfoPlusPlugin"))
   PathProviderPlugin.register(with: registry.registrar(forPlugin: "PathProviderPlugin"))
+  ScreenRetrieverMacosPlugin.register(with: registry.registrar(forPlugin: "ScreenRetrieverMacosPlugin"))
   SentryFlutterPlugin.register(with: registry.registrar(forPlugin: "SentryFlutterPlugin"))
   SqflitePlugin.register(with: registry.registrar(forPlugin: "SqflitePlugin"))
   Sqlite3FlutterLibsPlugin.register(with: registry.registrar(forPlugin: "Sqlite3FlutterLibsPlugin"))
   UrlLauncherPlugin.register(with: registry.registrar(forPlugin: "UrlLauncherPlugin"))
+  WindowManagerPlugin.register(with: registry.registrar(forPlugin: "WindowManagerPlugin"))
   WindowSizePlugin.register(with: registry.registrar(forPlugin: "WindowSizePlugin"))
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1034,6 +1034,46 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.5.0"
+  screen_retriever:
+    dependency: transitive
+    description:
+      name: screen_retriever
+      sha256: "570dbc8e4f70bac451e0efc9c9bb19fa2d6799a11e6ef04f946d7886d2e23d0c"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.0"
+  screen_retriever_linux:
+    dependency: transitive
+    description:
+      name: screen_retriever_linux
+      sha256: f7f8120c92ef0784e58491ab664d01efda79a922b025ff286e29aa123ea3dd18
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.0"
+  screen_retriever_macos:
+    dependency: transitive
+    description:
+      name: screen_retriever_macos
+      sha256: "71f956e65c97315dd661d71f828708bd97b6d358e776f1a30d5aa7d22d78a149"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.0"
+  screen_retriever_platform_interface:
+    dependency: transitive
+    description:
+      name: screen_retriever_platform_interface
+      sha256: ee197f4581ff0d5608587819af40490748e1e39e648d7680ecf95c05197240c0
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.0"
+  screen_retriever_windows:
+    dependency: transitive
+    description:
+      name: screen_retriever_windows
+      sha256: "449ee257f03ca98a57288ee526a301a430a344a161f9202b4fcc38576716fe13"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.0"
   sentry:
     dependency: transitive
     description:
@@ -1439,6 +1479,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.0"
+  window_manager:
+    dependency: "direct main"
+    description:
+      name: window_manager
+      sha256: "732896e1416297c63c9e3fb95aea72d0355f61390263982a47fd519169dc5059"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.4.3"
   window_size:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -82,6 +82,7 @@ dependencies:
   json_annotation: ^4.9.0
   flutter_secure_storage: ^9.2.4
   collection: ^1.18.0
+  window_manager: ^0.4.3
 
 
 dev_dependencies:

--- a/windows/flutter/generated_plugin_registrant.cc
+++ b/windows/flutter/generated_plugin_registrant.cc
@@ -10,9 +10,11 @@
 #include <flutter_secure_storage_windows/flutter_secure_storage_windows_plugin.h>
 #include <local_auth_windows/local_auth_plugin.h>
 #include <permission_handler_windows/permission_handler_windows_plugin.h>
+#include <screen_retriever_windows/screen_retriever_windows_plugin_c_api.h>
 #include <sentry_flutter/sentry_flutter_plugin.h>
 #include <sqlite3_flutter_libs/sqlite3_flutter_libs_plugin.h>
 #include <url_launcher_windows/url_launcher_windows.h>
+#include <window_manager/window_manager_plugin.h>
 #include <window_size/window_size_plugin.h>
 
 void RegisterPlugins(flutter::PluginRegistry* registry) {
@@ -24,12 +26,16 @@ void RegisterPlugins(flutter::PluginRegistry* registry) {
       registry->GetRegistrarForPlugin("LocalAuthPlugin"));
   PermissionHandlerWindowsPluginRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("PermissionHandlerWindowsPlugin"));
+  ScreenRetrieverWindowsPluginCApiRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("ScreenRetrieverWindowsPluginCApi"));
   SentryFlutterPluginRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("SentryFlutterPlugin"));
   Sqlite3FlutterLibsPluginRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("Sqlite3FlutterLibsPlugin"));
   UrlLauncherWindowsRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("UrlLauncherWindows"));
+  WindowManagerPluginRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("WindowManagerPlugin"));
   WindowSizePluginRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("WindowSizePlugin"));
 }

--- a/windows/flutter/generated_plugins.cmake
+++ b/windows/flutter/generated_plugins.cmake
@@ -7,9 +7,11 @@ list(APPEND FLUTTER_PLUGIN_LIST
   flutter_secure_storage_windows
   local_auth_windows
   permission_handler_windows
+  screen_retriever_windows
   sentry_flutter
   sqlite3_flutter_libs
   url_launcher_windows
+  window_manager
   window_size
 )
 


### PR DESCRIPTION
## Overview  
This PR addresses an issue where excessive web sessions were being created when interacting with Pi-hole v6, leading to session limit violations and blocked requests.　The fix optimizes session management to prevent exceeding the session limit.  

Additionally, this change resolves an issue where "No data" was temporarily displayed when the app was resumed.

## Changes  
- Pause auto-update when the app moves to the background.  
- Resume auto-update when the app returns to the foreground.  
- If a default server is configured, the app performs authentication before fetching data.  
- Ensure that only one active session is maintained to prevent exceeding Pi-hole’s session limit.  

## Tests

| No. | Platform  | Default | Session Status | App State | Session Count |
|----|-----------|---------|---------------|-----------|---------------|
| 1  | Windows   | -       | -             | First Run | 1             |
| 2  | Windows   | ✅      | Deleted       | Start     | 1             |
| 3  | Windows   | ✅      | Deleted       | Resume    | 1             |
| 4  | Windows   | ✅      | Expired       | Start     | 1             |
| 5  | Windows   | ✅      | Expired       | Resume    | 1             |
| 6  | Windows   | ✅      | Active        | Start     | 1             |
| 7  | Windows   | ✅      | Active        | Resume    | 1             |
| 8  | Windows   | ☐      | Deleted       | Start     | 1             |
| 9  | Windows   | ☐      | Deleted       | Resume    | 1             |
| 10 | Windows   | ☐      | Expired       | Start     | 1             |
| 11 | Windows   | ☐      | Expired       | Resume    | 1             |
| 12 | Windows   | ☐      | Active        | Start     | 1             |
| 13 | Windows   | ☐      | Active        | Resume    | 1             |
| 14 | Linux     | -       | -             | First Run |  1             |
| 15 | Linux     | ✅      | Deleted       | Start     |   1            |
| 16 | Linux     | ✅      | Deleted       | Resume    |    1           |
| 17 | Linux     | ✅      | Expired       | Start     |     1          |
| 18 | Linux     | ✅      | Expired       | Resume    |    1           |
| 19 | Linux     | ✅      | Active        | Start     |      1         |
| 20 | Linux     | ✅      | Active        | Resume    |   1            |
| 21 | Linux     | ☐      | Deleted       | Start     |       1        |
| 22 | Linux     | ☐      | Deleted       | Resume    |   1            |
| 23 | Linux     | ☐      | Expired       | Start     |       1        |
| 24 | Linux     | ☐      | Expired       | Resume    |    1           |
| 25 | Linux     | ☐      | Active        | Start     |        1       |
| 26 | Linux     | ☐      | Active        | Resume    |   1           |
| 27 | Android   | -       | -             | First Run | 1             |
| 28 | Android   | ✅      | Deleted       | Start     | 1             |
| 29 | Android   | ✅      | Deleted       | Resume    | 1             |
| 30 | Android   | ✅      | Expired       | Start     | 1             |
| 31 | Android   | ✅      | Expired       | Resume    | 1             |
| 32 | Android   | ✅      | Active        | Start     | 1             |
| 33 | Android   | ✅      | Active        | Resume    | 1             |
| 34 | Android   | ☐      | Deleted       | Start     | 1             |
| 35 | Android   | ☐      | Deleted       | Resume    | 1             |
| 36 | Android   | ☐      | Expired       | Start     | 1             |
| 37 | Android   | ☐      | Expired       | Resume    | 1             |
| 38 | Android   | ☐      | Active        | Start     | 1             |
| 39 | Android   | ☐      | Active        | Resume    | 1             |
