### PR TITLE
feat(server): move optional subroute settings to bottom and wrap in accordion

### DIFF
--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -28,6 +28,7 @@
   "adlistStatus": "Zustand",
   "adlistUpdated": "Adlist wurde erfolgreich aktualisiert",
   "adlistsNotLoaded": "Adlists konnte nicht geladen werden",
+  "advancedOptions": "Erweiterte Optionen",
   "advancedSetup": "Erweiterte Einstellungen",
   "advancedSetupDescription": "Erweiterte Optionen",
   "advancedStatusFiltering": "Erweiterte Statusfilterung",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -28,6 +28,7 @@
   "adlistStatus": "Health Status",
   "adlistUpdated": "Adlist updated successfully",
   "adlistsNotLoaded": "Adlists couldn't be loaded",
+  "advancedOptions": "Advanced Options",
   "advancedSetup": "Advanced settings",
   "advancedSetupDescription": "Advanced options",
   "advancedStatusFiltering": "Advanced status filtering",

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -28,6 +28,7 @@
   "adlistStatus": "Estado de salud",
   "adlistUpdated": "Adlist actualizada correctamente",
   "adlistsNotLoaded": "No se pudieron cargar las Adlists",
+  "advancedOptions": "Opciones avanzadas",
   "advancedSetup": "Configuración avanzada",
   "advancedSetupDescription": "Opciones avanzadas",
   "advancedStatusFiltering": "Filtros de estado avanzados",

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -28,6 +28,7 @@
   "adlistStatus": "ヘルスステータス",
   "adlistUpdated": "Adlistの更新に成功しました",
   "adlistsNotLoaded": "Adlistを読み込めませんでした",
+  "advancedOptions": "詳細オプション",
   "advancedSetup": "高度な設定",
   "advancedSetupDescription": "高度なオプション",
   "advancedStatusFiltering": "高度なステータスフィルタリング",

--- a/lib/l10n/app_pl.arb
+++ b/lib/l10n/app_pl.arb
@@ -28,6 +28,7 @@
   "adlistStatus": "Stan kondycji",
   "adlistUpdated": "Adlist została pomyślnie zaktualizowana",
   "adlistsNotLoaded": "Nie udało się załadować list Adlist",
+  "advancedOptions": "Zaawansowane opcje",
   "advancedSetup": "Ustawienia zaawansowane",
   "advancedSetupDescription": "Wykresy, bezpieczenstwo i inne",
   "advancedStatusFiltering": "Zaawansowane filtrowanie stanów",

