### PR TITLE
chore(android): support 16kb page sizes

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -27,6 +27,16 @@ android {
     }
 
     defaultConfig {
+        // This block is different from the one you use to link Gradle
+        // to your CMake or ndk-build script.
+        externalNativeBuild {
+            // For ndk-build, instead use the ndkBuild block.
+            cmake {
+                // Passes optional arguments to CMake.
+                arguments "-DANDROID_SUPPORT_FLEXIBLE_PAGE_SIZES=ON"
+            }
+        }
+
         // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
         applicationId = "io.github.tsutsu3.pi_hole_client"
         // You can update the following values to match your application needs.

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -14,7 +14,8 @@ if (keystorePropertiesFile.exists()) {
 android {
     namespace = "io.github.tsutsu3.pi_hole_client"
     compileSdk = flutter.compileSdkVersion
-    ndkVersion = flutter.ndkVersion
+    //ndkVersion = flutter.ndkVersion
+    ndkVersion = "27.2.12479018"
 
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_1_8
@@ -42,6 +43,8 @@ android {
         println("Target SDK: $targetSdk")
         println("Version code: $versionCode")
         println("Version name: $versionName")
+        println("Compile SDK: $compileSdk")
+        println("NDK Version: $ndkVersion")
     }
 
     signingConfigs {

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.10.2-all.zip

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -18,8 +18,8 @@ pluginManagement {
 
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
-    id "com.android.application" version "8.1.0" apply false
-    id "org.jetbrains.kotlin.android" version "1.8.22" apply false
+    id "com.android.application" version '8.8.2' apply false
+    id "org.jetbrains.kotlin.android" version "2.1.0" apply false
 }
 
 include ":app"


### PR DESCRIPTION
## Overview

## Changes

## Status

```
=== ELF alignment ===
/tmp/app-release_out_CikQq/lib/x86/libsentry.so: ALIGNED (2**14)
/tmp/app-release_out_CikQq/lib/x86/libsqlite3.so: UNALIGNED (2**12)
/tmp/app-release_out_CikQq/lib/x86/libimage_processing_util_jni.so: ALIGNED (2**14)
/tmp/app-release_out_CikQq/lib/x86/libbarhopper_v3.so: UNALIGNED (2**12)
/tmp/app-release_out_CikQq/lib/x86/libsentry-android.so: ALIGNED (2**14)
/tmp/app-release_out_CikQq/lib/x86/libsurface_util_jni.so: ALIGNED (2**14)
/tmp/app-release_out_CikQq/lib/armeabi-v7a/libsentry.so: ALIGNED (2**14)
/tmp/app-release_out_CikQq/lib/armeabi-v7a/libflutter.so: ALIGNED (2**16)
/tmp/app-release_out_CikQq/lib/armeabi-v7a/libapp.so: ALIGNED (2**14)
/tmp/app-release_out_CikQq/lib/armeabi-v7a/libsqlite3.so: UNALIGNED (2**12)
/tmp/app-release_out_CikQq/lib/armeabi-v7a/libimage_processing_util_jni.so: ALIGNED (2**14)
/tmp/app-release_out_CikQq/lib/armeabi-v7a/libbarhopper_v3.so: UNALIGNED (2**12)
/tmp/app-release_out_CikQq/lib/armeabi-v7a/libsentry-android.so: ALIGNED (2**14)
/tmp/app-release_out_CikQq/lib/armeabi-v7a/libsurface_util_jni.so: ALIGNED (2**14)
/tmp/app-release_out_CikQq/lib/x86_64/libsentry.so: ALIGNED (2**14)
/tmp/app-release_out_CikQq/lib/x86_64/libflutter.so: ALIGNED (2**16)
/tmp/app-release_out_CikQq/lib/x86_64/libapp.so: ALIGNED (2**16)
/tmp/app-release_out_CikQq/lib/x86_64/libsqlite3.so: ALIGNED (2**14)
/tmp/app-release_out_CikQq/lib/x86_64/libimage_processing_util_jni.so: ALIGNED (2**14)
/tmp/app-release_out_CikQq/lib/x86_64/libbarhopper_v3.so: ALIGNED (2**14)
/tmp/app-release_out_CikQq/lib/x86_64/libsentry-android.so: ALIGNED (2**14)
/tmp/app-release_out_CikQq/lib/x86_64/libsurface_util_jni.so: ALIGNED (2**14)
/tmp/app-release_out_CikQq/lib/arm64-v8a/libsentry.so: ALIGNED (2**14)
/tmp/app-release_out_CikQq/lib/arm64-v8a/libflutter.so: ALIGNED (2**16)
/tmp/app-release_out_CikQq/lib/arm64-v8a/libapp.so: ALIGNED (2**16)
/tmp/app-release_out_CikQq/lib/arm64-v8a/libsqlite3.so: ALIGNED (2**14)
/tmp/app-release_out_CikQq/lib/arm64-v8a/libimage_processing_util_jni.so: ALIGNED (2**14)
/tmp/app-release_out_CikQq/lib/arm64-v8a/libbarhopper_v3.so: ALIGNED (2**14)
/tmp/app-release_out_CikQq/lib/arm64-v8a/libsentry-android.so: ALIGNED (2**14)
/tmp/app-release_out_CikQq/lib/arm64-v8a/libsurface_util_jni.so: ALIGNED (2**14)
Found 4 unaligned libs (only arm64-v8a/x86_64 libs need to be aligned).
=====================
```