### PR TITLE
fix(server_info): handle server info fetch failure in ServerInfoScreen

### DIFF
--- a/lib/screens/settings/server_settings/server_info.dart
+++ b/lib/screens/settings/server_settings/server_info.dart
@@ -3,6 +3,7 @@ import 'package:pi_hole_client/classes/custom_scroll_behavior.dart';
 import 'package:pi_hole_client/functions/logger.dart';
 import 'package:pi_hole_client/gateways/api_gateway_interface.dart';
 import 'package:pi_hole_client/l10n/generated/app_localizations.dart';
+import 'package:pi_hole_client/models/gateways.dart';
 import 'package:pi_hole_client/models/server.dart';
 import 'package:pi_hole_client/models/version.dart';
 import 'package:pi_hole_client/providers/servers_provider.dart';
@@ -48,10 +49,19 @@ class ServerInfoScreen extends StatelessWidget {
               }
 
               final serverInfo = snapshot.data;
+
+              if (serverInfo?.result != APiResponseType.success) {
+                logger.e('Server Info fetch failed: ${serverInfo?.result}');
+                return ErrorMessageScreen(
+                  message: AppLocalizations.of(context)!.dataFetchFailed,
+                );
+              }
+
               logger.d('Server Info version: ${serverInfo?.version?.toJson()}');
               logger.d('Server Info host: ${serverInfo?.host?.toJson()}');
               logger.d('Server Info system: ${serverInfo?.system?.toJson()}');
               logger.d('Server Info sensor: ${serverInfo?.sensors?.toJson()}');
+
               return _buildServerInfoContent(
                 server: server,
                 apiGateway: apiGateway,

--- a/test/widgets/screens/settings/server_settings/server_info_test.dart
+++ b/test/widgets/screens/settings/server_settings/server_info_test.dart
@@ -179,6 +179,38 @@ void main() async {
           expect(find.text('raspberrypi'), findsNothing);
         },
       );
+
+      testWidgets(
+        'should show error when fetch fails',
+        (WidgetTester tester) async {
+          tester.view.physicalSize = const Size(1080, 2400);
+          tester.view.devicePixelRatio = 2.0;
+
+          when(testSetup.mockApiGatewayV6.fetchAllServerInfo()).thenAnswer(
+            (_) async => PiHoleServerInfoResponse(
+              result: APiResponseType.error,
+            ),
+          );
+
+          addTearDown(() {
+            tester.view.resetPhysicalSize();
+            tester.view.resetDevicePixelRatio();
+          });
+
+          await tester.pumpWidget(
+            testSetup.buildTestWidget(
+              const ServerInfoScreen(),
+            ),
+          );
+
+          expect(find.byType(ServerInfoScreen), findsOneWidget);
+          await tester.pump();
+
+          expect(find.byIcon(Icons.error), findsOneWidget);
+          expect(find.text('ERROR'), findsOneWidget);
+          expect(find.text('Failed to fetch data.'), findsOneWidget);
+        },
+      );
     },
   );
 


### PR DESCRIPTION
## Overview
This PR improves error handling on the Pi-hole server screen. If fetching server information fails, an ErrorMessageScreen is displayed to inform users of the issue.

## Changes
- Added error handling for failed server info retrieval.
- Displays an ErrorMessageScreen when fetching server info fails.