### PR TITLE
fix(process_modal): use rootOverlay to prevent app exit on back press (mobile only)

### DIFF
--- a/lib/classes/process_modal.dart
+++ b/lib/classes/process_modal.dart
@@ -22,6 +22,7 @@ class ProcessModal {
     _timer = Timer(delay, () {
       if (_isClosed) return;
       _overlayEntry = _createOverlayEntry(message);
+      // Use rootOverlay to prevent app exit on back press (mobile only)
       final overlay = Overlay.of(context, rootOverlay: true);
       overlay.insert(_overlayEntry!);
     });


### PR DESCRIPTION
#158 