### PR TITLE
feat(servers): allow editing default connection and SSL cert options on edit page

### DIFF
--- a/lib/base.dart
+++ b/lib/base.dart
@@ -138,7 +138,7 @@ class _BaseState extends State<Base>
   /// - When the window is minimized
   void onPaused() {
     final statusUpdateService = context.read<StatusUpdateService>();
-    statusUpdateService.dispose();
+    statusUpdateService.stopAutoRefresh();
   }
 
   Widget _buildPageTransitionSwitcher(Widget child) {

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -166,6 +166,7 @@
   "editConnection": "Verbindung bearbeiten",
   "editGroups": "Gruppen bearbeiten",
   "editServer": "Verbindung bearbeiten",
+  "editServerSuccessfully": "Servereinstellungen wurden erfolgreich aktualisiert.",
   "enable": "Aktivieren",
   "enableCrashReport": "Absturzbericht aktivieren",
   "enableCrashReportDetail": "Automatisch anonymisierte Berichte senden, um Probleme zu diagnostizieren.",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -166,6 +166,7 @@
   "editConnection": "Edit a Connection",
   "editGroups": "Edit groups",
   "editServer": "Edit server connection",
+  "editServerSuccessfully": "Server settings updated successfully.",
   "enable": "Enable",
   "enableCrashReport": "Enable Crash Reporting",
   "enableCrashReportDetail": "Automatically send anonymized reports to diagnose issues.",

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -167,6 +167,7 @@
   "editConnection": "Editar una conexión",
   "editGroups": "Editar grupos",
   "editServer": "Editar conexión",
+  "editServerSuccessfully": "La configuración del servidor se actualizó correctamente.",
   "enable": "Activar",
   "enableCrashReport": "Habilitar informes de fallos",
   "enableCrashReportDetail": "Enviar automáticamente informes anonimados para diagnosticar problemas.",

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -166,6 +166,7 @@
   "editConnection": "接続を編集",
   "editGroups": "グループを編集",
   "editServer": "サーバー接続を編集",
+  "editServerSuccessfully": "サーバー設定が正常に更新されました。",
   "enable": "有効化",
   "enableCrashReport": "クラッシュレポートを有効にする",
   "enableCrashReportDetail": "問題を診断するために匿名化されたレポートを自動的に送信します。",

--- a/lib/l10n/app_pl.arb
+++ b/lib/l10n/app_pl.arb
@@ -166,6 +166,7 @@
   "editConnection": "Edytuj połączenie",
   "editGroups": "Edytuj grupy",
   "editServer": "Edytowanie połączenia z serwerem",
+  "editServerSuccessfully": "Ustawienia serwera zostały pomyślnie zaktualizowane.",
   "enable": "Włączyć",
   "enableCrashReport": "Włącz raportowanie awarii",
   "enableCrashReportDetail": "Automatycznie wysyłaj anonimowe raporty w celu diagnozowania problemów.",

--- a/lib/l10n/generated/app_localizations.dart
+++ b/lib/l10n/generated/app_localizations.dart
@@ -1103,6 +1103,12 @@ abstract class AppLocalizations {
   /// **'Edit server connection'**
   String get editServer;
 
+  /// No description provided for @editServerSuccessfully.
+  ///
+  /// In en, this message translates to:
+  /// **'Server settings updated successfully.'**
+  String get editServerSuccessfully;
+
   /// No description provided for @enable.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/generated/app_localizations_de.dart
+++ b/lib/l10n/generated/app_localizations_de.dart
@@ -510,6 +510,9 @@ class AppLocalizationsDe extends AppLocalizations {
   String get editServer => 'Verbindung bearbeiten';
 
   @override
+  String get editServerSuccessfully => 'Servereinstellungen wurden erfolgreich aktualisiert.';
+
+  @override
   String get enable => 'Aktivieren';
 
   @override

--- a/lib/l10n/generated/app_localizations_en.dart
+++ b/lib/l10n/generated/app_localizations_en.dart
@@ -510,6 +510,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get editServer => 'Edit server connection';
 
   @override
+  String get editServerSuccessfully => 'Server settings updated successfully.';
+
+  @override
   String get enable => 'Enable';
 
   @override

--- a/lib/l10n/generated/app_localizations_es.dart
+++ b/lib/l10n/generated/app_localizations_es.dart
@@ -510,6 +510,9 @@ class AppLocalizationsEs extends AppLocalizations {
   String get editServer => 'Editar conexión';
 
   @override
+  String get editServerSuccessfully => 'La configuración del servidor se actualizó correctamente.';
+
+  @override
   String get enable => 'Activar';
 
   @override

--- a/lib/l10n/generated/app_localizations_ja.dart
+++ b/lib/l10n/generated/app_localizations_ja.dart
@@ -510,6 +510,9 @@ class AppLocalizationsJa extends AppLocalizations {
   String get editServer => 'サーバー接続を編集';
 
   @override
+  String get editServerSuccessfully => 'サーバー設定が正常に更新されました。';
+
+  @override
   String get enable => '有効化';
 
   @override

--- a/lib/l10n/generated/app_localizations_pl.dart
+++ b/lib/l10n/generated/app_localizations_pl.dart
@@ -510,6 +510,9 @@ class AppLocalizationsPl extends AppLocalizations {
   String get editServer => 'Edytowanie połączenia z serwerem';
 
   @override
+  String get editServerSuccessfully => 'Ustawienia serwera zostały pomyślnie zaktualizowane.';
+
+  @override
   String get enable => 'Włączyć';
 
   @override

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -200,7 +200,7 @@ void main() async {
             ),
             Provider<StatusUpdateService>(
               create: (_) => statusUpdateService,
-              dispose: (_, service) => service.dispose(),
+              dispose: (_, service) => service.stopAutoRefresh(),
             ),
           ],
           child: SentryWidget(

--- a/lib/providers/servers_provider.dart
+++ b/lib/providers/servers_provider.dart
@@ -83,6 +83,10 @@ class ServersProvider with ChangeNotifier {
     return _serverGateways[server.address];
   }
 
+  ApiGateway? createApiGateway(Server server) {
+    return ApiGatewayFactory.create(server);
+  }
+
   /// Returns the query status object for the given key.
   ///
   /// Parameters:
@@ -147,6 +151,16 @@ class ServersProvider with ChangeNotifier {
         }
       }).toList();
       _serversList = newServers;
+      if (_selectedServer != null &&
+          _selectedServer!.address == server.address) {
+        _selectedServer = server;
+      }
+
+      // Update the api gateway if it exists
+      if (_serverGateways.containsKey(server.address)) {
+        _serverGateways[server.address] = ApiGatewayFactory.create(server);
+      }
+
       notifyListeners();
       return true;
     } else {

--- a/lib/providers/servers_provider.dart
+++ b/lib/providers/servers_provider.dart
@@ -151,14 +151,23 @@ class ServersProvider with ChangeNotifier {
         }
       }).toList();
       _serversList = newServers;
+
       if (_selectedServer != null &&
           _selectedServer!.address == server.address) {
         _selectedServer = server;
       }
 
-      // Update the api gateway if it exists
+      // Update the API gateway if it exists
       if (_serverGateways.containsKey(server.address)) {
         _serverGateways[server.address] = ApiGatewayFactory.create(server);
+      }
+
+      // Handle default server update
+      if (server.defaultServer == true) {
+        final defaultUpdated = await setDefaultServer(server);
+        if (!defaultUpdated) {
+          return false;
+        }
       }
 
       notifyListeners();

--- a/lib/screens/servers/add_server_fullscreen.dart
+++ b/lib/screens/servers/add_server_fullscreen.dart
@@ -656,7 +656,6 @@ class _AddServerFullscreenState extends State<AddServerFullscreen> {
                       const SizedBox(height: 12),
                       CheckboxListTile(
                         contentPadding: const EdgeInsets.only(right: 8),
-                        enabled: widget.server != null ? false : true,
                         value: allowSelfSignedCert,
                         onChanged: connectionType == ConnectionType.https
                             ? (v) => setState(() => allowSelfSignedCert = v!)
@@ -722,30 +721,23 @@ class _AddServerFullscreenState extends State<AddServerFullscreen> {
                   children: [
                     Checkbox(
                       value: defaultCheckbox,
-                      onChanged: widget.server == null
-                          ? (value) => {
-                                setState(
-                                  () => defaultCheckbox = !defaultCheckbox,
-                                ),
-                              }
-                          : null,
+                      onChanged: (value) => {
+                        setState(
+                          () => defaultCheckbox = !defaultCheckbox,
+                        ),
+                      },
                       shape: RoundedRectangleBorder(
                         borderRadius: BorderRadius.circular(5),
                       ),
                     ),
                     GestureDetector(
-                      onTap: widget.server == null
-                          ? (() => {
-                                setState(
-                                  () => defaultCheckbox = !defaultCheckbox,
-                                ),
-                              })
-                          : null,
+                      onTap: () => {
+                        setState(
+                          () => defaultCheckbox = !defaultCheckbox,
+                        ),
+                      },
                       child: Text(
                         AppLocalizations.of(context)!.defaultConnection,
-                        style: TextStyle(
-                          color: widget.server != null ? Colors.grey : null,
-                        ),
                       ),
                     ),
                   ],

--- a/lib/screens/servers/add_server_fullscreen.dart
+++ b/lib/screens/servers/add_server_fullscreen.dart
@@ -363,6 +363,12 @@ class _AddServerFullscreenState extends State<AddServerFullscreen> {
         if (mounted) {
           if (result == true) {
             await Navigator.maybePop(context);
+
+            showSuccessSnackBar(
+              context: context,
+              appConfigProvider: appConfigProvider,
+              label: AppLocalizations.of(context)!.editServerSuccessfully,
+            );
           } else {
             setState(() {
               isConnecting = false;

--- a/lib/services/status_update_service.dart
+++ b/lib/services/status_update_service.dart
@@ -48,7 +48,7 @@ class StatusUpdateService {
     await _refreshOnce();
   }
 
-  void dispose() {
+  void stopAutoRefresh() {
     if (_isAutoRefreshRunning) {
       logger.d('Disposing Status Update Service');
       _stopAutoRefresh();

--- a/lib/services/status_update_service.dart
+++ b/lib/services/status_update_service.dart
@@ -37,7 +37,9 @@ class StatusUpdateService {
   /// Start timer for auto refresh
   void startAutoRefresh() {
     if (!_isAutoRefreshRunning) {
-      logger.d('Starting Auto Refresh');
+      logger.d(
+        'Starting Auto Refresh: (${_serversProvider.selectedServer?.alias}) ${_serversProvider.selectedServer?.address}',
+      );
       _startAutoRefresh();
     }
   }
@@ -50,7 +52,9 @@ class StatusUpdateService {
 
   void stopAutoRefresh() {
     if (_isAutoRefreshRunning) {
-      logger.d('Disposing Status Update Service');
+      logger.d(
+        'Stop Status Update Service. (${_serversProvider.selectedServer?.alias}) ${_serversProvider.selectedServer?.address}',
+      );
       _stopAutoRefresh();
     }
   }

--- a/test/ut/providers/domains_list_provider_test.mocks.dart
+++ b/test/ut/providers/domains_list_provider_test.mocks.dart
@@ -387,6 +387,13 @@ class MockServersProvider extends _i1.Mock implements _i6.ServersProvider {
       )) as _i9.ApiGateway?);
 
   @override
+  _i9.ApiGateway? createApiGateway(_i3.Server? server) =>
+      (super.noSuchMethod(Invocation.method(
+        #createApiGateway,
+        [server],
+      )) as _i9.ApiGateway?);
+
+  @override
   _i7.QueryStatus? getQueryStatus(String? key) =>
       (super.noSuchMethod(Invocation.method(
         #getQueryStatus,

--- a/test/ut/providers/filters_provider_test.mocks.dart
+++ b/test/ut/providers/filters_provider_test.mocks.dart
@@ -97,6 +97,13 @@ class MockServersProvider extends _i1.Mock implements _i3.ServersProvider {
       )) as _i7.ApiGateway?);
 
   @override
+  _i7.ApiGateway? createApiGateway(_i4.Server? server) =>
+      (super.noSuchMethod(Invocation.method(
+        #createApiGateway,
+        [server],
+      )) as _i7.ApiGateway?);
+
+  @override
   _i5.QueryStatus? getQueryStatus(String? key) =>
       (super.noSuchMethod(Invocation.method(
         #getQueryStatus,

--- a/test/ut/providers/gravity_provider_test.mocks.dart
+++ b/test/ut/providers/gravity_provider_test.mocks.dart
@@ -420,6 +420,13 @@ class MockServersProvider extends _i1.Mock implements _i8.ServersProvider {
       )) as _i11.ApiGateway?);
 
   @override
+  _i11.ApiGateway? createApiGateway(_i5.Server? server) =>
+      (super.noSuchMethod(Invocation.method(
+        #createApiGateway,
+        [server],
+      )) as _i11.ApiGateway?);
+
+  @override
   _i9.QueryStatus? getQueryStatus(String? key) =>
       (super.noSuchMethod(Invocation.method(
         #getQueryStatus,

--- a/test/ut/providers/groups_provider_test.mocks.dart
+++ b/test/ut/providers/groups_provider_test.mocks.dart
@@ -387,6 +387,13 @@ class MockServersProvider extends _i1.Mock implements _i6.ServersProvider {
       )) as _i9.ApiGateway?);
 
   @override
+  _i9.ApiGateway? createApiGateway(_i3.Server? server) =>
+      (super.noSuchMethod(Invocation.method(
+        #createApiGateway,
+        [server],
+      )) as _i9.ApiGateway?);
+
+  @override
   _i7.QueryStatus? getQueryStatus(String? key) =>
       (super.noSuchMethod(Invocation.method(
         #getQueryStatus,

--- a/test/ut/providers/servers_provider_test.dart
+++ b/test/ut/providers/servers_provider_test.dart
@@ -115,6 +115,16 @@ void main() async {
       expect(listenerCalled, false);
     });
 
+    test('createApiGateway creates the api gateways', () {
+      final result = serversProvider.createApiGateway(server);
+      expect(result?.server.alias, server.alias);
+      expect(result?.server.address, server.address);
+      expect(result?.server.apiVersion, server.apiVersion);
+      expect(result?.server.allowSelfSignedCert, server.allowSelfSignedCert);
+      expect(result?.server.defaultServer, server.defaultServer);
+      expect(listenerCalled, false);
+    });
+
     test('loadApiGateway loads the api gateways', () {
       final result = serversProvider.loadApiGateway(server);
       expect(result!.server, ApiGatewayV6(server).server);
@@ -147,8 +157,25 @@ void main() async {
       expect(listenerCalled, true);
     });
 
+    test(
+        'addServer adds a server (defaultServer: on) option and notifies listeners',
+        () async {
+      final server2 = Server(
+        address: 'http://localhost:8081',
+        alias: 'test v6',
+        defaultServer: true,
+        apiVersion: 'v6',
+        allowSelfSignedCert: true,
+      );
+      final result = await serversProvider.addServer(server2);
+
+      expect(result, true);
+      expect(serversProvider.getServersList.contains(server2), true);
+      expect(listenerCalled, true);
+    });
+
     test('editServer edits a server and notifies listeners', () async {
-      serversProvider.getServersList.add(server);
+      await serversProvider.addServer(server);
       final updatedServer = server.copyWith(alias: 'Updated Server');
 
       final result = await serversProvider.editServer(updatedServer);

--- a/test/ut/providers/subscriptions_list_provider_test.mocks.dart
+++ b/test/ut/providers/subscriptions_list_provider_test.mocks.dart
@@ -387,6 +387,13 @@ class MockServersProvider extends _i1.Mock implements _i6.ServersProvider {
       )) as _i9.ApiGateway?);
 
   @override
+  _i9.ApiGateway? createApiGateway(_i3.Server? server) =>
+      (super.noSuchMethod(Invocation.method(
+        #createApiGateway,
+        [server],
+      )) as _i9.ApiGateway?);
+
+  @override
   _i7.QueryStatus? getQueryStatus(String? key) =>
       (super.noSuchMethod(Invocation.method(
         #getQueryStatus,

--- a/test/ut/services/status_update_service_test.dart
+++ b/test/ut/services/status_update_service_test.dart
@@ -106,7 +106,7 @@ void main() async {
       verify(mockStatusProvider.setOvertimeData(any)).called(1);
       expect(statusUpdateService.isAutoRefreshRunning, true);
 
-      statusUpdateService.dispose();
+      statusUpdateService.stopAutoRefresh();
     });
 
     test(
@@ -122,7 +122,7 @@ void main() async {
       verify(mockStatusProvider.setOvertimeData(any)).called(1);
       expect(statusUpdateService.isAutoRefreshRunning, true);
 
-      statusUpdateService.dispose();
+      statusUpdateService.stopAutoRefresh();
     });
 
     test(
@@ -150,7 +150,7 @@ void main() async {
       verifyNever(mockStatusProvider.setOvertimeData(any)).called(0);
       expect(statusUpdateService.isAutoRefreshRunning, true);
 
-      statusUpdateService.dispose();
+      statusUpdateService.stopAutoRefresh();
     });
 
     test(
@@ -179,7 +179,7 @@ void main() async {
       // No raised error
       expect(caughtError, isNull);
 
-      statusUpdateService.dispose();
+      statusUpdateService.stopAutoRefresh();
     });
 
     test(
@@ -208,7 +208,7 @@ void main() async {
       // No raised error
       expect(caughtError, isNull);
 
-      statusUpdateService.dispose();
+      statusUpdateService.stopAutoRefresh();
     });
 
     test('refreshOnce should succeed', () async {
@@ -244,7 +244,7 @@ void main() async {
     });
 
     test('dispose should succeed', () {
-      statusUpdateService.dispose();
+      statusUpdateService.stopAutoRefresh();
       expect(statusUpdateService.isAutoRefreshRunning, false);
     });
   });

--- a/test/ut/services/status_update_service_test.mocks.dart
+++ b/test/ut/services/status_update_service_test.mocks.dart
@@ -793,6 +793,13 @@ class MockServersProvider extends _i1.Mock implements _i15.ServersProvider {
       )) as _i17.ApiGateway?);
 
   @override
+  _i17.ApiGateway? createApiGateway(_i3.Server? server) =>
+      (super.noSuchMethod(Invocation.method(
+        #createApiGateway,
+        [server],
+      )) as _i17.ApiGateway?);
+
+  @override
   _i16.QueryStatus? getQueryStatus(String? key) =>
       (super.noSuchMethod(Invocation.method(
         #getQueryStatus,

--- a/test/widgets/helpers.dart
+++ b/test/widgets/helpers.dart
@@ -1072,7 +1072,7 @@ class TestSetupHelper {
             ),
             Provider<StatusUpdateService>(
               create: (_) => mockStatusUpdateService,
-              dispose: (_, service) => service.dispose(),
+              dispose: (_, service) => service.stopAutoRefresh(),
             ),
           ],
           child: Phoenix(
@@ -1148,7 +1148,7 @@ class TestSetupHelper {
         ),
         Provider<StatusUpdateService>(
           create: (_) => mockStatusUpdateService,
-          dispose: (_, service) => service.dispose(),
+          dispose: (_, service) => service.stopAutoRefresh(),
         ),
       ],
       child: child,

--- a/test/widgets/helpers.dart
+++ b/test/widgets/helpers.dart
@@ -1234,7 +1234,11 @@ class TestSetupHelper {
           ? mockApiGatewayV5 as ApiGateway
           : mockApiGatewayV6 as ApiGateway,
     );
-    when(mockServersProvider.deleteDbData()).thenAnswer((_) async => true);
+    when(mockServersProvider.createApiGateway(any)).thenReturn(
+      useApiGatewayVersion == 'v5'
+          ? mockApiGatewayV5 as ApiGateway
+          : mockApiGatewayV6 as ApiGateway,
+    );
     when(mockServersProvider.getServersList)
         .thenReturn(useApiGatewayVersion == 'v5' ? [serverV5] : [serverV6]);
     when(mockServersProvider.colors).thenReturn(lightAppColors);
@@ -1242,6 +1246,7 @@ class TestSetupHelper {
       useApiGatewayVersion == 'v5' ? queryStatusesV5 : queryStatusesV6,
     );
     when(mockServersProvider.removeServer(any)).thenAnswer((_) async => true);
+    when(mockServersProvider.deleteDbData()).thenAnswer((_) async => true);
   }
 
   void _initFiltersProviderMock(String useApiGatewayVersion) {

--- a/test/widgets/helpers.mocks.dart
+++ b/test/widgets/helpers.mocks.dart
@@ -801,6 +801,13 @@ class MockServersProvider extends _i1.Mock implements _i15.ServersProvider {
       )) as _i17.ApiGateway?);
 
   @override
+  _i17.ApiGateway? createApiGateway(_i3.Server? server) =>
+      (super.noSuchMethod(Invocation.method(
+        #createApiGateway,
+        [server],
+      )) as _i17.ApiGateway?);
+
+  @override
   _i16.QueryStatus? getQueryStatus(String? key) =>
       (super.noSuchMethod(Invocation.method(
         #getQueryStatus,
@@ -2773,9 +2780,9 @@ class MockStatusUpdateService extends _i1.Mock
       ) as _i12.Future<void>);
 
   @override
-  void dispose() => super.noSuchMethod(
+  void stopAutoRefresh() => super.noSuchMethod(
         Invocation.method(
-          #dispose,
+          #stopAutoRefresh,
           [],
         ),
         returnValueForMissingStub: null,

--- a/test/widgets/screens/servers/add_server_fullscreen_test.dart
+++ b/test/widgets/screens/servers/add_server_fullscreen_test.dart
@@ -536,6 +536,8 @@ void main() async {
       },
     );
 
+    // --------------------- edit ----------------------------
+
     testWidgets(
       'should show the successful snackbar when editing a server',
       (WidgetTester tester) async {
@@ -568,7 +570,11 @@ void main() async {
 
         await tester.tap(find.byIcon(Icons.save_rounded));
         await tester.pump(const Duration(milliseconds: 1000));
-        expect(find.byType(SnackBar), findsNothing);
+        expect(find.byType(SnackBar), findsOneWidget);
+        expect(
+          find.text('Server settings updated successfully.'),
+          findsOneWidget,
+        );
       },
     );
 


### PR DESCRIPTION
## Overview

This PR enhances the **Edit a Connection** page by allowing users to modify additional connection settings that were previously read-only. These settings include SSL certificate handling and default server designation, improving configuration flexibility.

## Changes

- Enabled editing of the following fields in the **Edit Connection** page:
  - Allow self-signed certificates**
  - Default connection**

## Screenshot

|before|after|
|---|---|
|![before](https://github.com/user-attachments/assets/99e20215-fb42-4acd-a768-0a4618cc4920)|![after](https://github.com/user-attachments/assets/abc45c37-c5ce-49ef-ae6e-0c195e59bb1e)|




