### PR TITLE
fix(dialog): useRootNavigator false to handle back navigation correctly on mobile

### DIFF
--- a/lib/screens/app_logs/app_logs.dart
+++ b/lib/screens/app_logs/app_logs.dart
@@ -77,6 +77,7 @@ class AppLogs extends StatelessWidget {
                   onTap: () => {
                     showDialog(
                       context: context,
+                      useRootNavigator: false,
                       builder: (context) => AppLogDetailsModal(
                         log: appConfigProvider.logs[index],
                       ),

--- a/lib/screens/app_logs/app_logs.dart
+++ b/lib/screens/app_logs/app_logs.dart
@@ -77,7 +77,8 @@ class AppLogs extends StatelessWidget {
                   onTap: () => {
                     showDialog(
                       context: context,
-                      useRootNavigator: false,
+                      useRootNavigator:
+                          false, // Prevents unexpected app exit on mobile when pressing back
                       builder: (context) => AppLogDetailsModal(
                         log: appConfigProvider.logs[index],
                       ),

--- a/lib/screens/domains/domain_details_screen.dart
+++ b/lib/screens/domains/domain_details_screen.dart
@@ -30,6 +30,7 @@ class DomainDetailsScreen extends StatelessWidget {
           IconButton(
             onPressed: () => showDialog(
               context: context,
+              useRootNavigator: false,
               builder: (context) => DeleteDomainModal(
                 onConfirm: () {
                   Navigator.maybePop(context);

--- a/lib/screens/domains/domain_details_screen.dart
+++ b/lib/screens/domains/domain_details_screen.dart
@@ -83,6 +83,7 @@ class DomainDetailsScreen extends StatelessWidget {
                     ? () => {
                           showModal(
                             context: context,
+                            useRootNavigator: false,
                             builder: (context) =>
                                 DomainCommentModal(comment: domain.comment!),
                           ),

--- a/lib/screens/domains/domain_details_screen.dart
+++ b/lib/screens/domains/domain_details_screen.dart
@@ -30,7 +30,8 @@ class DomainDetailsScreen extends StatelessWidget {
           IconButton(
             onPressed: () => showDialog(
               context: context,
-              useRootNavigator: false,
+              useRootNavigator:
+                  false, // Prevents unexpected app exit on mobile when pressing back
               builder: (context) => DeleteDomainModal(
                 onConfirm: () {
                   Navigator.maybePop(context);
@@ -83,7 +84,8 @@ class DomainDetailsScreen extends StatelessWidget {
                     ? () => {
                           showModal(
                             context: context,
-                            useRootNavigator: false,
+                            useRootNavigator:
+                                false, // Prevents unexpected app exit on mobile when pressing back
                             builder: (context) =>
                                 DomainCommentModal(comment: domain.comment!),
                           ),

--- a/lib/screens/domains/domains_list.dart
+++ b/lib/screens/domains/domains_list.dart
@@ -146,6 +146,7 @@ class _DomainsListState extends State<DomainsList> {
       if (MediaQuery.of(context).size.width > ResponsiveConstants.medium) {
         showDialog(
           context: context,
+          useRootNavigator: false,
           builder: (ctx) => AddDomainModal(
             selectedlist: widget.type,
             addDomain: onAddDomain,

--- a/lib/screens/domains/domains_list.dart
+++ b/lib/screens/domains/domains_list.dart
@@ -146,7 +146,8 @@ class _DomainsListState extends State<DomainsList> {
       if (MediaQuery.of(context).size.width > ResponsiveConstants.medium) {
         showDialog(
           context: context,
-          useRootNavigator: false,
+          useRootNavigator:
+              false, // Prevents unexpected app exit on mobile when pressing back
           builder: (ctx) => AddDomainModal(
             selectedlist: widget.type,
             addDomain: onAddDomain,

--- a/lib/screens/home/home.dart
+++ b/lib/screens/home/home.dart
@@ -187,7 +187,8 @@ class _HomeState extends State<Home> {
           if (width > ResponsiveConstants.medium) {
             await showDialog(
               context: context,
-              useRootNavigator: false,
+              useRootNavigator:
+                  false, // Prevents unexpected app exit on mobile when pressing back
               builder: (_) => DisableModal(
                 onDisable: (time) => disableServer(time, context),
                 window: true,

--- a/lib/screens/home/home.dart
+++ b/lib/screens/home/home.dart
@@ -187,6 +187,7 @@ class _HomeState extends State<Home> {
           if (width > ResponsiveConstants.medium) {
             await showDialog(
               context: context,
+              useRootNavigator: false,
               builder: (_) => DisableModal(
                 onDisable: (time) => disableServer(time, context),
                 window: true,

--- a/lib/screens/home/home_appbar.dart
+++ b/lib/screens/home/home_appbar.dart
@@ -114,6 +114,7 @@ class HomeAppBar extends StatelessWidget implements PreferredSizeWidget {
     void openSwitchServerModal() {
       showDialog(
         context: context,
+        useRootNavigator: false,
         builder: (context) => SwitchServerModal(
           onServerSelect: connectToServer,
         ),

--- a/lib/screens/home/home_appbar.dart
+++ b/lib/screens/home/home_appbar.dart
@@ -114,7 +114,8 @@ class HomeAppBar extends StatelessWidget implements PreferredSizeWidget {
     void openSwitchServerModal() {
       showDialog(
         context: context,
-        useRootNavigator: false,
+        useRootNavigator:
+            false, // Prevents unexpected app exit on mobile when pressing back
         builder: (context) => SwitchServerModal(
           onServerSelect: connectToServer,
         ),

--- a/lib/screens/logs/logs.dart
+++ b/lib/screens/logs/logs.dart
@@ -309,7 +309,8 @@ class _LogsState extends State<Logs> {
       if (width > ResponsiveConstants.medium) {
         showDialog(
           context: context,
-          useRootNavigator: false,
+          useRootNavigator:
+              false, // Prevents unexpected app exit on mobile when pressing back
           builder: (context) => LogsFiltersModal(
             statusBarHeight: statusBarHeight,
             bottomNavBarHeight: bottomNavBarHeight,

--- a/lib/screens/logs/logs.dart
+++ b/lib/screens/logs/logs.dart
@@ -309,6 +309,7 @@ class _LogsState extends State<Logs> {
       if (width > ResponsiveConstants.medium) {
         showDialog(
           context: context,
+          useRootNavigator: false,
           builder: (context) => LogsFiltersModal(
             statusBarHeight: statusBarHeight,
             bottomNavBarHeight: bottomNavBarHeight,

--- a/lib/screens/logs/logs_filters_modal.dart
+++ b/lib/screens/logs/logs_filters_modal.dart
@@ -47,6 +47,7 @@ class _LogsFiltersModalState extends State<LogsFiltersModal> {
       if (width > ResponsiveConstants.medium) {
         showDialog(
           context: context,
+          useRootNavigator: false,
           builder: (context) => StatusFiltersModal(
             statusBarHeight: widget.statusBarHeight,
             bottomNavBarHeight: widget.bottomNavBarHeight,
@@ -77,6 +78,7 @@ class _LogsFiltersModalState extends State<LogsFiltersModal> {
       if (width > ResponsiveConstants.medium) {
         showDialog(
           context: context,
+          useRootNavigator: false,
           builder: (context) => ClientsFiltersModal(
             statusBarHeight: widget.statusBarHeight,
             bottomNavBarHeight: widget.bottomNavBarHeight,
@@ -113,6 +115,7 @@ class _LogsFiltersModalState extends State<LogsFiltersModal> {
       final now = DateTime.now();
       final dateValue = await showDatePicker(
         context: context,
+        useRootNavigator: false,
         initialDate: now,
         firstDate: DateTime(now.year, now.month - 1, now.day),
         lastDate: now,
@@ -120,6 +123,7 @@ class _LogsFiltersModalState extends State<LogsFiltersModal> {
       if (dateValue != null) {
         final timeValue = await showTimePicker(
           context: context,
+          useRootNavigator: false,
           initialTime: TimeOfDay.now(),
           helpText: time == 'from'
               ? AppLocalizations.of(context)!.selectStartTime

--- a/lib/screens/logs/logs_filters_modal.dart
+++ b/lib/screens/logs/logs_filters_modal.dart
@@ -47,7 +47,8 @@ class _LogsFiltersModalState extends State<LogsFiltersModal> {
       if (width > ResponsiveConstants.medium) {
         showDialog(
           context: context,
-          useRootNavigator: false,
+          useRootNavigator:
+              false, // Prevents unexpected app exit on mobile when pressing back
           builder: (context) => StatusFiltersModal(
             statusBarHeight: widget.statusBarHeight,
             bottomNavBarHeight: widget.bottomNavBarHeight,
@@ -78,7 +79,8 @@ class _LogsFiltersModalState extends State<LogsFiltersModal> {
       if (width > ResponsiveConstants.medium) {
         showDialog(
           context: context,
-          useRootNavigator: false,
+          useRootNavigator:
+              false, // Prevents unexpected app exit on mobile when pressing back
           builder: (context) => ClientsFiltersModal(
             statusBarHeight: widget.statusBarHeight,
             bottomNavBarHeight: widget.bottomNavBarHeight,
@@ -115,7 +117,8 @@ class _LogsFiltersModalState extends State<LogsFiltersModal> {
       final now = DateTime.now();
       final dateValue = await showDatePicker(
         context: context,
-        useRootNavigator: false,
+        useRootNavigator:
+            false, // Prevents unexpected app exit on mobile when pressing back
         initialDate: now,
         firstDate: DateTime(now.year, now.month - 1, now.day),
         lastDate: now,
@@ -123,7 +126,8 @@ class _LogsFiltersModalState extends State<LogsFiltersModal> {
       if (dateValue != null) {
         final timeValue = await showTimePicker(
           context: context,
-          useRootNavigator: false,
+          useRootNavigator:
+              false, // Prevents unexpected app exit on mobile when pressing back
           initialTime: TimeOfDay.now(),
           helpText: time == 'from'
               ? AppLocalizations.of(context)!.selectStartTime

--- a/lib/screens/servers/add_server_fullscreen.dart
+++ b/lib/screens/servers/add_server_fullscreen.dart
@@ -427,6 +427,7 @@ class _AddServerFullscreenState extends State<AddServerFullscreen> {
     void openScanTokenModal() {
       showDialog(
         context: context,
+        useRootNavigator: false,
         builder: (context) => ScanTokenModal(
           qrScanned: (value) =>
               setState(() => tokenFieldController.text = value),

--- a/lib/screens/servers/add_server_fullscreen.dart
+++ b/lib/screens/servers/add_server_fullscreen.dart
@@ -427,7 +427,8 @@ class _AddServerFullscreenState extends State<AddServerFullscreen> {
     void openScanTokenModal() {
       showDialog(
         context: context,
-        useRootNavigator: false,
+        useRootNavigator:
+            false, // Prevents unexpected app exit on mobile when pressing back
         builder: (context) => ScanTokenModal(
           qrScanned: (value) =>
               setState(() => tokenFieldController.text = value),

--- a/lib/screens/servers/servers.dart
+++ b/lib/screens/servers/servers.dart
@@ -90,6 +90,7 @@ class _ServersPageState extends State<ServersPage> {
             {
               showDialog(
                 context: context,
+                useRootNavigator: false,
                 builder: (context) => AddServerFullscreen(
                   server: server,
                   window: true,

--- a/lib/screens/servers/servers.dart
+++ b/lib/screens/servers/servers.dart
@@ -90,7 +90,8 @@ class _ServersPageState extends State<ServersPage> {
             {
               showDialog(
                 context: context,
-                useRootNavigator: false,
+                useRootNavigator:
+                    false, // Prevents unexpected app exit on mobile when pressing back
                 builder: (context) => AddServerFullscreen(
                   server: server,
                   window: true,

--- a/lib/screens/servers/servers_tile_item.dart
+++ b/lib/screens/servers/servers_tile_item.dart
@@ -51,7 +51,8 @@ class _ServersTileItemState extends State<ServersTileItem>
         () => {
           showDialog(
             context: context,
-            useRootNavigator: false,
+            useRootNavigator:
+                false, // Prevents unexpected app exit on mobile when pressing back
             builder: (context) => DeleteModal(
               serverToDelete: server,
             ),
@@ -70,7 +71,8 @@ class _ServersTileItemState extends State<ServersTileItem>
             {
               showDialog(
                 context: context,
-                useRootNavigator: false,
+                useRootNavigator:
+                    false, // Prevents unexpected app exit on mobile when pressing back
                 barrierDismissible: false,
                 builder: (context) => AddServerFullscreen(
                   server: server,

--- a/lib/screens/servers/servers_tile_item.dart
+++ b/lib/screens/servers/servers_tile_item.dart
@@ -51,6 +51,7 @@ class _ServersTileItemState extends State<ServersTileItem>
         () => {
           showDialog(
             context: context,
+            useRootNavigator: false,
             builder: (context) => DeleteModal(
               serverToDelete: server,
             ),
@@ -69,6 +70,7 @@ class _ServersTileItemState extends State<ServersTileItem>
             {
               showDialog(
                 context: context,
+                useRootNavigator: false,
                 barrierDismissible: false,
                 builder: (context) => AddServerFullscreen(
                   server: server,

--- a/lib/screens/settings/app_settings/advanced_settings/advanced_options.dart
+++ b/lib/screens/settings/app_settings/advanced_settings/advanced_options.dart
@@ -124,6 +124,7 @@ class AdvancedOptions extends StatelessWidget {
         if (width > ResponsiveConstants.medium) {
           showDialog(
             context: context,
+            useRootNavigator: false,
             builder: (context) => AppUnlockSetupModal(
               topBarHeight: topBarHeight,
               useBiometrics: appConfigProvider.useBiometrics,
@@ -148,6 +149,7 @@ class AdvancedOptions extends StatelessWidget {
         if (width > ResponsiveConstants.medium) {
           showDialog(
             context: context,
+            useRootNavigator: false,
             builder: (BuildContext context) => EnterPasscodeModal(
               onConfirm: openModal,
               window: true,

--- a/lib/screens/settings/app_settings/advanced_settings/advanced_options.dart
+++ b/lib/screens/settings/app_settings/advanced_settings/advanced_options.dart
@@ -124,7 +124,8 @@ class AdvancedOptions extends StatelessWidget {
         if (width > ResponsiveConstants.medium) {
           showDialog(
             context: context,
-            useRootNavigator: false,
+            useRootNavigator:
+                false, // Prevents unexpected app exit on mobile when pressing back
             builder: (context) => AppUnlockSetupModal(
               topBarHeight: topBarHeight,
               useBiometrics: appConfigProvider.useBiometrics,
@@ -149,7 +150,8 @@ class AdvancedOptions extends StatelessWidget {
         if (width > ResponsiveConstants.medium) {
           showDialog(
             context: context,
-            useRootNavigator: false,
+            useRootNavigator:
+                false, // Prevents unexpected app exit on mobile when pressing back
             builder: (BuildContext context) => EnterPasscodeModal(
               onConfirm: openModal,
               window: true,

--- a/lib/screens/settings/app_settings/advanced_settings/app_unlock_setup_modal.dart
+++ b/lib/screens/settings/app_settings/advanced_settings/app_unlock_setup_modal.dart
@@ -65,6 +65,7 @@ class _AppUnlockSetupModalState extends State<AppUnlockSetupModal> {
     void openRemovePasscode() {
       showDialog(
         context: context,
+        useRootNavigator: false,
         builder: (context) => const RemovePasscodeModal(),
         barrierDismissible: false,
       );

--- a/lib/screens/settings/app_settings/advanced_settings/app_unlock_setup_modal.dart
+++ b/lib/screens/settings/app_settings/advanced_settings/app_unlock_setup_modal.dart
@@ -65,7 +65,8 @@ class _AppUnlockSetupModalState extends State<AppUnlockSetupModal> {
     void openRemovePasscode() {
       showDialog(
         context: context,
-        useRootNavigator: false,
+        useRootNavigator:
+            false, // Prevents unexpected app exit on mobile when pressing back
         builder: (context) => const RemovePasscodeModal(),
         barrierDismissible: false,
       );

--- a/lib/screens/settings/server_settings/widgets/subscriptions/subscription_details_screen.dart
+++ b/lib/screens/settings/server_settings/widgets/subscriptions/subscription_details_screen.dart
@@ -85,7 +85,8 @@ class _SubscriptionDetailsScreenState extends State<SubscriptionDetailsScreen> {
           IconButton(
             onPressed: () => showDialog(
               context: context,
-              useRootNavigator: false,
+              useRootNavigator:
+                  false, // Prevents unexpected app exit on mobile when pressing back
               builder: (context) => DeleteSubscriptionModal(
                 onConfirm: () {
                   Navigator.maybePop(context);
@@ -263,7 +264,8 @@ class _SubscriptionDetailsScreenState extends State<SubscriptionDetailsScreen> {
     if (MediaQuery.of(context).size.width > ResponsiveConstants.medium) {
       showDialog(
         context: context,
-        useRootNavigator: false,
+        useRootNavigator:
+            false, // Prevents unexpected app exit on mobile when pressing back
         builder: (ctx) => EditSubscriptionModal(
           subscription: _subscription,
           keyItem: 'comment',
@@ -296,7 +298,8 @@ class _SubscriptionDetailsScreenState extends State<SubscriptionDetailsScreen> {
     if (MediaQuery.of(context).size.width > ResponsiveConstants.medium) {
       showDialog(
         context: context,
-        useRootNavigator: false,
+        useRootNavigator:
+            false, // Prevents unexpected app exit on mobile when pressing back
         builder: (ctx) => EditSubscriptionModal(
           subscription: _subscription,
           keyItem: 'groups',

--- a/lib/screens/settings/server_settings/widgets/subscriptions/subscription_details_screen.dart
+++ b/lib/screens/settings/server_settings/widgets/subscriptions/subscription_details_screen.dart
@@ -263,6 +263,7 @@ class _SubscriptionDetailsScreenState extends State<SubscriptionDetailsScreen> {
     if (MediaQuery.of(context).size.width > ResponsiveConstants.medium) {
       showDialog(
         context: context,
+        useRootNavigator: false,
         builder: (ctx) => EditSubscriptionModal(
           subscription: _subscription,
           keyItem: 'comment',
@@ -295,6 +296,7 @@ class _SubscriptionDetailsScreenState extends State<SubscriptionDetailsScreen> {
     if (MediaQuery.of(context).size.width > ResponsiveConstants.medium) {
       showDialog(
         context: context,
+        useRootNavigator: false,
         builder: (ctx) => EditSubscriptionModal(
           subscription: _subscription,
           keyItem: 'groups',

--- a/lib/screens/settings/server_settings/widgets/subscriptions/subscriptions_list.dart
+++ b/lib/screens/settings/server_settings/widgets/subscriptions/subscriptions_list.dart
@@ -156,6 +156,7 @@ class _SubscriptionsListState extends State<SubscriptionsList> {
       if (MediaQuery.of(context).size.width > ResponsiveConstants.medium) {
         showDialog(
           context: context,
+          useRootNavigator: false,
           builder: (ctx) => AddSubscriptionModal(
             selectedlist: widget.type,
             addSubscription: onAddSubscription,

--- a/lib/screens/settings/server_settings/widgets/subscriptions/subscriptions_list.dart
+++ b/lib/screens/settings/server_settings/widgets/subscriptions/subscriptions_list.dart
@@ -156,7 +156,8 @@ class _SubscriptionsListState extends State<SubscriptionsList> {
       if (MediaQuery.of(context).size.width > ResponsiveConstants.medium) {
         showDialog(
           context: context,
-          useRootNavigator: false,
+          useRootNavigator:
+              false, // Prevents unexpected app exit on mobile when pressing back
           builder: (ctx) => AddSubscriptionModal(
             selectedlist: widget.type,
             addSubscription: onAddSubscription,


### PR DESCRIPTION
##  Summary
This PR fixes an issue where pressing the system back button while a dialog is open would cause the app to exit unexpectedly.

##  Fix
- Added `useRootNavigator: false` to the `showDialog` call

## Affected Screens
- Home
  - Switch server
  - Disable
- Logs
  - Filters
- Domains
  - Add domain
  - Delete domain
  - Domain Comment
- Advenced settings
  - App unlock

## ref

#158