### PR TITLE
feat(ssl): change default value of overrideSslCheck to true

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -64,6 +64,7 @@ void main() async {
     filtersProvider: filtersProvider,
   );
 
+  // TODO: Allow configuration per server
   if (dbRepository.appConfig.overrideSslCheck == 1) {
     HttpOverrides.global = MyHttpOverrides();
   }

--- a/lib/providers/app_config_provider.dart
+++ b/lib/providers/app_config_provider.dart
@@ -18,7 +18,7 @@ class AppConfigProvider with ChangeNotifier {
   PackageInfo? _appInfo;
   int? _autoRefreshTime = 2; // secounds
   int _selectedTheme = 0;
-  int _overrideSslCheck = 0;
+  int _overrideSslCheck = 1;
   int _reducedDataCharts = 0;
   double _logsPerQuery = 2; //hours
   String? _passCode;
@@ -420,7 +420,7 @@ class AppConfigProvider with ChangeNotifier {
       _autoRefreshTime = 5;
       _selectedTheme = 0;
       _selectedLanguage = 'en';
-      _overrideSslCheck = 0;
+      _overrideSslCheck = 1;
       _reducedDataCharts = 0;
       _logsPerQuery = 2;
       _passCode = null;

--- a/lib/repository/database.dart
+++ b/lib/repository/database.dart
@@ -127,7 +127,7 @@ class DatabaseRepository {
               hideZeroValues,
               statisticsVisualizationMode,
               sendCrashReports
-            ) VALUES (5, 0, 'en', 0, 0, 2, 0, 0, 0, 0, 0)
+            ) VALUES (5, 0, 'en', 1, 0, 2, 0, 0, 0, 0, 0)
           ''');
         logger.d('Database created');
       },
@@ -461,7 +461,7 @@ class DatabaseRepository {
             'autoRefreshTime': 5,
             'theme': 0,
             'language': 'en',
-            'overrideSslCheck': 0,
+            'overrideSslCheck': 1,
             'reducedDataCharts': 0,
             'logsPerQuery': 2,
             'useBiometricAuth': 0,

--- a/lib/screens/settings/app_settings/advanced_settings/advanced_options.dart
+++ b/lib/screens/settings/app_settings/advanced_settings/advanced_options.dart
@@ -1,11 +1,15 @@
 // ignore_for_file: use_build_context_synchronously
 
+import 'dart:io';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_phoenix/flutter_phoenix.dart';
+import 'package:pi_hole_client/classes/http_override.dart';
 import 'package:pi_hole_client/classes/process_modal.dart';
 import 'package:pi_hole_client/config/system_overlay_style.dart';
 import 'package:pi_hole_client/constants/responsive.dart';
 import 'package:pi_hole_client/functions/conversions.dart';
+import 'package:pi_hole_client/functions/logger.dart';
 import 'package:pi_hole_client/functions/snackbar.dart';
 import 'package:pi_hole_client/l10n/generated/app_localizations.dart';
 import 'package:pi_hole_client/providers/app_config_provider.dart';
@@ -92,6 +96,10 @@ class AdvancedOptions extends StatelessWidget {
         await appConfigProvider.restoreAppConfig();
         appConfigProvider.setSelectedTab(0);
         process.close();
+        if (appConfigProvider.overrideSslCheck == true) {
+          logger.d('SSL Check Override: ON');
+          HttpOverrides.global = MyHttpOverrides();
+        }
         Phoenix.rebirth(context);
       }
 

--- a/test/ut/helper.dart
+++ b/test/ut/helper.dart
@@ -52,7 +52,7 @@ class DbHelper {
               hideZeroValues,
               statisticsVisualizationMode,
               sendCrashReports
-            ) VALUES (5, 0, 'en', 0, 0, 2, 0, 0, 0, 0, 0)
+            ) VALUES (5, 0, 'en', 1, 0, 2, 0, 0, 0, 0, 0)
           ''');
       },
       onOpen: (Database db) async {},

--- a/test/ut/providers/app_config_provider_test.dart
+++ b/test/ut/providers/app_config_provider_test.dart
@@ -337,7 +337,7 @@ void main() {
           appConfigProvider.selectedLanguage,
           SchedulerBinding.instance.platformDispatcher.locale.languageCode,
         );
-        expect(appConfigProvider.overrideSslCheck, false);
+        expect(appConfigProvider.overrideSslCheck, true);
         expect(appConfigProvider.reducedDataCharts, false);
         expect(appConfigProvider.logsPerQuery, 2);
         expect(appConfigProvider.passCode, null);

