### PR TITLE
feat(ui): enable auto-save for refresh interval and log quantity in advanced settings

### DIFF
--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -432,7 +432,7 @@
   "useFingerprint": "Fingerabdruck nutzen",
   "username": "Nutzername",
   "valid": "Gültig",
-  "valueNotValid": "Eingabe nicht gültig",
+  "valueNotValid": "Bitte eine Zahl zwischen 1 und 86400 Sekunden eingeben",
   "version": "Version",
   "versionDescription": "Wählen Sie die Version von Pi-hole, die Sie verwenden",
   "versionRequirements": "Versionsanforderungen",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -432,7 +432,7 @@
   "useFingerprint": "Use fingerprint",
   "username": "Username",
   "valid": "Valid",
-  "valueNotValid": "Value not valid",
+  "valueNotValid": "Please enter a number between 1 and 86400 seconds",
   "version": "Version",
   "versionDescription": "Select the version of Pi-hole you are using",
   "versionRequirements": "Version Requirements",

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -433,7 +433,7 @@
   "useFingerprint": "Usar huella dactilar",
   "username": "Nombre de usuario",
   "valid": "Válido",
-  "valueNotValid": "Valor no válido",
+  "valueNotValid": "Ingrese un número entre 1 y 86400 segundos",
   "version": "Versión",
   "versionDescription": "Seleccione la versión de Pi-hole que está utilizando",
   "versionRequirements": "Requisitos de versión",

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -432,7 +432,7 @@
   "useFingerprint": "指紋を使用",
   "username": "ユーザー名",
   "valid": "有効",
-  "valueNotValid": "無効な値",
+  "valueNotValid": "1〜86400秒の範囲の数値を入力してください",
   "version": "バージョン",
   "versionDescription": "使用している Pi-hole のバージョンを選択してください",
   "versionRequirements": "バージョン要件",

--- a/lib/l10n/app_pl.arb
+++ b/lib/l10n/app_pl.arb
@@ -432,7 +432,7 @@
   "useFingerprint": "Użyj odcisku palca",
   "username": "Nazwa użytkownika",
   "valid": "Poprawny",
-  "valueNotValid": "Wartość nieprawidłowa",
+  "valueNotValid": "Wprowadź liczbę od 1 do 86400 sekund",
   "version": "Wersja",
   "versionDescription": "Wybierz wersję Pi-hole, której używasz",
   "versionRequirements": "Wymagania dotyczące wersji",

