### PR TITLE
feat(statistics): adjust default donut chart size via constructor

### DIFF
--- a/lib/screens/statistics/custom_pie_chart.dart
+++ b/lib/screens/statistics/custom_pie_chart.dart
@@ -5,17 +5,19 @@ import 'package:pie_chart/pie_chart.dart';
 class CustomPieChart extends StatelessWidget {
   const CustomPieChart({
     required this.data,
+    this.radiusScale = 3.0,
     super.key,
   });
 
   final Map<String, double> data;
+  final double radiusScale;
 
   @override
   Widget build(BuildContext context) {
     return PieChart(
       dataMap: data,
       animationDuration: const Duration(milliseconds: 800),
-      chartRadius: MediaQuery.of(context).size.width / 3,
+      chartRadius: MediaQuery.of(context).size.width / radiusScale,
       colorList: Theme.of(context).extension<GraphColors>()!.colors,
       initialAngleInDegree: 270,
       chartType: ChartType.ring,

--- a/lib/screens/statistics/statistics_list.dart
+++ b/lib/screens/statistics/statistics_list.dart
@@ -86,11 +86,13 @@ class StatisticsListContent extends StatelessWidget {
   const StatisticsListContent({
     required this.type,
     required this.countLabel,
+    this.pieChartRadiusScale = 3.0,
     super.key,
   });
 
   final String type;
   final String countLabel;
+  final double pieChartRadiusScale;
 
   @override
   Widget build(BuildContext context) {
@@ -196,7 +198,10 @@ class StatisticsListContent extends StatelessWidget {
       return Column(
         children: [
           const SizedBox(height: 10),
-          CustomPieChart(data: items),
+          CustomPieChart(
+            data: items,
+            radiusScale: pieChartRadiusScale,
+          ),
           const SizedBox(height: 20),
           PieChartLegend(
             data: legend,

--- a/lib/screens/statistics/statistics_triple_column.dart
+++ b/lib/screens/statistics/statistics_triple_column.dart
@@ -96,6 +96,7 @@ class StatisticsTripleColumn extends StatelessWidget {
                             StatisticsListContent(
                               type: 'domains',
                               countLabel: AppLocalizations.of(context)!.hits,
+                              pieChartRadiusScale: 6.0,
                             ),
                           ],
                         ),
@@ -131,6 +132,7 @@ class StatisticsTripleColumn extends StatelessWidget {
                               type: 'clients',
                               countLabel:
                                   AppLocalizations.of(context)!.requests,
+                              pieChartRadiusScale: 6.0,
                             ),
                           ],
                         ),


### PR DESCRIPTION
## Overview

Change pie chart size

|before|after|
|---|---|
|![before](https://github.com/user-attachments/assets/f6ce1b76-35ac-4579-960a-52ceda544beb)|![after](https://github.com/user-attachments/assets/f95893f0-5e7e-4523-8b3d-b0abf1f04027)|
