### PR TITLE
chore(android): disable autoBackup as a tentative fix for app launch …

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -5,7 +5,9 @@
     <application
         android:label="Pi-hole client"
         android:name="${applicationName}"
-        android:icon="@mipmap/ic_launcher">
+        android:icon="@mipmap/ic_launcher"
+        android:allowBackup="false"
+        android:fullBackupContent="@xml/backup_rules">
         <activity
             android:name=".MainActivity"
             android:exported="true"

--- a/android/app/src/main/res/xml/backup_rules.xml
+++ b/android/app/src/main/res/xml/backup_rules.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<data-extraction-rules>
+ <cloud-backup>
+   <include domain="sharedpref" path="."/>
+   <exclude domain="sharedpref" path="FlutterSecureStorage"/>
+ </cloud-backup>
+</data-extraction-rules>


### PR DESCRIPTION
## Summary

This PR explicitly disables Android's auto backup feature by setting `android:allowBackup="false"` in `AndroidManifest.xml`.

## Notes

This is a defensive measure based on suspected issues with encrypted preferences or secure storage libraries. Effectiveness will be monitored post-deployment.

## Ref

#227 