--- a/lib/l10n/generated/app_localizations.dart
+++ b/lib/l10n/generated/app_localizations.dart
@@ -275,6 +275,12 @@ abstract class AppLocalizations {
   /// **'Adlists couldn\'t be loaded'**
   String get adlistsNotLoaded;
 
+  /// No description provided for @advancedOptions.
+  ///
+  /// In en, this message translates to:
+  /// **'Advanced Options'**
+  String get advancedOptions;
+
   /// No description provided for @advancedSetup.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/generated/app_localizations_de.dart
+++ b/lib/l10n/generated/app_localizations_de.dart
@@ -96,6 +96,9 @@ class AppLocalizationsDe extends AppLocalizations {
   String get adlistsNotLoaded => 'Adlists konnte nicht geladen werden';
 
   @override
+  String get advancedOptions => 'Erweiterte Optionen';
+
+  @override
   String get advancedSetup => 'Erweiterte Einstellungen';
 
   @override

--- a/lib/l10n/generated/app_localizations_en.dart
+++ b/lib/l10n/generated/app_localizations_en.dart
@@ -96,6 +96,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get adlistsNotLoaded => 'Adlists couldn\'t be loaded';
 
   @override
+  String get advancedOptions => 'Advanced Options';
+
+  @override
   String get advancedSetup => 'Advanced settings';
 
   @override

--- a/lib/l10n/generated/app_localizations_es.dart
+++ b/lib/l10n/generated/app_localizations_es.dart
@@ -96,6 +96,9 @@ class AppLocalizationsEs extends AppLocalizations {
   String get adlistsNotLoaded => 'No se pudieron cargar las Adlists';
 
   @override
+  String get advancedOptions => 'Opciones avanzadas';
+
+  @override
   String get advancedSetup => 'Configuración avanzada';
 
   @override

--- a/lib/l10n/generated/app_localizations_ja.dart
+++ b/lib/l10n/generated/app_localizations_ja.dart
@@ -96,6 +96,9 @@ class AppLocalizationsJa extends AppLocalizations {
   String get adlistsNotLoaded => 'Adlistを読み込めませんでした';
 
   @override
+  String get advancedOptions => '詳細オプション';
+
+  @override
   String get advancedSetup => '高度な設定';
 
   @override

--- a/lib/l10n/generated/app_localizations_pl.dart
+++ b/lib/l10n/generated/app_localizations_pl.dart
@@ -96,6 +96,9 @@ class AppLocalizationsPl extends AppLocalizations {
   String get adlistsNotLoaded => 'Nie udało się załadować list Adlist';
 
   @override
+  String get advancedOptions => 'Zaawansowane opcje';
+
+  @override
   String get advancedSetup => 'Ustawienia zaawansowane';
 
   @override

--- a/lib/screens/servers/add_server_fullscreen.dart
+++ b/lib/screens/servers/add_server_fullscreen.dart
@@ -538,7 +538,7 @@ class _AddServerFullscreenState extends State<AddServerFullscreen> {
                   padding: const EdgeInsets.symmetric(vertical: 16),
                 ),
                 Padding(
-                  padding: const EdgeInsets.symmetric(vertical: 20),
+                  padding: const EdgeInsets.only(bottom: 20),
                   child: TextField(
                     controller: aliasFieldController,
                     onChanged: (value) => checkDataValid(),
@@ -591,24 +591,6 @@ class _AddServerFullscreenState extends State<AddServerFullscreen> {
                 Padding(
                   padding: const EdgeInsets.only(top: 30),
                   child: TextFormField(
-                    onChanged: validateSubroute,
-                    controller: subrouteFieldController,
-                    enabled: widget.server != null ? false : true,
-                    decoration: InputDecoration(
-                      errorText: subrouteFieldError,
-                      prefixIcon: const Icon(Icons.route_rounded),
-                      border: const OutlineInputBorder(
-                        borderRadius: BorderRadius.all(Radius.circular(10)),
-                      ),
-                      labelText: AppLocalizations.of(context)!.subrouteField,
-                      hintText: AppLocalizations.of(context)!.subrouteExample,
-                      helperText: AppLocalizations.of(context)!.subrouteHelper,
-                    ),
-                  ),
-                ),
-                Padding(
-                  padding: const EdgeInsets.only(top: 30),
-                  child: TextFormField(
                     onChanged: validatePort,
                     controller: portFieldController,
                     enabled: widget.server != null ? false : true,
@@ -623,9 +605,45 @@ class _AddServerFullscreenState extends State<AddServerFullscreen> {
                     ),
                   ),
                 ),
+                Theme(
+                  data: Theme.of(context).copyWith(
+                    dividerColor: Colors.transparent,
+                    hoverColor: Colors.transparent,
+                    splashColor: Colors.transparent,
+                    highlightColor: Colors.transparent,
+                  ),
+                  child: ExpansionTile(
+                    tilePadding: EdgeInsets.zero,
+                    title: SectionLabel(
+                      label: AppLocalizations.of(context)!.advancedOptions,
+                      padding: const EdgeInsets.symmetric(vertical: 16),
+                    ),
+                    children: [
+                      TextFormField(
+                        onChanged: validateSubroute,
+                        controller: subrouteFieldController,
+                        enabled: widget.server != null ? false : true,
+                        decoration: InputDecoration(
+                          errorText: subrouteFieldError,
+                          prefixIcon: const Icon(Icons.route_rounded),
+                          border: const OutlineInputBorder(
+                            borderRadius: BorderRadius.all(Radius.circular(10)),
+                          ),
+                          labelText:
+                              AppLocalizations.of(context)!.subrouteField,
+                          hintText:
+                              AppLocalizations.of(context)!.subrouteExample,
+                          helperText:
+                              AppLocalizations.of(context)!.subrouteHelper,
+                        ),
+                      ),
+                      const SizedBox(height: 20),
+                    ],
+                  ),
+                ),
                 SectionLabel(
                   label: AppLocalizations.of(context)!.version,
-                  padding: const EdgeInsets.only(top: 30, bottom: 10),
+                  padding: const EdgeInsets.only(top: 10, bottom: 10),
                 ),
                 Align(
                   alignment: Alignment.centerLeft,
@@ -657,10 +675,10 @@ class _AddServerFullscreenState extends State<AddServerFullscreen> {
                 ),
                 SectionLabel(
                   label: AppLocalizations.of(context)!.authentication,
-                  padding: const EdgeInsets.only(top: 30),
+                  padding: const EdgeInsets.only(top: 20),
                 ),
                 Padding(
-                  padding: const EdgeInsets.symmetric(vertical: 10),
+                  padding: const EdgeInsets.only(bottom: 10),
                   child: piHoleVersion == SupportedApiVersions.v5
                       ? buildV5Settings(context)
                       : buildV6Settings(context),

--- a/lib/screens/servers/add_server_fullscreen.dart
+++ b/lib/screens/servers/add_server_fullscreen.dart
@@ -66,7 +66,12 @@ class _AddServerFullscreenState extends State<AddServerFullscreen> {
     if (widget.server != null) {
       final splitted = widget.server!.address.split(':');
       addressFieldController.text = splitted[1].split('/')[2];
-      portFieldController.text = splitted.length == 3 ? splitted[2] : '';
+      portFieldController.text =
+          splitted.length > 2 ? splitted[2].split('/')[0] : '';
+      subrouteFieldController.text =
+          widget.server!.address.split('/').length > 3
+              ? '/${widget.server!.address.split('/')[3]}'
+              : '';
       aliasFieldController.text = widget.server!.alias;
       connectionType = widget.server!.address.split(':')[0] == 'https'
           ? ConnectionType.https

--- a/test/widgets/screens/servers/add_server_fullscreen_test.dart
+++ b/test/widgets/screens/servers/add_server_fullscreen_test.dart
@@ -76,7 +76,7 @@ void main() async {
           'localhost',
         ); // IP Address
         await tester.enterText(
-          find.byType(TextField).at(4),
+          find.byType(TextField).at(3),
           'test123',
         ); // token
 
@@ -123,23 +123,26 @@ void main() async {
         expect(find.byType(AddServerFullscreen), findsOneWidget);
         expect(find.byIcon(Icons.login_rounded), findsOneWidget);
 
+        await tester.tap(find.text('Advanced Options'));
+        await tester.pump();
+
         await tester.enterText(find.byType(TextField).at(0), 'v6'); // Alias
         await tester.enterText(
           find.byType(TextField).at(1),
           'localhost',
-        ); // IP Address
+        );
         await tester.enterText(
-          find.byType(TextField).at(1),
-          '/test',
-        ); // subroute
-        await tester.enterText(
-          find.byType(TextField).at(1),
+          find.byType(TextField).at(2),
           '8080',
-        ); // port
+        );
+        await tester.enterText(
+          find.byType(TextField).at(3),
+          '/test',
+        );
         await tester.enterText(
           find.byType(TextField).at(4),
           'test123',
-        ); // token
+        );
 
         await tester.tap(find.byIcon(Icons.login_rounded));
         await tester.pump(const Duration(milliseconds: 1000));
@@ -184,23 +187,26 @@ void main() async {
         expect(find.byType(AddServerFullscreen), findsOneWidget);
         expect(find.byIcon(Icons.login_rounded), findsOneWidget);
 
+        await tester.tap(find.text('Advanced Options'));
+        await tester.pump();
+
         await tester.enterText(find.byType(TextField).at(0), 'v6'); // Alias
         await tester.enterText(
           find.byType(TextField).at(1),
           'localhost',
-        ); // IP Address
+        );
         await tester.enterText(
-          find.byType(TextField).at(1),
-          '/test',
-        ); // subroute
-        await tester.enterText(
-          find.byType(TextField).at(1),
+          find.byType(TextField).at(2),
           '8080',
-        ); // port
+        );
+        await tester.enterText(
+          find.byType(TextField).at(3),
+          '/test',
+        );
         await tester.enterText(
           find.byType(TextField).at(4),
           'test123',
-        ); // token
+        );
 
         await tester.tap(find.byIcon(Icons.login_rounded));
         await tester.pump(const Duration(milliseconds: 1000));
@@ -250,23 +256,26 @@ void main() async {
         expect(find.byType(AddServerFullscreen), findsOneWidget);
         expect(find.byIcon(Icons.login_rounded), findsOneWidget);
 
+        await tester.tap(find.text('Advanced Options'));
+        await tester.pump();
+
         await tester.enterText(find.byType(TextField).at(0), 'v6'); // Alias
         await tester.enterText(
           find.byType(TextField).at(1),
           'localhost',
-        ); // IP Address
+        );
         await tester.enterText(
-          find.byType(TextField).at(1),
-          '/test',
-        ); // subroute
-        await tester.enterText(
-          find.byType(TextField).at(1),
+          find.byType(TextField).at(2),
           '8080',
-        ); // port
+        );
+        await tester.enterText(
+          find.byType(TextField).at(3),
+          '/test',
+        );
         await tester.enterText(
           find.byType(TextField).at(4),
           'test123',
-        ); // token
+        );
 
         await tester.tap(find.byIcon(Icons.login_rounded));
         await tester.pump(const Duration(milliseconds: 1000));
@@ -314,23 +323,26 @@ void main() async {
         expect(find.byType(AddServerFullscreen), findsOneWidget);
         expect(find.byIcon(Icons.login_rounded), findsOneWidget);
 
+        await tester.tap(find.text('Advanced Options'));
+        await tester.pump();
+
         await tester.enterText(find.byType(TextField).at(0), 'v6'); // Alias
         await tester.enterText(
           find.byType(TextField).at(1),
           'localhost',
-        ); // IP Address
+        );
         await tester.enterText(
-          find.byType(TextField).at(1),
-          '/test',
-        ); // subroute
-        await tester.enterText(
-          find.byType(TextField).at(1),
+          find.byType(TextField).at(2),
           '8080',
-        ); // port
+        );
+        await tester.enterText(
+          find.byType(TextField).at(3),
+          '/test',
+        );
         await tester.enterText(
           find.byType(TextField).at(4),
           'test123',
-        ); // token
+        );
 
         await tester.tap(find.byIcon(Icons.login_rounded));
         await tester.pump(const Duration(milliseconds: 1000));
@@ -375,23 +387,26 @@ void main() async {
         expect(find.byType(AddServerFullscreen), findsOneWidget);
         expect(find.byIcon(Icons.login_rounded), findsOneWidget);
 
+        await tester.tap(find.text('Advanced Options'));
+        await tester.pump();
+
         await tester.enterText(find.byType(TextField).at(0), 'v6'); // Alias
         await tester.enterText(
           find.byType(TextField).at(1),
           'localhost',
-        ); // IP Address
+        );
         await tester.enterText(
-          find.byType(TextField).at(1),
-          '/test',
-        ); // subroute
-        await tester.enterText(
-          find.byType(TextField).at(1),
+          find.byType(TextField).at(2),
           '8080',
-        ); // port
+        );
+        await tester.enterText(
+          find.byType(TextField).at(3),
+          '/test',
+        );
         await tester.enterText(
           find.byType(TextField).at(4),
           'test123',
-        ); // token
+        );
 
         await tester.tap(find.byIcon(Icons.login_rounded));
         await tester.pump(const Duration(milliseconds: 1000));
@@ -439,23 +454,26 @@ void main() async {
         expect(find.byType(AddServerFullscreen), findsOneWidget);
         expect(find.byIcon(Icons.login_rounded), findsOneWidget);
 
+        await tester.tap(find.text('Advanced Options'));
+        await tester.pump();
+
         await tester.enterText(find.byType(TextField).at(0), 'v6'); // Alias
         await tester.enterText(
           find.byType(TextField).at(1),
           'localhost',
-        ); // IP Address
+        );
         await tester.enterText(
-          find.byType(TextField).at(1),
-          '/test',
-        ); // subroute
-        await tester.enterText(
-          find.byType(TextField).at(1),
+          find.byType(TextField).at(2),
           '8080',
-        ); // port
+        );
+        await tester.enterText(
+          find.byType(TextField).at(3),
+          '/test',
+        );
         await tester.enterText(
           find.byType(TextField).at(4),
           'test123',
-        ); // token
+        );
 
         await tester.tap(find.byIcon(Icons.login_rounded));
         await tester.pump(const Duration(milliseconds: 1000));
