### PR TITLE
fix(statistics): isolate ScrollControllers for each CustomTabContent

### DIFF
--- a/lib/screens/statistics/statistics.dart
+++ b/lib/screens/statistics/statistics.dart
@@ -11,6 +11,10 @@ class Statistics extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final queriesController = ScrollController();
+    final domainsController = ScrollController();
+    final clientsController = ScrollController();
+
     if (MediaQuery.of(context).size.width > ResponsiveConstants.xxLarge) {
       return const StatisticsTripleColumn();
     } else {
@@ -72,16 +76,19 @@ class Statistics extends StatelessWidget {
               children: [
                 QueriesServersTab(
                   onRefresh: () async => refreshServerStatus(context),
+                  controller: queriesController,
                 ),
                 StatisticsList(
                   countLabel: AppLocalizations.of(context)!.hits,
                   type: 'domains',
                   onRefresh: () async => refreshServerStatus(context),
+                  controller: domainsController,
                 ),
                 StatisticsList(
                   countLabel: AppLocalizations.of(context)!.requests,
                   type: 'clients',
                   onRefresh: () async => refreshServerStatus(context),
+                  controller: clientsController,
                 ),
               ],
             ),

--- a/lib/screens/statistics/statistics.dart
+++ b/lib/screens/statistics/statistics.dart
@@ -6,15 +6,36 @@ import 'package:pi_hole_client/screens/statistics/statistics_list.dart';
 import 'package:pi_hole_client/screens/statistics/statistics_queries_servers_tab.dart';
 import 'package:pi_hole_client/screens/statistics/statistics_triple_column.dart';
 
-class Statistics extends StatelessWidget {
+class Statistics extends StatefulWidget {
   const Statistics({super.key});
 
   @override
-  Widget build(BuildContext context) {
-    final queriesController = ScrollController();
-    final domainsController = ScrollController();
-    final clientsController = ScrollController();
+  State<Statistics> createState() => _StatisticsState();
+}
 
+class _StatisticsState extends State<Statistics> {
+  late final ScrollController queriesController;
+  late final ScrollController domainsController;
+  late final ScrollController clientsController;
+
+  @override
+  void initState() {
+    super.initState();
+    queriesController = ScrollController();
+    domainsController = ScrollController();
+    clientsController = ScrollController();
+  }
+
+  @override
+  void dispose() {
+    queriesController.dispose();
+    domainsController.dispose();
+    clientsController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
     if (MediaQuery.of(context).size.width > ResponsiveConstants.xxLarge) {
       return const StatisticsTripleColumn();
     } else {

--- a/lib/screens/statistics/statistics_list.dart
+++ b/lib/screens/statistics/statistics_list.dart
@@ -17,12 +17,14 @@ class StatisticsList extends StatelessWidget {
     required this.countLabel,
     required this.type,
     required this.onRefresh,
+    this.controller,
     super.key,
   });
 
   final String countLabel;
   final String type;
   final Future<void> Function() onRefresh;
+  final ScrollController? controller;
 
   @override
   Widget build(BuildContext context) {
@@ -75,6 +77,7 @@ class StatisticsList extends StatelessWidget {
       ),
       loadStatus: statusProvider.getStatusLoading,
       onRefresh: onRefresh,
+      controller: controller,
     );
   }
 }

--- a/lib/screens/statistics/statistics_queries_servers_tab.dart
+++ b/lib/screens/statistics/statistics_queries_servers_tab.dart
@@ -10,9 +10,14 @@ import 'package:pi_hole_client/widgets/tab_content.dart';
 import 'package:provider/provider.dart';
 
 class QueriesServersTab extends StatelessWidget {
-  const QueriesServersTab({required this.onRefresh, super.key});
+  const QueriesServersTab({
+    required this.onRefresh,
+    this.controller,
+    super.key,
+  });
 
   final Future<void> Function() onRefresh;
+  final ScrollController? controller;
 
   @override
   Widget build(BuildContext context) {
@@ -64,6 +69,7 @@ class QueriesServersTab extends StatelessWidget {
       ),
       loadStatus: statusProvider.getStatusLoading,
       onRefresh: onRefresh,
+      controller: controller,
     );
   }
 }

--- a/lib/widgets/tab_content.dart
+++ b/lib/widgets/tab_content.dart
@@ -9,6 +9,7 @@ class CustomTabContent extends StatelessWidget {
     required this.errorGenerator,
     required this.loadStatus,
     required this.onRefresh,
+    this.controller,
     super.key,
   });
 
@@ -17,6 +18,7 @@ class CustomTabContent extends StatelessWidget {
   final Widget Function() errorGenerator;
   final LoadStatus loadStatus;
   final Future<void> Function() onRefresh;
+  final ScrollController? controller;
 
   @override
   Widget build(BuildContext context) {
@@ -27,6 +29,7 @@ class CustomTabContent extends StatelessWidget {
           bottom: false,
           child: Builder(
             builder: (BuildContext context) => CustomScrollView(
+              controller: controller,
               slivers: [
                 SliverOverlapInjector(
                   handle:
@@ -53,6 +56,7 @@ class CustomTabContent extends StatelessWidget {
                 onRefresh: onRefresh,
                 edgeOffset: 95,
                 child: CustomScrollView(
+                  controller: controller,
                   slivers: <Widget>[
                     SliverOverlapInjector(
                       handle: NestedScrollView.sliverOverlapAbsorberHandleFor(
@@ -75,6 +79,7 @@ class CustomTabContent extends StatelessWidget {
           bottom: false,
           child: Builder(
             builder: (BuildContext context) => CustomScrollView(
+              controller: controller,
               slivers: [
                 SliverOverlapInjector(
                   handle:


### PR DESCRIPTION
## Overview

This PR fixes a error caused by sharing the same `ScrollController` across multiple tabs using `CustomTabContent`. The issue occurred when switching between the "Domains" and "Clients" tabs and scrolling.

### Changes:
- Assigned separate `ScrollController`s to each tab.
- Updated components to accept optional controllers.
- Prevented multiple scroll views from using the same controller.

