### PR TITLE
feat(ui): improve NoDataChart layout and section labeling on home and statistics pages

### DIFF
--- a/lib/functions/charts_data_functions.dart
+++ b/lib/functions/charts_data_functions.dart
@@ -1,10 +1,34 @@
 import 'dart:collection';
 
+/// Removes all entries from the given [values] map where the value is zero or NaN.
+///
+/// Modifies the original map by removing key-value pairs whose values are either `0`
+/// or `NaN`, and returns the modified map.
+///
+/// Example:
+/// ```dart
+/// final data = {'a': 1.0, 'b': 0.0, 'c': double.nan};
+/// final result = removeZeroValues(data);
+/// // result: {'a': 1.0}
+/// ```
 Map<String, double> removeZeroValues(Map<String, double> values) {
-  values.removeWhere((key, value) => value == 0);
+  values.removeWhere((key, value) => value == 0 || value.isNaN);
   return values;
 }
 
+/// Sorts a map of string keys and double values in descending order based on the values.
+///
+/// Takes a [values] map and returns a new map with the entries sorted by their values
+/// from highest to lowest. The returned map preserves the order of the sorted entries.
+///
+/// Example:
+/// ```dart
+/// final data = {'a': 2.0, 'b': 3.5, 'c': 1.0};
+/// final sorted = sortValues(data);
+/// // sorted: {'b': 3.5, 'a': 2.0, 'c': 1.0}
+/// ```
+///
+/// If a value is missing for a key, it defaults to 0.0.
 Map<String, double> sortValues(Map<String, double> values) {
   final sortedKeys = values.keys.toList(growable: false)
     ..sort((k1, k2) => values[k1]!.compareTo(values[k2]!));

--- a/lib/screens/statistics/no_data_chart.dart
+++ b/lib/screens/statistics/no_data_chart.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:pi_hole_client/l10n/generated/app_localizations.dart';
+import 'package:pi_hole_client/widgets/section_label.dart';
 
 class NoDataChart extends StatelessWidget {
   const NoDataChart({
@@ -18,13 +19,8 @@ class NoDataChart extends StatelessWidget {
       padding: const EdgeInsets.all(20),
       child: Column(
         children: [
-          Text(
-            topLabel,
-            style: TextStyle(
-              fontSize: 18,
-              fontWeight: FontWeight.w500,
-              color: Theme.of(context).colorScheme.onSurface,
-            ),
+          SectionLabel(
+            label: topLabel,
           ),
           const SizedBox(height: 50),
           Icon(

--- a/lib/screens/statistics/no_data_chart.dart
+++ b/lib/screens/statistics/no_data_chart.dart
@@ -14,30 +14,44 @@ class NoDataChart extends StatelessWidget {
   Widget build(BuildContext context) {
     final width = MediaQuery.of(context).size.width;
 
-    return Container(
+    return SizedBox(
       width: width,
-      padding: const EdgeInsets.all(20),
       child: Column(
         children: [
           SectionLabel(
             label: topLabel,
           ),
-          const SizedBox(height: 50),
-          Icon(
-            Icons.show_chart_rounded,
-            size: 40,
-            color: Theme.of(context).colorScheme.onSurfaceVariant,
-          ),
-          const SizedBox(height: 30),
-          Text(
-            AppLocalizations.of(context)!.noData,
-            style: TextStyle(
-              color: Theme.of(context).colorScheme.onSurfaceVariant,
-              fontWeight: FontWeight.w700,
-              fontSize: 14,
+          Container(
+            width: width,
+            margin: const EdgeInsets.symmetric(horizontal: 16),
+            decoration: BoxDecoration(
+              color: Theme.of(context)
+                  .colorScheme
+                  .surfaceTint
+                  .withValues(alpha: 0.05),
+              borderRadius: BorderRadius.circular(10),
+            ),
+            child: Column(
+              children: [
+                const SizedBox(height: 80),
+                Icon(
+                  Icons.show_chart_rounded,
+                  size: 40,
+                  color: Theme.of(context).colorScheme.onSurfaceVariant,
+                ),
+                const SizedBox(height: 20),
+                Text(
+                  AppLocalizations.of(context)!.noData,
+                  style: TextStyle(
+                    color: Theme.of(context).colorScheme.onSurfaceVariant,
+                    fontWeight: FontWeight.w700,
+                    fontSize: 14,
+                  ),
+                ),
+                const SizedBox(height: 80),
+              ],
             ),
           ),
-          const SizedBox(height: 30),
         ],
       ),
     );

--- a/lib/screens/statistics/statistics_list.dart
+++ b/lib/screens/statistics/statistics_list.dart
@@ -238,14 +238,18 @@ class StatisticsListContent extends StatelessWidget {
               AppLocalizations.of(context)!.topPermittedDomains,
             )
           else
-            NoDataChart(topLabel: AppLocalizations.of(context)!.noData),
+            NoDataChart(
+              topLabel: AppLocalizations.of(context)!.topPermittedDomains,
+            ),
           if (statusProvider.getRealtimeStatus!.topAds.isNotEmpty)
             generateList(
               statusProvider.getRealtimeStatus!.topAds,
               AppLocalizations.of(context)!.topBlockedDomains,
             )
           else
-            NoDataChart(topLabel: AppLocalizations.of(context)!.noData),
+            NoDataChart(
+              topLabel: AppLocalizations.of(context)!.topBlockedDomains,
+            ),
         ],
       );
     } else if (type == 'clients') {
@@ -257,14 +261,16 @@ class StatisticsListContent extends StatelessWidget {
               AppLocalizations.of(context)!.topClients,
             )
           else
-            NoDataChart(topLabel: AppLocalizations.of(context)!.noData),
+            NoDataChart(topLabel: AppLocalizations.of(context)!.topClients),
           if (statusProvider.getRealtimeStatus!.topSourcesBlocked.isNotEmpty)
             generateList(
               statusProvider.getRealtimeStatus!.topSourcesBlocked,
               AppLocalizations.of(context)!.topClientsBlocked,
             )
           else
-            NoDataChart(topLabel: AppLocalizations.of(context)!.noData),
+            NoDataChart(
+              topLabel: AppLocalizations.of(context)!.topClientsBlocked,
+            ),
         ],
       );
     } else {

--- a/test/widgets/screens/statistics/statistics_test.dart
+++ b/test/widgets/screens/statistics/statistics_test.dart
@@ -227,13 +227,13 @@ void main() async {
           // Switch to Domains tab
           await tester.tap(find.text('Domains'));
           await tester.pumpAndSettle();
-          expect(find.text('No data'), findsNWidgets(4));
+          expect(find.text('No data'), findsNWidgets(2));
           expect(find.byType(StatisticsListContent), findsOneWidget);
 
           // Switch to Clients tab
           await tester.tap(find.text('Clients'));
           await tester.pumpAndSettle();
-          expect(find.text('No data'), findsNWidgets(4));
+          expect(find.text('No data'), findsNWidgets(2));
           expect(find.byType(StatisticsListContent), findsOneWidget);
         },
       );


### PR DESCRIPTION
## Overview

This PR improves the visual layout  of the `NoDataChart` component, used in both the **Home** and **Statistics** screens. 

## Changes

- Added a light background tint and border with rounded corners to enhance the visual clarity of the empty chart area.
- Passed correct localized section titles (e.g., "Top Clients", "Top Permitted Domains") instead of using "No data" as a placeholder.

## Affected Screens

- Home
- Statistics (Top Clients, Top Blocked Domains, etc.)

## Screenshots

|beafore|after|
|---|---|
|![before](https://github.com/user-attachments/assets/a624b13c-8daf-436f-b00f-81c9722b8f88)|![after](https://github.com/user-attachments/assets/1c884d3e-8413-4685-9000-f3b7ea0b4197)|
