### PR TITLE
fix(server_info): avoid null crash in ServerInfoScreen when no server is selected

### DIFF
--- a/lib/screens/settings/server_settings/server_info.dart
+++ b/lib/screens/settings/server_settings/server_info.dart
@@ -28,6 +28,10 @@ class ServerInfoScreen extends StatelessWidget {
       (provider) => provider.selectedServer,
     );
 
+    if (apiGateway == null || server == null) {
+      return const EmptyDataScreen();
+    }
+
     return ScrollConfiguration(
       behavior: CustomScrollBehavior(),
       child: Scaffold(
@@ -36,7 +40,7 @@ class ServerInfoScreen extends StatelessWidget {
         ),
         body: SafeArea(
           child: FutureBuilder(
-            future: apiGateway?.fetchAllServerInfo(),
+            future: apiGateway.fetchAllServerInfo(),
             builder: (context, snapshot) {
               if (snapshot.connectionState == ConnectionState.waiting) {
                 return _buildSkeletonLoading(context, server, apiGateway);


### PR DESCRIPTION
## Summary  
This PR fixes a potential crash in `ServerInfoScreen` that could occur when `selectedServer` or `selectedApiGateway` is `null`.

## Changes  
- Added null checks at the beginning of `build()` to show `EmptyDataScreen` when no server is selected  


