### PR TITLE
fix(logs_filter_modal): keep action buttons always visible in dialog

### DIFF
--- a/lib/screens/logs/clients_filters_modal.dart
+++ b/lib/screens/logs/clients_filters_modal.dart
@@ -91,88 +91,92 @@ class _ClientsFiltersModalState extends State<ClientsFiltersModal> {
     }
 
     Widget content() {
-      return Wrap(
-        alignment: WrapAlignment.center,
-        children: [
-          ConstrainedBox(
-            constraints: BoxConstraints(
-              maxHeight: MediaQuery.of(context).size.height * 0.8,
-            ),
-            child: ListView(
-              children: [
-                Padding(
-                  padding: const EdgeInsets.only(top: 24),
-                  child: Icon(
-                    Icons.phone_android_rounded,
-                    size: 24,
-                    color: Theme.of(context).colorScheme.secondary,
-                  ),
-                ),
-                Padding(
-                  padding: const EdgeInsets.only(top: 24, bottom: 24),
-                  child: Text(
-                    AppLocalizations.of(context)!.clients,
-                    textAlign: TextAlign.center,
-                    style: const TextStyle(fontSize: 24),
-                  ),
-                ),
-                ...filtersProvider.totalClients.map(
-                  (e) => listItem(
-                    label: e,
-                    value: e,
-                  ),
-                ),
-              ],
-            ),
-          ),
-          Padding(
-            padding: const EdgeInsets.all(20),
-            child: Row(
-              mainAxisAlignment: MainAxisAlignment.spaceBetween,
-              children: [
-                TextButton(
-                  onPressed: checkUncheckAll,
-                  child: _selectedClients.length ==
-                          filtersProvider.totalClients.length
-                      ? Text(AppLocalizations.of(context)!.uncheckAll)
-                      : Text(AppLocalizations.of(context)!.checkAll),
-                ),
-                Row(
-                  mainAxisAlignment: MainAxisAlignment.end,
-                  children: [
-                    TextButton(
-                      onPressed: () => Navigator.maybePop(context),
-                      child: Text(AppLocalizations.of(context)!.close),
+      return ConstrainedBox(
+        constraints: BoxConstraints(
+          maxHeight: MediaQuery.of(context).size.height * 0.8,
+        ),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Expanded(
+              child: ListView(
+                shrinkWrap: true,
+                children: [
+                  Padding(
+                    padding: const EdgeInsets.only(top: 24),
+                    child: Icon(
+                      Icons.phone_android_rounded,
+                      size: 24,
+                      color: Theme.of(context).colorScheme.secondary,
                     ),
-                    const SizedBox(width: 20),
-                    TextButton(
-                      onPressed: _selectedClients.isNotEmpty
-                          ? () {
-                              updateList();
-                              Navigator.maybePop(context);
-                            }
-                          : null,
-                      style: ButtonStyle(
-                        foregroundColor: WidgetStateProperty.all(
-                          _selectedClients.isNotEmpty
-                              ? Theme.of(context).colorScheme.primary
-                              : Colors.grey,
-                        ),
-                        overlayColor: WidgetStateProperty.all(
-                          Theme.of(context)
-                              .colorScheme
-                              .primary
-                              .withValues(alpha: 0.1),
-                        ),
+                  ),
+                  Padding(
+                    padding: const EdgeInsets.only(top: 24, bottom: 24),
+                    child: Text(
+                      AppLocalizations.of(context)!.clients,
+                      textAlign: TextAlign.center,
+                      style: const TextStyle(fontSize: 24),
+                    ),
+                  ),
+                  ...filtersProvider.totalClients.map(
+                    (e) => listItem(
+                      label: e,
+                      value: e,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+            Padding(
+              padding: const EdgeInsets.all(20),
+              child: Row(
+                mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                children: [
+                  TextButton(
+                    onPressed: checkUncheckAll,
+                    child: Text(
+                      _selectedClients.length ==
+                              filtersProvider.totalClients.length
+                          ? AppLocalizations.of(context)!.uncheckAll
+                          : AppLocalizations.of(context)!.checkAll,
+                    ),
+                  ),
+                  Row(
+                    children: [
+                      TextButton(
+                        onPressed: () => Navigator.maybePop(context),
+                        child: Text(AppLocalizations.of(context)!.close),
                       ),
-                      child: Text(AppLocalizations.of(context)!.apply),
-                    ),
-                  ],
-                ),
-              ],
+                      const SizedBox(width: 20),
+                      TextButton(
+                        onPressed: _selectedClients.isNotEmpty
+                            ? () {
+                                updateList();
+                                Navigator.maybePop(context);
+                              }
+                            : null,
+                        style: ButtonStyle(
+                          foregroundColor: WidgetStateProperty.all(
+                            _selectedClients.isNotEmpty
+                                ? Theme.of(context).colorScheme.primary
+                                : Colors.grey,
+                          ),
+                          overlayColor: WidgetStateProperty.all(
+                            Theme.of(context)
+                                .colorScheme
+                                .primary
+                                .withValues(alpha: 0.1),
+                          ),
+                        ),
+                        child: Text(AppLocalizations.of(context)!.apply),
+                      ),
+                    ],
+                  ),
+                ],
+              ),
             ),
-          ),
-        ],
+          ],
+        ),
       );
     }
 

--- a/lib/screens/logs/status_filters_modal.dart
+++ b/lib/screens/logs/status_filters_modal.dart
@@ -107,88 +107,90 @@ class _StatusFiltersModalState extends State<StatusFiltersModal> {
     }
 
     Widget content() {
-      return Wrap(
-        alignment: WrapAlignment.center,
-        children: [
-          ConstrainedBox(
-            constraints: BoxConstraints(
-              maxHeight: MediaQuery.of(context).size.height * 0.8,
-            ),
-            child: ListView(
-              children: [
-                Padding(
-                  padding: const EdgeInsets.only(top: 24),
-                  child: Icon(
-                    Icons.shield_rounded,
-                    size: 24,
-                    color: Theme.of(context).colorScheme.secondary,
-                  ),
-                ),
-                Row(
-                  mainAxisAlignment: MainAxisAlignment.center,
-                  children: [
-                    Padding(
-                      padding: const EdgeInsets.only(top: 24, bottom: 24),
-                      child: Text(
-                        AppLocalizations.of(context)!.logsStatus,
-                        style: const TextStyle(fontSize: 24),
-                      ),
+      return ConstrainedBox(
+        constraints: BoxConstraints(
+          maxHeight: MediaQuery.of(context).size.height * 0.8,
+        ),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Expanded(
+              child: ListView(
+                shrinkWrap: true,
+                children: [
+                  Padding(
+                    padding: const EdgeInsets.only(top: 24),
+                    child: Icon(
+                      Icons.shield_rounded,
+                      size: 24,
+                      color: Theme.of(context).colorScheme.secondary,
                     ),
-                  ],
-                ),
-                ...generateListItems(),
-              ],
-            ),
-          ),
-          Padding(
-            padding: const EdgeInsets.all(20),
-            child: Row(
-              mainAxisAlignment: MainAxisAlignment.spaceBetween,
-              children: [
-                TextButton(
-                  onPressed: checkUncheckAll,
-                  child: Text(
-                    _statusSelected.length == serversProvider.numShown
-                        ? AppLocalizations.of(context)!.uncheckAll
-                        : AppLocalizations.of(context)!.checkAll,
                   ),
-                ),
-                Row(
-                  mainAxisAlignment: MainAxisAlignment.end,
-                  children: [
-                    TextButton(
-                      onPressed: () => Navigator.maybePop(context),
-                      child: Text(AppLocalizations.of(context)!.close),
-                    ),
-                    const SizedBox(width: 20),
-                    TextButton(
-                      onPressed: _statusSelected.isNotEmpty
-                          ? () {
-                              updateList();
-                              Navigator.maybePop(context);
-                            }
-                          : null,
-                      style: ButtonStyle(
-                        foregroundColor: WidgetStateProperty.all(
-                          _statusSelected.isNotEmpty
-                              ? Theme.of(context).colorScheme.primary
-                              : Colors.grey,
-                        ),
-                        overlayColor: WidgetStateProperty.all(
-                          Theme.of(context)
-                              .colorScheme
-                              .primary
-                              .withValues(alpha: 0.1),
+                  Row(
+                    mainAxisAlignment: MainAxisAlignment.center,
+                    children: [
+                      Padding(
+                        padding: const EdgeInsets.only(top: 24, bottom: 24),
+                        child: Text(
+                          AppLocalizations.of(context)!.logsStatus,
+                          style: const TextStyle(fontSize: 24),
                         ),
                       ),
-                      child: Text(AppLocalizations.of(context)!.apply),
-                    ),
-                  ],
-                ),
-              ],
+                    ],
+                  ),
+                  ...generateListItems(),
+                ],
+              ),
             ),
-          ),
-        ],
+            Padding(
+              padding: const EdgeInsets.all(20),
+              child: Row(
+                mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                children: [
+                  TextButton(
+                    onPressed: checkUncheckAll,
+                    child: Text(
+                      _statusSelected.length == serversProvider.numShown
+                          ? AppLocalizations.of(context)!.uncheckAll
+                          : AppLocalizations.of(context)!.checkAll,
+                    ),
+                  ),
+                  Row(
+                    children: [
+                      TextButton(
+                        onPressed: () => Navigator.maybePop(context),
+                        child: Text(AppLocalizations.of(context)!.close),
+                      ),
+                      const SizedBox(width: 20),
+                      TextButton(
+                        onPressed: _statusSelected.isNotEmpty
+                            ? () {
+                                updateList();
+                                Navigator.maybePop(context);
+                              }
+                            : null,
+                        style: ButtonStyle(
+                          foregroundColor: WidgetStateProperty.all(
+                            _statusSelected.isNotEmpty
+                                ? Theme.of(context).colorScheme.primary
+                                : Colors.grey,
+                          ),
+                          overlayColor: WidgetStateProperty.all(
+                            Theme.of(context)
+                                .colorScheme
+                                .primary
+                                .withValues(alpha: 0.1),
+                          ),
+                        ),
+                        child: Text(AppLocalizations.of(context)!.apply),
+                      ),
+                    ],
+                  ),
+                ],
+              ),
+            ),
+          ],
+        ),
       );
     }
 


### PR DESCRIPTION
## Overview
Fix dialogs to keep action buttons (Check All, Close, Apply) always visible at the bottom, even when the list content is scrollable. Improves usability when working with long lists.

### Affected dialogs:

- Logs Status filter (logsStatus)
- Clients filter (clients)

## Screenshot

|before|after|
|---|---|
|![Screenshot_1745728333](https://github.com/user-attachments/assets/e4b92896-532f-482f-81c5-4dc29cb487d9)|![Screenshot_1745728317](https://github.com/user-attachments/assets/0d5533ba-34f4-4340-a888-5964ee009333)|

## Related to issue

- #96 

