### PR TITLE
fix(navrail): prevent bottom overflow in CustomNavigationRail with scrollable layout

### DIFF
--- a/lib/widgets/navigation_rail.dart
+++ b/lib/widgets/navigation_rail.dart
@@ -49,6 +49,12 @@ class CustomNavigationRail extends StatelessWidget {
             constraints: BoxConstraints(
               minHeight: constraints.maxHeight,
             ),
+            // IntrinsicHeight is needed because NavigationRail uses a Column with Expanded.
+            // Without it, placing NavigationRail inside a scroll view causes unbounded height,
+            // leading to layout errors. IntrinsicHeight ensures a proper bounded layout.
+            //
+            // TODO: IntrinsicHeight is costly for layout performance.
+            // Consider refactoring to a custom NavigationRail if performance issues are observed.
             child: IntrinsicHeight(
               child: NavigationRail(
                 selectedIndex: selectedScreen,

--- a/lib/widgets/navigation_rail.dart
+++ b/lib/widgets/navigation_rail.dart
@@ -42,22 +42,37 @@ class CustomNavigationRail extends StatelessWidget {
       }
     }
 
-    return NavigationRail(
-      selectedIndex: selectedScreen,
-      onDestinationSelected: onChange,
-      destinations: screens
-          .map(
-            (screen) => NavigationRailDestination(
-              icon: screen.icon,
-              label: Text(getStringLocalization(screen.name)),
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        return SingleChildScrollView(
+          child: ConstrainedBox(
+            constraints: BoxConstraints(
+              minHeight: constraints.maxHeight,
             ),
-          )
-          .toList(),
-      labelType: NavigationRailLabelType.all,
-      useIndicator: true,
-      groupAlignment: 0,
-      backgroundColor:
-          Theme.of(context).colorScheme.primary.withValues(alpha: 0.05),
+            child: IntrinsicHeight(
+              child: NavigationRail(
+                selectedIndex: selectedScreen,
+                onDestinationSelected: onChange,
+                destinations: screens
+                    .map(
+                      (screen) => NavigationRailDestination(
+                        icon: screen.icon,
+                        label: Text(getStringLocalization(screen.name)),
+                      ),
+                    )
+                    .toList(),
+                labelType: NavigationRailLabelType.all,
+                useIndicator: true,
+                groupAlignment: 0,
+                backgroundColor: Theme.of(context)
+                    .colorScheme
+                    .primary
+                    .withValues(alpha: 0.05),
+              ),
+            ),
+          ),
+        );
+      },
     );
   }
 }


### PR DESCRIPTION
## Overview
This PR addresses a layout issue where the CustomNavigationRail component would cause a bottom overflow error when the keyboard was opened, especially in landscape mode.

## Changes
- Wrapped NavigationRail with LayoutBuilder to capture parent height constraints.
- Added a ConstrainedBox with minHeight to enforce minimum height behavior.
- Wrapped the entire structure in a SingleChildScrollView to enable scrolling when necessary.

## Screenshots

|before|after|
|---|---|
|![Screenshot_1745669319](https://github.com/user-attachments/assets/5c7f2d75-6a0d-4993-8ad7-5c55dd6cf631)|![Screenshot_1745669297](https://github.com/user-attachments/assets/0dd555ad-22ce-4873-962b-fea2c9e3c796)|

## Related to Issue

- #96 

