### PR TITLE
feat(model): support %cpu field from FTL v6.1

### DIFF
--- a/lib/models/api/v6/ftl/system.dart
+++ b/lib/models/api/v6/ftl/system.dart
@@ -66,6 +66,7 @@ sealed class CPU with _$CPU {
   const factory CPU({
     required int nprocs,
     required Load load,
+    @JsonKey(name: '%cpu') double? percentCpu, // Added in FTL v6.1
   }) = _CPU;
 
   factory CPU.fromJson(Map<String, dynamic> json) => _$CPUFromJson(json);

--- a/lib/models/api/v6/ftl/system.freezed.dart
+++ b/lib/models/api/v6/ftl/system.freezed.dart
@@ -1049,6 +1049,8 @@ class __$SwapCopyWithImpl<$Res> implements _$SwapCopyWith<$Res> {
 mixin _$CPU {
   int get nprocs;
   Load get load;
+  @JsonKey(name: '%cpu')
+  double? get percentCpu;
 
   /// Create a copy of CPU
   /// with the given fields replaced by the non-null parameter values.
@@ -1066,16 +1068,18 @@ mixin _$CPU {
         (other.runtimeType == runtimeType &&
             other is CPU &&
             (identical(other.nprocs, nprocs) || other.nprocs == nprocs) &&
-            (identical(other.load, load) || other.load == load));
+            (identical(other.load, load) || other.load == load) &&
+            (identical(other.percentCpu, percentCpu) ||
+                other.percentCpu == percentCpu));
   }
 
   @JsonKey(includeFromJson: false, includeToJson: false)
   @override
-  int get hashCode => Object.hash(runtimeType, nprocs, load);
+  int get hashCode => Object.hash(runtimeType, nprocs, load, percentCpu);
 
   @override
   String toString() {
-    return 'CPU(nprocs: $nprocs, load: $load)';
+    return 'CPU(nprocs: $nprocs, load: $load, percentCpu: $percentCpu)';
   }
 }
 
@@ -1083,7 +1087,7 @@ mixin _$CPU {
 abstract mixin class $CPUCopyWith<$Res> {
   factory $CPUCopyWith(CPU value, $Res Function(CPU) _then) = _$CPUCopyWithImpl;
   @useResult
-  $Res call({int nprocs, Load load});
+  $Res call({int nprocs, Load load, @JsonKey(name: '%cpu') double? percentCpu});
 
   $LoadCopyWith<$Res> get load;
 }
@@ -1102,6 +1106,7 @@ class _$CPUCopyWithImpl<$Res> implements $CPUCopyWith<$Res> {
   $Res call({
     Object? nprocs = null,
     Object? load = null,
+    Object? percentCpu = freezed,
   }) {
     return _then(_self.copyWith(
       nprocs: null == nprocs
@@ -1112,6 +1117,10 @@ class _$CPUCopyWithImpl<$Res> implements $CPUCopyWith<$Res> {
           ? _self.load
           : load // ignore: cast_nullable_to_non_nullable
               as Load,
+      percentCpu: freezed == percentCpu
+          ? _self.percentCpu
+          : percentCpu // ignore: cast_nullable_to_non_nullable
+              as double?,
     ));
   }
 
@@ -1129,13 +1138,19 @@ class _$CPUCopyWithImpl<$Res> implements $CPUCopyWith<$Res> {
 /// @nodoc
 @JsonSerializable()
 class _CPU implements CPU {
-  const _CPU({required this.nprocs, required this.load});
+  const _CPU(
+      {required this.nprocs,
+      required this.load,
+      @JsonKey(name: '%cpu') this.percentCpu});
   factory _CPU.fromJson(Map<String, dynamic> json) => _$CPUFromJson(json);
 
   @override
   final int nprocs;
   @override
   final Load load;
+  @override
+  @JsonKey(name: '%cpu')
+  final double? percentCpu;
 
   /// Create a copy of CPU
   /// with the given fields replaced by the non-null parameter values.
@@ -1158,16 +1173,18 @@ class _CPU implements CPU {
         (other.runtimeType == runtimeType &&
             other is _CPU &&
             (identical(other.nprocs, nprocs) || other.nprocs == nprocs) &&
-            (identical(other.load, load) || other.load == load));
+            (identical(other.load, load) || other.load == load) &&
+            (identical(other.percentCpu, percentCpu) ||
+                other.percentCpu == percentCpu));
   }
 
   @JsonKey(includeFromJson: false, includeToJson: false)
   @override
-  int get hashCode => Object.hash(runtimeType, nprocs, load);
+  int get hashCode => Object.hash(runtimeType, nprocs, load, percentCpu);
 
   @override
   String toString() {
-    return 'CPU(nprocs: $nprocs, load: $load)';
+    return 'CPU(nprocs: $nprocs, load: $load, percentCpu: $percentCpu)';
   }
 }
 
@@ -1177,7 +1194,7 @@ abstract mixin class _$CPUCopyWith<$Res> implements $CPUCopyWith<$Res> {
       __$CPUCopyWithImpl;
   @override
   @useResult
-  $Res call({int nprocs, Load load});
+  $Res call({int nprocs, Load load, @JsonKey(name: '%cpu') double? percentCpu});
 
   @override
   $LoadCopyWith<$Res> get load;
@@ -1197,6 +1214,7 @@ class __$CPUCopyWithImpl<$Res> implements _$CPUCopyWith<$Res> {
   $Res call({
     Object? nprocs = null,
     Object? load = null,
+    Object? percentCpu = freezed,
   }) {
     return _then(_CPU(
       nprocs: null == nprocs
@@ -1207,6 +1225,10 @@ class __$CPUCopyWithImpl<$Res> implements _$CPUCopyWith<$Res> {
           ? _self.load
           : load // ignore: cast_nullable_to_non_nullable
               as Load,
+      percentCpu: freezed == percentCpu
+          ? _self.percentCpu
+          : percentCpu // ignore: cast_nullable_to_non_nullable
+              as double?,
     ));
   }
 

--- a/lib/models/api/v6/ftl/system.g.dart
+++ b/lib/models/api/v6/ftl/system.g.dart
@@ -74,11 +74,13 @@ Map<String, dynamic> _$SwapToJson(_Swap instance) => <String, dynamic>{
 _CPU _$CPUFromJson(Map<String, dynamic> json) => _CPU(
       nprocs: (json['nprocs'] as num).toInt(),
       load: Load.fromJson(json['load'] as Map<String, dynamic>),
+      percentCpu: (json['%cpu'] as num?)?.toDouble(),
     );
 
 Map<String, dynamic> _$CPUToJson(_CPU instance) => <String, dynamic>{
       'nprocs': instance.nprocs,
       'load': instance.load,
+      '%cpu': instance.percentCpu,
     };
 
 _Load _$LoadFromJson(Map<String, dynamic> json) => _Load(

--- a/lib/models/system.dart
+++ b/lib/models/system.dart
@@ -11,7 +11,8 @@ class SystemInfo {
     return SystemInfo(
       uptime: system.system.uptime,
       ramUsage: system.system.memory.ram.percentUsed,
-      cpuUsage: _average(system.system.cpu.load.percent),
+      cpuUsage: system.system.cpu.percentCpu ??
+          _average(system.system.cpu.load.percent),
     );
   }
 

--- a/test/ut/gateways/v6/api_gateway_v6_test.dart
+++ b/test/ut/gateways/v6/api_gateway_v6_test.dart
@@ -1748,6 +1748,42 @@ void main() async {
       'took': 0.003,
     };
 
+    // FTL >= 6.1
+    const dataNewV61 = {
+      'system': {
+        'uptime': 67906,
+        'memory': {
+          'ram': {
+            'total': 10317877,
+            'free': 308736,
+            'used': 8920416,
+            'available': 972304,
+            '%used': 26.854,
+          },
+          'swap': {
+            'total': 10317877,
+            'used': 8920416,
+            'free': 308736,
+            '%used': 1.67,
+          },
+        },
+        'procs': 1452,
+        'cpu': {
+          'nprocs': 8,
+          '%cpu': 3.3232043958349604,
+          'load': {
+            'raw': [0.58837890625, 0.64990234375, 0.66748046875],
+            'percent': [
+              4.903157711029053,
+              5.415853023529053,
+              5.562337398529053,
+            ],
+          },
+        },
+      },
+      'took': 0.003,
+    };
+
     setUp(() {
       server = Server(
         address: 'http://example.com',
@@ -1775,6 +1811,27 @@ void main() async {
         response.data?.toJson(),
         SystemInfo.fromV6(System.fromJson(data)).toJson(),
       );
+    });
+
+    test('should return cpuUsage from percentCpu when provided (FTL v6.1)',
+        () async {
+      final mockClient = MockClient();
+      final apiGateway = ApiGatewayV6(server, client: mockClient);
+      when(
+        mockClient.get(
+          Uri.parse(url),
+          headers: anyNamed('headers'),
+        ),
+      ).thenAnswer((_) async => http.Response(jsonEncode(dataNewV61), 200));
+      final response = await apiGateway.fetchSystemInfo();
+
+      expect(response.result, APiResponseType.success);
+      expect(response.message, null);
+      expect(
+        response.data?.toJson(),
+        SystemInfo.fromV6(System.fromJson(dataNewV61)).toJson(),
+      );
+      expect(response.data?.cpuUsage, 3.3232043958349604);
     });
   });
 


### PR DESCRIPTION
## Overview

This PR adds an optional percentCpu field to the CPU model, mapped from the %cpu key introduced in FTL v6.1.
If the field is not present, the system will fallback to using the average CPU load as before.