@@ -487,20 +505,21 @@ void main() async {
         expect(find.byType(AddServerFullscreen), findsOneWidget);
         expect(find.byIcon(Icons.login_rounded), findsOneWidget);
 
+        await tester.tap(find.text('Advanced Options'));
+        await tester.pump();
+
         await tester.enterText(
           find.byType(TextField).at(1),
           '@',
         ); // IP Address
-
         await tester.enterText(
           find.byType(TextField).at(2),
           '@',
-        ); // subroute
-
+        ); // port
         await tester.enterText(
           find.byType(TextField).at(3),
           '@',
-        ); // port
+        ); // subroute
 
         await tester.pump();
         await tester.pump();
@@ -543,7 +562,7 @@ void main() async {
 
         await tester.enterText(find.byType(TextField).at(0), 'v6'); // Alias
         await tester.enterText(
-          find.byType(TextField).at(4),
+          find.byType(TextField).at(3),
           'test123',
         ); // token
 
@@ -590,7 +609,7 @@ void main() async {
 
         await tester.enterText(find.byType(TextField).at(0), 'v6'); // Alias
         await tester.enterText(
-          find.byType(TextField).at(4),
+          find.byType(TextField).at(3),
           'test123',
         ); // token
 
@@ -638,7 +657,7 @@ void main() async {
 
         await tester.enterText(find.byType(TextField).at(0), 'v6'); // Alias
         await tester.enterText(
-          find.byType(TextField).at(4),
+          find.byType(TextField).at(3),
           'test123',
         ); // token
 
@@ -691,7 +710,7 @@ void main() async {
 
         await tester.enterText(find.byType(TextField).at(0), 'v6'); // Alias
         await tester.enterText(
-          find.byType(TextField).at(4),
+          find.byType(TextField).at(3),
           'test123',
         ); // token
 
@@ -742,7 +761,7 @@ void main() async {
 
         await tester.enterText(find.byType(TextField).at(0), 'v6'); // Alias
         await tester.enterText(
-          find.byType(TextField).at(4),
+          find.byType(TextField).at(3),
           'test123',
         ); // token
 
@@ -790,7 +809,7 @@ void main() async {
 
         await tester.enterText(find.byType(TextField).at(0), 'v6'); // Alias
         await tester.enterText(
-          find.byType(TextField).at(4),
+          find.byType(TextField).at(3),
           'test123',
         ); // token
 
@@ -841,7 +860,7 @@ void main() async {
 
         await tester.enterText(find.byType(TextField).at(0), 'v6'); // Alias
         await tester.enterText(
-          find.byType(TextField).at(4),
+          find.byType(TextField).at(3),
           'test123',
         ); // token
 


### PR DESCRIPTION
## Overview

Moved the subroute setting to the bottom of the **Connection Settings** section and placed it inside an accordion. This helps reduce visual clutter by hiding advanced options by default. Padding has also been adjusted for consistency with other form fields.

##  Changes

- Moved subroute field to the bottom of the connection section
- Wrapped the subroute setting inside an `ExpansionTile` (accordion)
- Adjusted padding around the subroute input for layout consistency

## Screen Shot

![3](https://github.com/user-attachments/assets/db6555cc-ca33-407c-800e-733ace671cea)
