### PR TITLE
fix(overtime_data): handle null client names by providing an empty string

### DIFF
--- a/lib/models/overtime_data.dart
+++ b/lib/models/overtime_data.dart
@@ -68,7 +68,7 @@ class OverTimeData {
     final clients = historyClients.clients.isNotEmpty
         ? historyClients.clients.entries.map((entry) {
             final ip = entry.key;
-            final name = entry.value.name ?? ip;
+            final name = entry.value.name ?? '';
 
             return Client(
               name: name,


### PR DESCRIPTION
## Overview

|before|after|
|---|---|
|![before](https://github.com/user-attachments/assets/96428d7a-d681-4426-96d5-269a4969a420)|![after](https://github.com/user-attachments/assets/53a2b96b-74b9-4563-8f40-09c90a8f4ec7)|
