### PR TITLE
chore(ui): replace icons in domain detail screen

### DIFF
--- a/lib/screens/domains/widgets/domain_details_screen.dart
+++ b/lib/screens/domains/widgets/domain_details_screen.dart
@@ -173,12 +173,12 @@ class _DomainDetailsScreenState extends State<DomainDetailsScreen> {
               onTap: isV5 ? null : openCommentModal,
             ),
             CustomListTile(
-              leadingIcon: Icons.schedule_rounded,
+              leadingIcon: Icons.event_available_rounded,
               label: AppLocalizations.of(context)!.dateAdded,
               description: formatTimestamp(_domain.dateAdded, 'yyyy-MM-dd'),
             ),
             CustomListTile(
-              leadingIcon: Icons.update_rounded,
+              leadingIcon: Icons.edit_calendar_rounded,
               label: AppLocalizations.of(context)!.dateModified,
               description: formatTimestamp(_domain.dateModified, 'yyyy-MM-dd'),
             ),


### PR DESCRIPTION
## Overview

Update `Date addted` and `Date modified` icons.

## Screenshots
|before|after|
|---|---|
|![Screenshot_1747655502](https://github.com/user-attachments/assets/5a70aa29-04a1-4a89-ab10-efc1f03b7f43)|![Screenshot_1747655493](https://github.com/user-attachments/assets/1416d34a-179a-4674-8bba-5e1274c3b2d3)|

