### PR TITLE
fix(modal): prevent bottom overflow when keyboard is visible in landscape

### DIFF
--- a/lib/screens/domains/add_domain_modal.dart
+++ b/lib/screens/domains/add_domain_modal.dart
@@ -94,6 +94,10 @@ class _AddDomainModalState extends State<AddDomainModal> {
 
   @override
   Widget build(BuildContext context) {
+    final mediaQuery = MediaQuery.of(context);
+    final isLandscape = mediaQuery.orientation == Orientation.landscape;
+    final isKeyboardVisible = mediaQuery.viewInsets.bottom > 0;
+
     Widget content() {
       return Column(
         mainAxisSize: MainAxisSize.min,
@@ -169,7 +173,9 @@ class _AddDomainModalState extends State<AddDomainModal> {
             ),
           ),
           Padding(
-            padding: const EdgeInsets.only(top: 20),
+            padding: (isLandscape && isKeyboardVisible)
+                ? EdgeInsets.zero
+                : const EdgeInsets.only(top: 20),
             child: Row(
               mainAxisAlignment: MainAxisAlignment.end,
               children: [
@@ -209,7 +215,9 @@ class _AddDomainModalState extends State<AddDomainModal> {
         child: ConstrainedBox(
           constraints: const BoxConstraints(maxWidth: 500),
           child: Padding(
-            padding: const EdgeInsets.all(16),
+            padding: (isLandscape && isKeyboardVisible)
+                ? const EdgeInsets.symmetric(horizontal: 16)
+                : const EdgeInsets.all(16),
             child: content(),
           ),
         ),

--- a/lib/screens/domains/domains_list.dart
+++ b/lib/screens/domains/domains_list.dart
@@ -143,9 +143,14 @@ class _DomainsListState extends State<DomainsList> {
     }
 
     void openModalAddDomainToList() {
+      final mediaQuery = MediaQuery.of(context);
+      final isSmallLandscape = mediaQuery.size.width > mediaQuery.size.height &&
+          mediaQuery.size.height < ResponsiveConstants.medium;
+
       if (MediaQuery.of(context).size.width > ResponsiveConstants.medium) {
         showDialog(
           context: context,
+          useSafeArea: !isSmallLandscape,
           useRootNavigator:
               false, // Prevents unexpected app exit on mobile when pressing back
           builder: (ctx) => AddDomainModal(

--- a/lib/screens/servers/add_server_fullscreen.dart
+++ b/lib/screens/servers/add_server_fullscreen.dart
@@ -741,6 +741,7 @@ class _AddServerFullscreenState extends State<AddServerFullscreen> {
 
     if (widget.window == true) {
       return Dialog(
+        insetPadding: const EdgeInsets.symmetric(vertical: 24),
         child: SizedBox(
           width: 400,
           child: Column(
@@ -756,7 +757,6 @@ class _AddServerFullscreenState extends State<AddServerFullscreen> {
                           onPressed: () => Navigator.maybePop(context),
                           icon: const Icon(Icons.clear_rounded),
                         ),
-                        const SizedBox(width: 8),
                         Text(
                           widget.title,
                           style: const TextStyle(fontSize: 20),
@@ -771,21 +771,18 @@ class _AddServerFullscreenState extends State<AddServerFullscreen> {
                           tooltip:
                               AppLocalizations.of(context)!.howCreateConnection,
                         ),
-                        Padding(
-                          padding: const EdgeInsets.only(right: 10),
-                          child: IconButton(
-                            tooltip: widget.server != null
-                                ? AppLocalizations.of(context)!.save
-                                : AppLocalizations.of(context)!.connect,
-                            onPressed: validData()
-                                ? widget.server != null
-                                    ? save
-                                    : connect
-                                : null,
-                            icon: widget.server != null
-                                ? const Icon(Icons.save_rounded)
-                                : const Icon(Icons.login_rounded),
-                          ),
+                        IconButton(
+                          tooltip: widget.server != null
+                              ? AppLocalizations.of(context)!.save
+                              : AppLocalizations.of(context)!.connect,
+                          onPressed: validData()
+                              ? widget.server != null
+                                  ? save
+                                  : connect
+                              : null,
+                          icon: widget.server != null
+                              ? const Icon(Icons.save_rounded)
+                              : const Icon(Icons.login_rounded),
                         ),
                       ],
                     ),

--- a/lib/screens/settings/server_settings/widgets/subscriptions/add_subscription_modal.dart
+++ b/lib/screens/settings/server_settings/widgets/subscriptions/add_subscription_modal.dart
@@ -97,6 +97,10 @@ class _AddSubscriptionModalState extends State<AddSubscriptionModal> {
 
   @override
   Widget build(BuildContext context) {
+    final mediaQuery = MediaQuery.of(context);
+    final isLandscape = mediaQuery.orientation == Orientation.landscape;
+    final isKeyboardVisible = mediaQuery.viewInsets.bottom > 0;
+
     Widget content() {
       return Column(
         mainAxisSize: MainAxisSize.min,
@@ -199,7 +203,9 @@ class _AddSubscriptionModalState extends State<AddSubscriptionModal> {
             ),
           ),
           Padding(
-            padding: const EdgeInsets.only(top: 20),
+            padding: (isLandscape && isKeyboardVisible)
+                ? EdgeInsets.zero
+                : const EdgeInsets.only(top: 20),
             child: Row(
               mainAxisAlignment: MainAxisAlignment.end,
               children: [
@@ -240,7 +246,9 @@ class _AddSubscriptionModalState extends State<AddSubscriptionModal> {
         child: ConstrainedBox(
           constraints: const BoxConstraints(maxWidth: 600),
           child: Padding(
-            padding: const EdgeInsets.all(16),
+            padding: (isLandscape && isKeyboardVisible)
+                ? const EdgeInsets.symmetric(horizontal: 16)
+                : const EdgeInsets.all(16),
             child: content(),
           ),
         ),

--- a/lib/screens/settings/server_settings/widgets/subscriptions/add_subscription_modal.dart
+++ b/lib/screens/settings/server_settings/widgets/subscriptions/add_subscription_modal.dart
@@ -99,7 +99,6 @@ class _AddSubscriptionModalState extends State<AddSubscriptionModal> {
   Widget build(BuildContext context) {
     final mediaQuery = MediaQuery.of(context);
     final isLandscape = mediaQuery.orientation == Orientation.landscape;
-    final isKeyboardVisible = mediaQuery.viewInsets.bottom > 0;
 
     Widget content() {
       return Column(
@@ -203,9 +202,8 @@ class _AddSubscriptionModalState extends State<AddSubscriptionModal> {
             ),
           ),
           Padding(
-            padding: (isLandscape && isKeyboardVisible)
-                ? EdgeInsets.zero
-                : const EdgeInsets.only(top: 20),
+            padding:
+                isLandscape ? EdgeInsets.zero : const EdgeInsets.only(top: 20),
             child: Row(
               mainAxisAlignment: MainAxisAlignment.end,
               children: [
@@ -246,7 +244,7 @@ class _AddSubscriptionModalState extends State<AddSubscriptionModal> {
         child: ConstrainedBox(
           constraints: const BoxConstraints(maxWidth: 600),
           child: Padding(
-            padding: (isLandscape && isKeyboardVisible)
+            padding: isLandscape
                 ? const EdgeInsets.symmetric(horizontal: 16)
                 : const EdgeInsets.all(16),
             child: content(),

--- a/lib/screens/settings/server_settings/widgets/subscriptions/edit_subscription_modal.dart
+++ b/lib/screens/settings/server_settings/widgets/subscriptions/edit_subscription_modal.dart
@@ -75,35 +75,39 @@ class _EditSubscriptionModalState extends State<EditSubscriptionModal> {
 
   @override
   Widget build(BuildContext context) {
+    final mediaQuery = MediaQuery.of(context);
+    final isLandscape = mediaQuery.orientation == Orientation.landscape;
+    final isKeyboardVisible = mediaQuery.viewInsets.bottom > 0;
+
     Widget content() {
       return Container(
         constraints: const BoxConstraints(minHeight: 360),
         child: Column(
           mainAxisAlignment: MainAxisAlignment.spaceBetween,
           children: [
-            Column(
-              mainAxisSize: MainAxisSize.min,
-              children: [
-                Icon(
-                  widget.icon,
-                  size: 24,
-                  color: Theme.of(context).colorScheme.secondary,
-                ),
-                Padding(
-                  padding: const EdgeInsets.all(20),
-                  child: Text(
-                    widget.title,
-                    style: const TextStyle(fontSize: 24),
-                  ),
-                ),
-              ],
-            ),
             Flexible(
               child: Center(
                 child: SingleChildScrollView(
                   child: Column(
                     mainAxisSize: MainAxisSize.min,
                     children: [
+                      Column(
+                        mainAxisSize: MainAxisSize.min,
+                        children: [
+                          Icon(
+                            widget.icon,
+                            size: 24,
+                            color: Theme.of(context).colorScheme.secondary,
+                          ),
+                          Padding(
+                            padding: const EdgeInsets.all(20),
+                            child: Text(
+                              widget.title,
+                              style: const TextStyle(fontSize: 24),
+                            ),
+                          ),
+                        ],
+                      ),
                       if (widget.keyItem == 'comment')
                         SizedBox(
                           width: double.infinity,
@@ -140,7 +144,9 @@ class _EditSubscriptionModalState extends State<EditSubscriptionModal> {
               ),
             ),
             Padding(
-              padding: const EdgeInsets.only(top: 20),
+              padding: (isLandscape && isKeyboardVisible)
+                  ? EdgeInsets.zero
+                  : const EdgeInsets.only(top: 20),
               child: Row(
                 mainAxisAlignment: MainAxisAlignment.end,
                 children: [
@@ -189,7 +195,9 @@ class _EditSubscriptionModalState extends State<EditSubscriptionModal> {
         child: ConstrainedBox(
           constraints: const BoxConstraints(maxWidth: 600, maxHeight: 480),
           child: Padding(
-            padding: const EdgeInsets.all(16),
+            padding: (isLandscape && isKeyboardVisible)
+                ? const EdgeInsets.symmetric(horizontal: 16)
+                : const EdgeInsets.all(16),
             child: content(),
           ),
         ),

--- a/lib/screens/settings/server_settings/widgets/subscriptions/edit_subscription_modal.dart
+++ b/lib/screens/settings/server_settings/widgets/subscriptions/edit_subscription_modal.dart
@@ -77,7 +77,6 @@ class _EditSubscriptionModalState extends State<EditSubscriptionModal> {
   Widget build(BuildContext context) {
     final mediaQuery = MediaQuery.of(context);
     final isLandscape = mediaQuery.orientation == Orientation.landscape;
-    final isKeyboardVisible = mediaQuery.viewInsets.bottom > 0;
 
     Widget content() {
       return Container(
@@ -144,7 +143,7 @@ class _EditSubscriptionModalState extends State<EditSubscriptionModal> {
               ),
             ),
             Padding(
-              padding: (isLandscape && isKeyboardVisible)
+              padding: isLandscape
                   ? EdgeInsets.zero
                   : const EdgeInsets.only(top: 20),
               child: Row(
@@ -195,7 +194,7 @@ class _EditSubscriptionModalState extends State<EditSubscriptionModal> {
         child: ConstrainedBox(
           constraints: const BoxConstraints(maxWidth: 600, maxHeight: 480),
           child: Padding(
-            padding: (isLandscape && isKeyboardVisible)
+            padding: isLandscape
                 ? const EdgeInsets.symmetric(horizontal: 16)
                 : const EdgeInsets.all(16),
             child: content(),

--- a/lib/screens/settings/server_settings/widgets/subscriptions/subscription_details_screen.dart
+++ b/lib/screens/settings/server_settings/widgets/subscriptions/subscription_details_screen.dart
@@ -263,9 +263,14 @@ class _SubscriptionDetailsScreenState extends State<SubscriptionDetailsScreen> {
   }
 
   void openCommentModal() {
+    final mediaQuery = MediaQuery.of(context);
+    final isSmallLandscape = mediaQuery.size.width > mediaQuery.size.height &&
+        mediaQuery.size.height < ResponsiveConstants.medium;
+
     if (MediaQuery.of(context).size.width > ResponsiveConstants.medium) {
       showDialog(
         context: context,
+        useSafeArea: !isSmallLandscape,
         useRootNavigator:
             false, // Prevents unexpected app exit on mobile when pressing back
         builder: (ctx) => EditSubscriptionModal(

--- a/lib/screens/settings/server_settings/widgets/subscriptions/subscriptions_list.dart
+++ b/lib/screens/settings/server_settings/widgets/subscriptions/subscriptions_list.dart
@@ -153,9 +153,14 @@ class _SubscriptionsListState extends State<SubscriptionsList> {
     }
 
     void openModalAddSubscriptionToList() {
+      final mediaQuery = MediaQuery.of(context);
+      final isSmallLandscape = mediaQuery.size.width > mediaQuery.size.height &&
+          mediaQuery.size.height < ResponsiveConstants.medium;
+
       if (MediaQuery.of(context).size.width > ResponsiveConstants.medium) {
         showDialog(
           context: context,
+          useSafeArea: !isSmallLandscape,
           useRootNavigator:
               false, // Prevents unexpected app exit on mobile when pressing back
           builder: (ctx) => AddSubscriptionModal(


### PR DESCRIPTION
## Overview
Adjusted padding behavior to prevent overflow when the keyboard is visible in landscape mode.

## Screenshot

|before|after|
|---|---|
|![Screenshot_1745734731](https://github.com/user-attachments/assets/18692f76-516d-446d-88f9-841a7e0f5104)|![Screenshot_1745734741](https://github.com/user-attachments/assets/992a9ed0-e050-48d2-aeb2-d29e803d1cf0)|
|![Screenshot_1745734751](https://github.com/user-attachments/assets/6a7d388a-e070-409a-a704-9c0033a1f272)|![Screenshot_1745735429](https://github.com/user-attachments/assets/f1579fc8-c7ba-48ff-abb5-3d411ba1bf2c)|


## Related to issue
close #96 