### PR TITLE
feat(uninstaller): delete user data on Windows, show warning only on Linux

### DIFF
--- a/debian/scripts/postrm
+++ b/debian/scripts/postrm
@@ -3,9 +3,35 @@ set -e
 
 case "$1" in
     remove)
+        echo "🧹 Removing Pi-hole client core files..."
+
+        # Not strictly necessary: dpkg -r removes package files and empty dirs; use rm -rf for extra or generated files.
         if [ -d "/usr/local/lib/PiHoleClient" ]; then
             rm -rf /usr/local/lib/PiHoleClient
+            echo "✔️ Removed /usr/local/lib/PiHoleClient"
+        fi
+
+        echo ""
+        echo "⚠️  Note: User-specific data has NOT been deleted automatically."
+        echo ""
+        echo "📁  It may still exist in the following locations for each user:"
+        echo "     - ~/.dart_tool/sqflite_common_ffi/databases/pi_hole_client.db"
+        echo "     - ~/.local/share/io.github.tsutsu3.pi_hole_client/FlutterSecureStorage/"
+        echo "     - ~/.local/share/io.github.tsutsu3/Pi-hole client/"
+        echo ""
+        echo "Please delete these manually if you want to fully remove user data."
+        echo ""
+
+        if [[ "${XDG_CURRENT_DESKTOP,,}" == *kde* ]] || [[ "${DESKTOP_SESSION,,}" == *plasma* ]]; then
+            echo "🔐  KDE Wallet (KWallet) Warning:"
+            echo "    Some secure data may be stored in KWallet."
+            echo "    To manage or delete it:"
+            echo "     - Run: kwalletmanager5"
+            echo "     - Or (if installed): seahorse"
+            echo "     - Or try: secret-tool clear service 'FlutterSecureStorage'"
+            echo ""
         fi
         ;;
 esac
+
 exit 0

--- a/windows/innosetup_installer_builder.iss
+++ b/windows/innosetup_installer_builder.iss
@@ -55,6 +55,11 @@ Source: "..\build\windows\x64\runner\Release\data\*"; DestDir: "{app}\data"; Fla
 Name: "{autoprograms}\{#MyAppName}"; Filename: "{app}\{#MyAppExeName}"
 Name: "{autodesktop}\{#MyAppName}"; Filename: "{app}\{#MyAppExeName}"; Tasks: desktopicon
 
+[UninstallDelete]
+; Delete app folder and secure storage folter
+Type: filesandordirs; Name: "{app}"
+Type: filesandordirs; Name: "{userappdata}\io.github.tsutsu3\Pi-hole client"
+
 [Run]
 Filename: "{app}\{#MyAppExeName}"; Description: "{cm:LaunchProgram,{#StringChange(MyAppName, '&', '&&')}}"; Flags: nowait postinstall skipifsilent
 


### PR DESCRIPTION
## Overview

This PR improves the uninstall process by implementing platform-specific behavior for user data cleanup:

### Windows
User-specific data such as SQLite databases and secure storage files are **automatically deleted** during uninstallation, since the app and data are stored in the user’s own profile and are not shared.

### Linux  
User data is **not deleted automatically**, as the application is typically shared across users. Instead, a warning message is displayed during uninstall, guiding users to manually delete their own data if needed. KDE users are also informed about potential remaining secrets in KWallet.

## Changes

### Windows (Inno Setup)
  - Added code to delete:
    - `%LOCALAPPDATA%\Programs\Pi-hole client`
    - `%APPDATA%\io.github.tsutsu3\Pi-hole client`

### Linux (postrm script)
  - Retained `/usr/local/lib/PiHoleClient` deletion
  - Added user-facing warning about remaining user-specific data:
    - SQLite DB
    - Secure storage
    - App-specific config
  - KDE environments trigger an additional warning about KWallet