--- a/test/ut/providers/app_config_provider_test.dart
+++ b/test/ut/providers/app_config_provider_test.dart
@@ -40,7 +40,7 @@ void main() {
       expect(appConfigProvider.selectedTab, 0);
       expect(appConfigProvider.getAutoRefreshTime, 2);
       expect(appConfigProvider.selectedThemeNumber, 0);
-      expect(appConfigProvider.overrideSslCheck, false);
+      expect(appConfigProvider.overrideSslCheck, true);
       expect(appConfigProvider.reducedDataCharts, false);
       expect(appConfigProvider.logsPerQuery, 2);
       expect(appConfigProvider.passCode, null);

--- a/test/ut/repository/database_test.dart
+++ b/test/ut/repository/database_test.dart
@@ -52,7 +52,7 @@ void main() async {
       expect(appConfig.autoRefreshTime, 5);
       expect(appConfig.theme, 0);
       expect(appConfig.language, 'en');
-      expect(appConfig.overrideSslCheck, 0);
+      expect(appConfig.overrideSslCheck, 1);
       expect(appConfig.reducedDataCharts, 0);
       expect(appConfig.logsPerQuery, 2);
       expect(appConfig.passCode, isNull);
@@ -76,7 +76,7 @@ void main() async {
       expect(appConfig.autoRefreshTime, 5);
       expect(appConfig.theme, 0);
       expect(appConfig.language, 'en');
-      expect(appConfig.overrideSslCheck, 0);
+      expect(appConfig.overrideSslCheck, 1);
       expect(appConfig.reducedDataCharts, 0);
       expect(appConfig.logsPerQuery, 2);
       expect(appConfig.passCode, isNull);
@@ -119,7 +119,7 @@ void main() async {
       expect(appConfig.autoRefreshTime, 5);
       expect(appConfig.theme, 0);
       expect(appConfig.language, 'en');
-      expect(appConfig.overrideSslCheck, 0);
+      expect(appConfig.overrideSslCheck, 1);
       expect(appConfig.reducedDataCharts, 0);
       expect(appConfig.logsPerQuery, 2);
       expect(appConfig.passCode, isNull);
@@ -163,7 +163,7 @@ void main() async {
       expect(appConfig.autoRefreshTime, 5);
       expect(appConfig.theme, 0);
       expect(appConfig.language, 'en');
-      expect(appConfig.overrideSslCheck, 0);
+      expect(appConfig.overrideSslCheck, 1);
       expect(appConfig.reducedDataCharts, 0);
       expect(appConfig.logsPerQuery, 2);
       expect(appConfig.passCode, '9999');

--- a/test/widgets/helpers.dart
+++ b/test/widgets/helpers.dart
@@ -1023,7 +1023,7 @@ class TestSetupHelper {
     when(mockConfigProvider.logsPerQuery).thenReturn(2);
     when(mockConfigProvider.passCode).thenReturn(null);
     when(mockConfigProvider.useBiometrics).thenReturn(false);
-    when(mockConfigProvider.overrideSslCheck).thenReturn(false);
+    when(mockConfigProvider.overrideSslCheck).thenReturn(true);
     when(mockConfigProvider.reducedDataCharts).thenReturn(false);
     when(mockConfigProvider.hideZeroValues).thenReturn(false);
     when(mockConfigProvider.selectedTheme).thenReturn(ThemeMode.light);


### PR DESCRIPTION
## Overview

Previously, SSL certificate verification was enabled by default. With this change, SSL verification is now **disabled by default**.  

## Reason for Change  
- Pi-hole v6 now supports HTTPS connections with self-signed certificates by default.  
- There have been multiple user reports about connection issues when trying to connect via HTTPS, especially due to self-signed certificates.  
- To improve user experience and reduce confusion, we are changing the default behavior to **disable** SSL certificate verification unless explicitly enabled by the user.  

## Key Changes
- The default value of `Don't check SSL Certificate` is now **true** (previously **false**).  
- Users who require strict SSL verification should manually disable `Don't check SSL Certificate` in the settings.  

## Impact and Migration
- **Breaking Change:** Users who expect SSL certificate verification to be enforced by default must now explicitly **enable** it.  
- **Existing users:** If the app is already installed, the current setting will be retained unless the app is reset. This means users who have previously enabled SSL verification will not be affected unless they manually reset their settings.  
- **New users:** The default behavior for fresh installations will now disable SSL certificate verification unless explicitly disabled in the settings.  

## Related Issues
#137 
#209