--- a/lib/l10n/generated/app_localizations.dart
+++ b/lib/l10n/generated/app_localizations.dart
@@ -2702,7 +2702,7 @@ abstract class AppLocalizations {
   /// No description provided for @valueNotValid.
   ///
   /// In en, this message translates to:
-  /// **'Value not valid'**
+  /// **'Please enter a number between 1 and 86400 seconds'**
   String get valueNotValid;
 
   /// No description provided for @version.

--- a/lib/l10n/generated/app_localizations_de.dart
+++ b/lib/l10n/generated/app_localizations_de.dart
@@ -1308,7 +1308,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get valid => 'Gültig';
 
   @override
-  String get valueNotValid => 'Eingabe nicht gültig';
+  String get valueNotValid => 'Bitte eine Zahl zwischen 1 und 86400 Sekunden eingeben';
 
   @override
   String get version => 'Version';

--- a/lib/l10n/generated/app_localizations_en.dart
+++ b/lib/l10n/generated/app_localizations_en.dart
@@ -1308,7 +1308,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get valid => 'Valid';
 
   @override
-  String get valueNotValid => 'Value not valid';
+  String get valueNotValid => 'Please enter a number between 1 and 86400 seconds';
 
   @override
   String get version => 'Version';

--- a/lib/l10n/generated/app_localizations_es.dart
+++ b/lib/l10n/generated/app_localizations_es.dart
@@ -1308,7 +1308,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get valid => 'Válido';
 
   @override
-  String get valueNotValid => 'Valor no válido';
+  String get valueNotValid => 'Ingrese un número entre 1 y 86400 segundos';
 
   @override
   String get version => 'Versión';

--- a/lib/l10n/generated/app_localizations_ja.dart
+++ b/lib/l10n/generated/app_localizations_ja.dart
@@ -1308,7 +1308,7 @@ class AppLocalizationsJa extends AppLocalizations {
   String get valid => '有効';
 
   @override
-  String get valueNotValid => '無効な値';
+  String get valueNotValid => '1〜86400秒の範囲の数値を入力してください';
 
   @override
   String get version => 'バージョン';

--- a/lib/l10n/generated/app_localizations_pl.dart
+++ b/lib/l10n/generated/app_localizations_pl.dart
@@ -1308,7 +1308,7 @@ class AppLocalizationsPl extends AppLocalizations {
   String get valid => 'Poprawny';
 
   @override
-  String get valueNotValid => 'Wartość nieprawidłowa';
+  String get valueNotValid => 'Wprowadź liczbę od 1 do 86400 sekund';
 
   @override
   String get version => 'Wersja';

--- a/lib/screens/settings/app_settings/advanced_settings/auto_refresh_time_screen.dart
+++ b/lib/screens/settings/app_settings/advanced_settings/auto_refresh_time_screen.dart
@@ -1,6 +1,7 @@
 // ignore_for_file: use_build_context_synchronously
 
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:pi_hole_client/functions/snackbar.dart';
 import 'package:pi_hole_client/l10n/generated/app_localizations.dart';
 import 'package:pi_hole_client/providers/app_config_provider.dart';
@@ -204,6 +205,7 @@ class _AutoRefreshTimeScreenState extends State<AutoRefreshTimeScreen> {
                   onChanged: _validateCustomTime,
                   controller: customTimeController,
                   keyboardType: TextInputType.number,
+                  inputFormatters: [FilteringTextInputFormatter.digitsOnly],
                   decoration: InputDecoration(
                     errorText:
                         !customTimeIsValid && customTimeController.text != ''

--- a/lib/screens/settings/app_settings/advanced_settings/auto_refresh_time_screen.dart
+++ b/lib/screens/settings/app_settings/advanced_settings/auto_refresh_time_screen.dart
@@ -1,5 +1,3 @@
-// ignore_for_file: use_build_context_synchronously
-
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:pi_hole_client/functions/snackbar.dart';
@@ -7,6 +5,35 @@ import 'package:pi_hole_client/l10n/generated/app_localizations.dart';
 import 'package:pi_hole_client/providers/app_config_provider.dart';
 import 'package:pi_hole_client/widgets/custom_radio_list_tile.dart';
 import 'package:provider/provider.dart';
+
+class RefreshOption {
+  const RefreshOption(this.time, this.labelBuilder);
+
+  final int time;
+  final String Function(AppLocalizations) labelBuilder;
+
+  static const defaultTime = 10;
+  static const defaultIndex = 3;
+
+  static final List<RefreshOption> all = [
+    RefreshOption(1, (loc) => loc.second1),
+    RefreshOption(2, (loc) => loc.seconds2),
+    RefreshOption(5, (loc) => loc.seconds5),
+    RefreshOption(10, (loc) => loc.seconds10),
+    RefreshOption(30, (loc) => loc.seconds30),
+    RefreshOption(-1, (loc) => loc.custom),
+  ];
+
+  static int indexFromTime(int time) {
+    final idx = all.indexWhere((opt) => opt.time == time);
+    return idx != -1 ? idx : all.length - 1;
+  }
+
+  static int timeFromIndex(int index) {
+    final t = all[index].time;
+    return t > 0 ? t : 0;
+  }
+}
 
 class AutoRefreshTimeScreen extends StatefulWidget {
   const AutoRefreshTimeScreen({super.key});
@@ -16,205 +43,148 @@ class AutoRefreshTimeScreen extends StatefulWidget {
 }
 
 class _AutoRefreshTimeScreenState extends State<AutoRefreshTimeScreen> {
-  int selectedOption = 1;
-  TextEditingController customTimeController = TextEditingController();
-  bool showCustomDurationInput = false;
-  bool customTimeIsValid = false;
+  int selectedIndex = RefreshOption.defaultIndex;
+  final TextEditingController customTimeController = TextEditingController();
+  final FocusNode customFocusNode = FocusNode();
+  bool showCustomInput = false;
+  bool customValid = false;
+  late final AppConfigProvider configProvider;
+
+  bool get isCustomSelected => selectedIndex == RefreshOption.all.length - 1;
 
   @override
   void initState() {
     super.initState();
-    selectedOption = _setTime(
-      Provider.of<AppConfigProvider>(context, listen: false)
-              .getAutoRefreshTime ??
-          0,
-    );
-  }
-
-  void _updateRadioValue(int value) {
-    setState(() {
-      selectedOption = value;
-      if (selectedOption != 5) {
-        customTimeController.text = '';
-        showCustomDurationInput = false;
-      } else {
-        setState(() {
-          showCustomDurationInput = true;
-        });
+    customFocusNode.addListener(() {
+      if (!customFocusNode.hasFocus && customValid) {
+        _save();
       }
+    });
+    configProvider = context.read<AppConfigProvider>();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      final saved =
+          configProvider.getAutoRefreshTime ?? RefreshOption.defaultTime;
+      setState(() {
+        selectedIndex = RefreshOption.indexFromTime(saved);
+        if (isCustomSelected) {
+          customTimeController.text = saved.toString();
+          _validateCustom(saved.toString());
+          showCustomInput = true;
+        }
+      });
     });
   }
 
-  void _validateCustomTime(String value) {
-    if (int.tryParse(value) != null) {
-      setState(() {
-        customTimeIsValid = true;
-      });
-    } else {
-      setState(() {
-        customTimeIsValid = false;
-      });
+  @override
+  void dispose() {
+    customTimeController.dispose();
+    customFocusNode.dispose();
+    super.dispose();
+  }
+
+  void _updateRadioValue(int index) {
+    setState(() {
+      selectedIndex = index;
+      showCustomInput = isCustomSelected;
+      if (!showCustomInput) {
+        customTimeController.clear();
+        customValid = false;
+      }
+    });
+
+    if (!showCustomInput) {
+      _save();
     }
   }
 
-  bool _selectionIsValid() {
-    if (selectedOption != 5) {
-      return true;
-    } else if (selectedOption == 5 && customTimeIsValid == true) {
-      return true;
-    } else {
-      return false;
-    }
+  void _validateCustom(String value) {
+    final input = int.tryParse(value);
+    final valid = input != null && input > 0 && input <= 86400; // 24 hours
+    setState(() {
+      customValid = valid;
+    });
   }
 
   int _getTime() {
-    switch (selectedOption) {
-      case 0:
-        return 1;
-
-      case 1:
-        return 2;
-
-      case 2:
-        return 5;
-
-      case 3:
-        return 10;
-
-      case 4:
-        return 30;
-
-      case 5:
-        return int.parse(customTimeController.text);
-
-      default:
-        return 0;
-    }
+    final opt = RefreshOption.all[selectedIndex];
+    if (opt.time > 0) return opt.time;
+    final parsed = int.tryParse(customTimeController.text);
+    return parsed ?? RefreshOption.defaultTime;
   }
 
-  int _setTime(int time) {
-    switch (time) {
-      case 1:
-        return 0;
+  Future<void> _save() async {
+    final time = _getTime();
+    final result = await configProvider.setAutoRefreshTime(time);
 
-      case 2:
-        return 1;
+    if (!mounted) return;
 
-      case 5:
-        return 2;
-
-      case 10:
-        return 3;
-
-      case 30:
-        return 4;
-
-      default:
-        setState(() {
-          customTimeController.text = time.toString();
-          _validateCustomTime(time.toString());
-          showCustomDurationInput = true;
-        });
-        return 5;
-    }
-  }
-
-  Future<void> onSave() async {
-    final result = await Provider.of<AppConfigProvider>(context, listen: false)
-        .setAutoRefreshTime(_getTime());
-    if (result == true) {
+    final loc = AppLocalizations.of(context)!;
+    if (result) {
       showSuccessSnackBar(
         context: context,
-        appConfigProvider:
-            Provider.of<AppConfigProvider>(context, listen: false),
-        label: AppLocalizations.of(context)!.updateTimeChanged,
+        appConfigProvider: configProvider,
+        label: loc.updateTimeChanged,
       );
     } else {
       showErrorSnackBar(
         context: context,
-        appConfigProvider:
-            Provider.of<AppConfigProvider>(context, listen: false),
-        label: AppLocalizations.of(context)!.cannotChangeUpdateTime,
+        appConfigProvider: configProvider,
+        label: loc.cannotChangeUpdateTime,
       );
     }
   }
 
   @override
   Widget build(BuildContext context) {
+    final loc = AppLocalizations.of(context)!;
     return Scaffold(
-      appBar: AppBar(
-        title: Text(AppLocalizations.of(context)!.autoRefreshTime),
-        actions: [
-          IconButton(
-            onPressed: _selectionIsValid() == true ? onSave : null,
-            icon: const Icon(Icons.save_rounded),
-            tooltip: AppLocalizations.of(context)!.save,
-          ),
-          const SizedBox(width: 8),
-        ],
-      ),
+      appBar: AppBar(title: Text(loc.autoRefreshTime)),
       body: SafeArea(
         child: ListView(
           children: [
-            CustomRadioListTile(
-              groupValue: selectedOption,
-              value: 0,
-              radioBackgroundColor: Theme.of(context).colorScheme.surface,
-              title: AppLocalizations.of(context)!.second1,
-              onChanged: _updateRadioValue,
+            const SizedBox(height: 16),
+            ...RefreshOption.all.asMap().entries.map(
+              (entry) {
+                final idx = entry.key;
+                final option = entry.value;
+                return CustomRadioListTile(
+                  groupValue: selectedIndex,
+                  value: idx,
+                  radioBackgroundColor: Theme.of(context).colorScheme.surface,
+                  title: option.labelBuilder(loc),
+                  onChanged: _updateRadioValue,
+                );
+              },
             ),
-            CustomRadioListTile(
-              groupValue: selectedOption,
-              value: 1,
-              radioBackgroundColor: Theme.of(context).colorScheme.surface,
-              title: AppLocalizations.of(context)!.seconds2,
-              onChanged: _updateRadioValue,
-            ),
-            CustomRadioListTile(
-              groupValue: selectedOption,
-              value: 2,
-              radioBackgroundColor: Theme.of(context).colorScheme.surface,
-              title: AppLocalizations.of(context)!.seconds5,
-              onChanged: _updateRadioValue,
-            ),
-            CustomRadioListTile(
-              groupValue: selectedOption,
-              value: 3,
-              radioBackgroundColor: Theme.of(context).colorScheme.surface,
-              title: AppLocalizations.of(context)!.seconds10,
-              onChanged: _updateRadioValue,
-            ),
-            CustomRadioListTile(
-              groupValue: selectedOption,
-              value: 4,
-              radioBackgroundColor: Theme.of(context).colorScheme.surface,
-              title: AppLocalizations.of(context)!.seconds30,
-              onChanged: _updateRadioValue,
-            ),
-            CustomRadioListTile(
-              groupValue: selectedOption,
-              value: 5,
-              radioBackgroundColor: Theme.of(context).colorScheme.surface,
-              title: AppLocalizations.of(context)!.custom,
-              onChanged: _updateRadioValue,
-            ),
-            if (showCustomDurationInput == true)
+            if (showCustomInput)
               Padding(
                 padding: const EdgeInsets.all(16),
                 child: TextField(
-                  onChanged: _validateCustomTime,
                   controller: customTimeController,
+                  focusNode: customFocusNode,
                   keyboardType: TextInputType.number,
                   inputFormatters: [FilteringTextInputFormatter.digitsOnly],
+                  onChanged: _validateCustom,
+                  onSubmitted: (value) {
+                    if (customValid) {
+                      _save();
+                      FocusScope.of(context).unfocus();
+                    }
+                  },
+                  onEditingComplete: () {
+                    if (customValid) {
+                      FocusScope.of(context).unfocus();
+                    }
+                  },
                   decoration: InputDecoration(
                     errorText:
-                        !customTimeIsValid && customTimeController.text != ''
-                            ? AppLocalizations.of(context)!.valueNotValid
+                        !customValid && customTimeController.text.isNotEmpty
+                            ? loc.valueNotValid
                             : null,
                     border: const OutlineInputBorder(
                       borderRadius: BorderRadius.all(Radius.circular(10)),
                     ),
-                    labelText: AppLocalizations.of(context)!.customSeconds,
+                    labelText: loc.customSeconds,
                   ),
                 ),
               ),

--- a/test/widgets/screens/settings/app_settings/auto_refresh_time_screen_test.dart
+++ b/test/widgets/screens/settings/app_settings/auto_refresh_time_screen_test.dart
@@ -37,13 +37,10 @@ void main() async {
 
           expect(find.byType(AutoRefreshTimeScreen), findsOneWidget);
           expect(find.text('Auto refresh time'), findsOneWidget);
-          expect(find.byIcon(Icons.save_rounded), findsOneWidget);
 
           await tester.tap(find.text('30 seconds'));
           await tester.pumpAndSettle();
 
-          await tester.tap(find.byIcon(Icons.save_rounded));
-          await tester.pumpAndSettle();
           expect(find.byType(SnackBar), findsOneWidget);
           expect(
             find.text('Update time changed successfully.'),
@@ -74,13 +71,10 @@ void main() async {
 
           expect(find.byType(AutoRefreshTimeScreen), findsOneWidget);
           expect(find.text('Auto refresh time'), findsOneWidget);
-          expect(find.byIcon(Icons.save_rounded), findsOneWidget);
 
           await tester.tap(find.text('30 seconds'));
           await tester.pumpAndSettle();
 
-          await tester.tap(find.byIcon(Icons.save_rounded));
-          await tester.pumpAndSettle();
           expect(find.byType(SnackBar), findsOneWidget);
           expect(find.text('Cannot change update time'), findsOneWidget);
         },
@@ -105,19 +99,20 @@ void main() async {
 
           expect(find.byType(AutoRefreshTimeScreen), findsOneWidget);
           expect(find.text('Auto refresh time'), findsOneWidget);
-          expect(find.byIcon(Icons.save_rounded), findsOneWidget);
 
           await tester.tap(find.text('Custom'));
           await tester.pumpAndSettle();
 
           expect(find.byType(TextField), findsOneWidget);
           await tester.enterText(find.byType(TextField), '11');
+          await tester.testTextInput.receiveAction(TextInputAction.done);
           await tester.pumpAndSettle();
 
-          expect(find.text('Value not valid'), findsNothing);
+          expect(
+            find.text('Please enter a number between 1 and 86400 seconds'),
+            findsNothing,
+          );
 
-          await tester.tap(find.byIcon(Icons.save_rounded));
-          await tester.pumpAndSettle();
           expect(find.byType(SnackBar), findsOneWidget);
 
           expect(
@@ -146,16 +141,19 @@ void main() async {
 
           expect(find.byType(AutoRefreshTimeScreen), findsOneWidget);
           expect(find.text('Auto refresh time'), findsOneWidget);
-          expect(find.byIcon(Icons.save_rounded), findsOneWidget);
 
           await tester.tap(find.text('Custom'));
           await tester.pumpAndSettle();
 
           expect(find.byType(TextField), findsOneWidget);
-          await tester.enterText(find.byType(TextField), 'aa');
+          await tester.enterText(find.byType(TextField), '0');
+          await tester.pump();
           await tester.pumpAndSettle();
 
-          expect(find.text('Value not valid'), findsOneWidget);
+          expect(
+            find.text('Please enter a number between 1 and 86400 seconds'),
+            findsOneWidget,
+          );
         },
       );
     },


### PR DESCRIPTION
## Overview

This PR improves the user experience on the Advanced Settings screen by enabling auto-save for two key configuration fields:

- Auto Refresh Time
- Logs Quantity Per Request

Manual save buttons have been removed. Changes are now saved automatically when the user enters valid input or moves focus away from the field.

## Changes

- Removed the save button previously used for these fields.
- Enabled real-time validation and saving

## Screenshots

|before|after|
|---|---|
|![before](https://github.com/user-attachments/assets/b1684112-54d9-4be9-abee-0a094e366874)|![after](https://github.com/user-attachments/assets/38421d3e-ce49-4ac2-89b1-b32554926dd6)|
