### PR TITLE
style(logs): unify datetime display format to yyyy-MM-dd

### DIFF
--- a/lib/constants/formats.dart
+++ b/lib/constants/formats.dart
@@ -1,0 +1,5 @@
+const String kUnifiedDateFormat = 'yyyy-MM-dd';
+
+const String kUnifiedDateTimeFormat = 'yyyy-MM-dd HH:mm';
+
+const String kUnifiedDateTimeLogFormat = 'yyyy-MM-dd HH:mm:ss';

--- a/lib/functions/format.dart
+++ b/lib/functions/format.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
+import 'package:pi_hole_client/constants/formats.dart';
 
 String formatTimestamp(DateTime timestamp, String format) {
   final f = DateFormat(format);
@@ -35,7 +36,7 @@ String formatWithDuration(DateTime? startedAt, DateTime? completedAt) {
   }
 
   final knownTime = (completedAt ?? startedAt)!.toLocal();
-  final formattedTime = DateFormat('yyyy-MM-dd HH:mm').format(knownTime);
+  final formattedTime = DateFormat(kUnifiedDateTimeFormat).format(knownTime);
 
   if (startedAt == null || completedAt == null) {
     return '$formattedTime (... s)';

--- a/lib/functions/logger.dart
+++ b/lib/functions/logger.dart
@@ -2,6 +2,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'package:intl/intl.dart';
 import 'package:logger/logger.dart';
+import 'package:pi_hole_client/constants/formats.dart';
 
 Level getLogLevel() {
   if (kReleaseMode) {
@@ -41,7 +42,8 @@ class TimeStampedPrinter extends LogPrinter {
 
   @override
   List<String> log(LogEvent event) {
-    final timestamp = DateFormat('yyyy-MM-dd HH:mm:ss').format(DateTime.now());
+    final timestamp =
+        DateFormat(kUnifiedDateTimeLogFormat).format(DateTime.now());
     return _prettyPrinter
         .log(event)
         .map((line) => '[$timestamp] $line')

--- a/lib/screens/domains/widgets/domain_details_screen.dart
+++ b/lib/screens/domains/widgets/domain_details_screen.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:pi_hole_client/classes/process_modal.dart';
 import 'package:pi_hole_client/config/theme.dart';
 import 'package:pi_hole_client/constants/api_versions.dart';
+import 'package:pi_hole_client/constants/formats.dart';
 import 'package:pi_hole_client/constants/responsive.dart';
 import 'package:pi_hole_client/functions/conversions.dart';
 import 'package:pi_hole_client/functions/format.dart';
@@ -175,12 +176,14 @@ class _DomainDetailsScreenState extends State<DomainDetailsScreen> {
             CustomListTile(
               leadingIcon: Icons.event_available_rounded,
               label: AppLocalizations.of(context)!.dateAdded,
-              description: formatTimestamp(_domain.dateAdded, 'yyyy-MM-dd'),
+              description:
+                  formatTimestamp(_domain.dateAdded, kUnifiedDateFormat),
             ),
             CustomListTile(
               leadingIcon: Icons.edit_calendar_rounded,
               label: AppLocalizations.of(context)!.dateModified,
-              description: formatTimestamp(_domain.dateModified, 'yyyy-MM-dd'),
+              description:
+                  formatTimestamp(_domain.dateModified, kUnifiedDateFormat),
             ),
           ],
         ),

--- a/lib/screens/domains/widgets/domain_tile.dart
+++ b/lib/screens/domains/widgets/domain_tile.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:pi_hole_client/config/theme.dart';
+import 'package:pi_hole_client/constants/formats.dart';
 import 'package:pi_hole_client/constants/responsive.dart';
 import 'package:pi_hole_client/functions/conversions.dart';
 import 'package:pi_hole_client/functions/format.dart';
@@ -105,7 +106,7 @@ class DomainTile extends StatelessWidget {
               ),
               const SizedBox(height: 10),
               Text(
-                formatTimestamp(domain.dateAdded, 'yyyy-MM-dd'),
+                formatTimestamp(domain.dateAdded, kUnifiedDateFormat),
                 overflow: TextOverflow.ellipsis,
                 style: TextStyle(
                   color: Theme.of(context).listTileTheme.textColor,

--- a/lib/screens/logs/logs_filters_modal.dart
+++ b/lib/screens/logs/logs_filters_modal.dart
@@ -3,6 +3,7 @@
 import 'dart:io';
 
 import 'package:flutter/material.dart';
+import 'package:pi_hole_client/constants/formats.dart';
 import 'package:pi_hole_client/constants/responsive.dart';
 import 'package:pi_hole_client/functions/format.dart';
 import 'package:pi_hole_client/l10n/generated/app_localizations.dart';
@@ -283,7 +284,7 @@ class _LogsFiltersModalState extends State<LogsFiltersModal> {
                                                       ? formatTimestamp(
                                                           filtersProvider
                                                               .startTime!,
-                                                          'yyyy-MM-dd HH:mm',
+                                                          kUnifiedDateTimeFormat,
                                                         )
                                                       : AppLocalizations.of(
                                                           context,
@@ -363,7 +364,7 @@ class _LogsFiltersModalState extends State<LogsFiltersModal> {
                                                       ? formatTimestamp(
                                                           filtersProvider
                                                               .endTime!,
-                                                          'yyyy-MM-dd HH:mm',
+                                                          kUnifiedDateTimeFormat,
                                                         )
                                                       : AppLocalizations.of(
                                                           context,

--- a/lib/screens/logs/logs_filters_modal.dart
+++ b/lib/screens/logs/logs_filters_modal.dart
@@ -283,7 +283,7 @@ class _LogsFiltersModalState extends State<LogsFiltersModal> {
                                                       ? formatTimestamp(
                                                           filtersProvider
                                                               .startTime!,
-                                                          'dd/MM/yyyy - HH:mm',
+                                                          'yyyy-MM-dd HH:mm',
                                                         )
                                                       : AppLocalizations.of(
                                                           context,
@@ -363,7 +363,7 @@ class _LogsFiltersModalState extends State<LogsFiltersModal> {
                                                       ? formatTimestamp(
                                                           filtersProvider
                                                               .endTime!,
-                                                          'dd/MM/yyyy - HH:mm',
+                                                          'yyyy-MM-dd HH:mm',
                                                         )
                                                       : AppLocalizations.of(
                                                           context,

--- a/lib/screens/logs/no_logs_message.dart
+++ b/lib/screens/logs/no_logs_message.dart
@@ -21,9 +21,9 @@ class NoLogsMessage extends StatelessWidget {
           filtersProvider.endTime != null) {
         return '${AppLocalizations.of(context)!.noLogsDisplay} '
             '${AppLocalizations.of(context)!.between}\n'
-            '${filtersProvider.startTime != null ? formatTimestamp(filtersProvider.startTime!, 'dd/MM/yyyy - HH:mm') : AppLocalizations.of(context)!.now}\n'
+            '${filtersProvider.startTime != null ? formatTimestamp(filtersProvider.startTime!, 'yyyy-MM-dd HH:mm') : AppLocalizations.of(context)!.now}\n'
             '${AppLocalizations.of(context)!.and}\n'
-            '${filtersProvider.startTime != null && filtersProvider.endTime != null ? formatTimestamp(filtersProvider.endTime!, 'dd/MM/yyyy - HH:mm') : AppLocalizations.of(context)!.now} ';
+            '${filtersProvider.startTime != null && filtersProvider.endTime != null ? formatTimestamp(filtersProvider.endTime!, 'yyyy-MM-dd HH:mm') : AppLocalizations.of(context)!.now} ';
       } else {
         return '${AppLocalizations.of(context)!.noLogsDisplay} '
             '${AppLocalizations.of(context)!.fromLast} ${logsPerQuery == 0.5 ? '30' : logsPerQuery.toInt()} ${logsPerQuery == 0.5 ? AppLocalizations.of(context)!.minutes : AppLocalizations.of(context)!.hours}';

--- a/lib/screens/logs/no_logs_message.dart
+++ b/lib/screens/logs/no_logs_message.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:pi_hole_client/classes/no_scroll_behavior.dart';
+import 'package:pi_hole_client/constants/formats.dart';
 import 'package:pi_hole_client/functions/format.dart';
 import 'package:pi_hole_client/l10n/generated/app_localizations.dart';
 import 'package:pi_hole_client/providers/filters_provider.dart';
@@ -21,9 +22,9 @@ class NoLogsMessage extends StatelessWidget {
           filtersProvider.endTime != null) {
         return '${AppLocalizations.of(context)!.noLogsDisplay} '
             '${AppLocalizations.of(context)!.between}\n'
-            '${filtersProvider.startTime != null ? formatTimestamp(filtersProvider.startTime!, 'yyyy-MM-dd HH:mm') : AppLocalizations.of(context)!.now}\n'
+            '${filtersProvider.startTime != null ? formatTimestamp(filtersProvider.startTime!, kUnifiedDateTimeFormat) : AppLocalizations.of(context)!.now}\n'
             '${AppLocalizations.of(context)!.and}\n'
-            '${filtersProvider.startTime != null && filtersProvider.endTime != null ? formatTimestamp(filtersProvider.endTime!, 'yyyy-MM-dd HH:mm') : AppLocalizations.of(context)!.now} ';
+            '${filtersProvider.startTime != null && filtersProvider.endTime != null ? formatTimestamp(filtersProvider.endTime!, kUnifiedDateTimeFormat) : AppLocalizations.of(context)!.now} ';
       } else {
         return '${AppLocalizations.of(context)!.noLogsDisplay} '
             '${AppLocalizations.of(context)!.fromLast} ${logsPerQuery == 0.5 ? '30' : logsPerQuery.toInt()} ${logsPerQuery == 0.5 ? AppLocalizations.of(context)!.minutes : AppLocalizations.of(context)!.hours}';

--- a/lib/screens/settings/server_settings/widgets/subscriptions/subscription_details_screen.dart
+++ b/lib/screens/settings/server_settings/widgets/subscriptions/subscription_details_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:pi_hole_client/classes/process_modal.dart';
 import 'package:pi_hole_client/config/theme.dart';
+import 'package:pi_hole_client/constants/formats.dart';
 import 'package:pi_hole_client/constants/responsive.dart';
 import 'package:pi_hole_client/functions/conversions.dart';
 import 'package:pi_hole_client/functions/format.dart';
@@ -194,15 +195,17 @@ class _SubscriptionDetailsScreenState extends State<SubscriptionDetailsScreen> {
             CustomListTile(
               leadingIcon: Icons.event_available_rounded,
               label: AppLocalizations.of(context)!.dateAdded,
-              description:
-                  formatTimestamp(_subscription.dateAdded, 'yyyy-MM-dd HH:mm'),
+              description: formatTimestamp(
+                _subscription.dateAdded,
+                kUnifiedDateTimeFormat,
+              ),
             ),
             CustomListTile(
               leadingIcon: Icons.edit_calendar_rounded,
               label: AppLocalizations.of(context)!.dateModified,
               description: formatTimestamp(
                 _subscription.dateModified,
-                'yyyy-MM-dd HH:mm',
+                kUnifiedDateTimeFormat,
               ),
             ),
             CustomListTile(
@@ -210,7 +213,7 @@ class _SubscriptionDetailsScreenState extends State<SubscriptionDetailsScreen> {
               label: AppLocalizations.of(context)!.dateUpdated,
               description: formatTimestamp(
                 _subscription.dateUpdated,
-                'yyyy-MM-dd HH:mm',
+                kUnifiedDateTimeFormat,
               ),
             ),
           ],


### PR DESCRIPTION
## Overview

Unified datetime display format to yyyy-MM-dd in the logs screen.

## Screenshots

|before|after|
|---|---|
|![before](https://github.com/user-attachments/assets/57d82956-3289-4eff-8754-d1615c067c1b)|![after](https://github.com/user-attachments/assets/00a733d4-5df1-4750-9cd3-5502d87f7574)|
