### PR TITLE
fix(context): ensure safe usage with context.mounted checks

### DIFF
--- a/lib/base.dart
+++ b/lib/base.dart
@@ -1,4 +1,3 @@
-// ignore_for_file: use_build_context_synchronously
 import 'dart:io';
 import 'package:animations/animations.dart';
 import 'package:flutter/material.dart';
@@ -70,6 +69,7 @@ class _BaseState extends State<Base>
 
       if (serversProvider.selectedServer != null) {
         await serversProvider.selectedApiGateway?.loginQuery();
+        if (!mounted) return;
         context.read<StatusUpdateService>().startAutoRefresh();
       }
     });

--- a/lib/functions/refresh_server_status.dart
+++ b/lib/functions/refresh_server_status.dart
@@ -1,5 +1,3 @@
-// ignore_for_file: use_build_context_synchronously
-
 import 'package:flutter/material.dart';
 import 'package:pi_hole_client/constants/enums.dart';
 import 'package:pi_hole_client/functions/snackbar.dart';

--- a/lib/functions/server_management.dart
+++ b/lib/functions/server_management.dart
@@ -1,5 +1,3 @@
-// ignore_for_file: use_build_context_synchronously
-
 import 'package:flutter/material.dart';
 import 'package:pi_hole_client/classes/process_modal.dart';
 import 'package:pi_hole_client/functions/snackbar.dart';
@@ -19,6 +17,9 @@ Future<void> enableServer(BuildContext context) async {
   process.open(AppLocalizations.of(context)!.enablingServer);
   final result = await apiGateway?.enableServerRequest();
   process.close();
+
+  if (!context.mounted) return;
+
   if (result?.result == APiResponseType.success) {
     serversProvider.updateselectedServerStatus(true);
     showSuccessSnackBar(

--- a/lib/functions/snackbar.dart
+++ b/lib/functions/snackbar.dart
@@ -1,5 +1,3 @@
-// ignore_for_file: use_build_context_synchronously
-
 import 'package:flutter/material.dart';
 import 'package:pi_hole_client/config/globals.dart';
 import 'package:pi_hole_client/config/theme.dart';
@@ -82,6 +80,8 @@ Future<void> showSnackBar({
     await Future.delayed(const Duration(milliseconds: 500));
   }
   appConfigProvider.setShowingSnackbar(true);
+
+  if (!context.mounted) return;
 
   final theme = Theme.of(context).extension<AppColors>()!;
   final backgroundColor = colorSelector(theme);

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,5 +1,3 @@
-// ignore_for_file: use_build_context_synchronously
-
 import 'dart:async';
 import 'dart:io';
 

--- a/lib/screens/app_logs/app_logs.dart
+++ b/lib/screens/app_logs/app_logs.dart
@@ -1,5 +1,3 @@
-// ignore_for_file: use_build_context_synchronously
-
 import 'dart:convert';
 
 import 'package:flutter/material.dart';
@@ -21,6 +19,8 @@ class AppLogs extends StatelessWidget {
       final logsString =
           appConfigProvider.logs.map((log) => log.toMap()).toList();
       await Clipboard.setData(ClipboardData(text: jsonEncode(logsString)));
+
+      if (!context.mounted) return;
 
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(

--- a/lib/screens/domains/domains.dart
+++ b/lib/screens/domains/domains.dart
@@ -1,5 +1,3 @@
-// ignore_for_file: use_build_context_synchronously
-
 import 'package:flutter/material.dart';
 import 'package:pi_hole_client/classes/process_modal.dart';
 import 'package:pi_hole_client/constants/responsive.dart';
@@ -88,6 +86,8 @@ class _DomainListsWidgetState extends State<DomainListsWidget>
       final result = await apiGateway?.removeDomainFromList(domain);
 
       process.close();
+
+      if (!context.mounted) return;
 
       if (result?.result == APiResponseType.success) {
         domainsListProvider.removeDomainFromList(domain);

--- a/lib/screens/domains/widgets/domains_list.dart
+++ b/lib/screens/domains/widgets/domains_list.dart
@@ -1,5 +1,3 @@
-// ignore_for_file: use_build_context_synchronously
-
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:pi_hole_client/classes/process_modal.dart';
@@ -88,9 +86,13 @@ class _DomainsListState extends State<DomainsList> {
 
       process.close();
 
+      if (!context.mounted) return;
+
       if (result?.result == APiResponseType.success) {
         domainsListProvider.removeDomainFromList(domain);
         await Navigator.maybePop(context);
+        if (!context.mounted) return;
+
         showSuccessSnackBar(
           context: context,
           appConfigProvider: appConfigProvider,
@@ -121,8 +123,12 @@ class _DomainsListState extends State<DomainsList> {
 
       process.close();
 
+      if (!context.mounted) return;
+
       if (result?.result == APiResponseType.success) {
         await domainsListProvider.fetchDomainsList();
+        if (!context.mounted) return;
+
         showSuccessSnackBar(
           context: context,
           appConfigProvider: appConfigProvider,

--- a/lib/screens/home/home.dart
+++ b/lib/screens/home/home.dart
@@ -1,5 +1,3 @@
-// ignore_for_file: use_build_context_synchronously
-
 import 'dart:io';
 
 import 'package:flutter/material.dart';

--- a/lib/screens/home/widgets/home_appbar.dart
+++ b/lib/screens/home/widgets/home_appbar.dart
@@ -1,5 +1,3 @@
-// ignore_for_file: use_build_context_synchronously
-
 import 'package:flutter/material.dart';
 import 'package:pi_hole_client/classes/process_modal.dart';
 import 'package:pi_hole_client/config/system_overlay_style.dart';
@@ -34,6 +32,8 @@ class HomeAppBar extends StatelessWidget implements PreferredSizeWidget {
       process.open(AppLocalizations.of(context)!.refreshingData);
       final result = await serversProvider.selectedApiGateway?.realtimeStatus();
       process.close();
+      if (!context.mounted) return;
+
       if (result?.result == APiResponseType.success) {
         serversProvider.updateselectedServerStatus(
           result!.data!.status == 'enabled' ? true : false,
@@ -54,14 +54,9 @@ class HomeAppBar extends StatelessWidget implements PreferredSizeWidget {
     }
 
     void changeServer() {
-      Future.delayed(
-        Duration.zero,
-        () => {
-          Navigator.push(
-            context,
-            MaterialPageRoute(builder: (context) => const ServersPage()),
-          ),
-        },
+      Navigator.push(
+        context,
+        MaterialPageRoute(builder: (context) => const ServersPage()),
       );
     }
 
@@ -101,6 +96,8 @@ class HomeAppBar extends StatelessWidget implements PreferredSizeWidget {
 
       final result = await serversProvider.loadApiGateway(server)?.loginQuery();
       process.close();
+      if (!context.mounted) return;
+
       if (result?.result == APiResponseType.success) {
         await connectSuccess(result);
       } else {

--- a/lib/screens/logs/logs.dart
+++ b/lib/screens/logs/logs.dart
@@ -1,5 +1,3 @@
-// ignore_for_file: use_build_context_synchronously
-
 import 'package:flutter/material.dart';
 import 'package:pi_hole_client/classes/process_modal.dart';
 import 'package:pi_hole_client/config/system_overlay_style.dart';
@@ -260,9 +258,11 @@ class _LogsState extends State<Logs> {
       );
       final result = await apiGateway?.setWhiteBlacklist(log.url, list);
       loading.close();
+
+      if (!context.mounted) return;
+
       if (result?.result == APiResponseType.success) {
         if (result!.data!.message.contains('Added')) {
-          if (!mounted) return;
           showSuccessSnackBar(
             context: context,
             appConfigProvider: appConfigProvider,

--- a/lib/screens/logs/logs_filters_modal.dart
+++ b/lib/screens/logs/logs_filters_modal.dart
@@ -1,5 +1,3 @@
-// ignore_for_file: use_build_context_synchronously
-
 import 'dart:io';
 
 import 'package:flutter/material.dart';
@@ -124,6 +122,8 @@ class _LogsFiltersModalState extends State<LogsFiltersModal> {
         firstDate: DateTime(now.year, now.month - 1, now.day),
         lastDate: now,
       );
+      if (!context.mounted) return;
+
       if (dateValue != null) {
         final timeValue = await showTimePicker(
           context: context,

--- a/lib/screens/servers/add_server_fullscreen.dart
+++ b/lib/screens/servers/add_server_fullscreen.dart
@@ -1,5 +1,3 @@
-// ignore_for_file: use_build_context_synchronously
-
 import 'dart:io';
 
 import 'package:flutter/material.dart';
@@ -260,6 +258,9 @@ class _AddServerFullscreenState extends State<AddServerFullscreen> {
       final url =
           '${connectionType.name}://${addressFieldController.text}${portFieldController.text != '' ? ':${portFieldController.text}' : ''}${subrouteFieldController.text}';
       final exists = await serversProvider.checkUrlExists(url);
+
+      if (!context.mounted) return;
+
       if (exists['result'] == 'success' && exists['exists'] == true) {
         setState(() {
           errorUrl = AppLocalizations.of(context)!.connectionAlreadyExists;
@@ -290,9 +291,10 @@ class _AddServerFullscreenState extends State<AddServerFullscreen> {
         await serverObj.sm.saveToken(tokenFieldController.text);
         final result =
             await serversProvider.loadApiGateway(serverObj)?.loginQuery();
-        if (!mounted) return;
+        if (!context.mounted) return;
         if (result?.result == APiResponseType.success) {
           await Navigator.maybePop(context);
+          if (!context.mounted) return;
           showSuccessSnackBar(
             context: context,
             appConfigProvider: appConfigProvider,
@@ -318,6 +320,7 @@ class _AddServerFullscreenState extends State<AddServerFullscreen> {
 
             await serverObj.sm.deletePassword();
             await serverObj.sm.deleteToken();
+            if (!context.mounted) return;
 
             handleApiErrorResult(
               context: context,
@@ -360,9 +363,10 @@ class _AddServerFullscreenState extends State<AddServerFullscreen> {
           defaultServer: defaultCheckbox,
         );
         final result = await serversProvider.editServer(server);
-        if (mounted) {
+        if (context.mounted) {
           if (result == true) {
             await Navigator.maybePop(context);
+            if (!context.mounted) return;
 
             showSuccessSnackBar(
               context: context,
@@ -381,7 +385,7 @@ class _AddServerFullscreenState extends State<AddServerFullscreen> {
           }
         }
       } else {
-        if (mounted) {
+        if (context.mounted) {
           setState(() {
             isConnecting = false;
             _restoreSecrets();

--- a/lib/screens/servers/servers.dart
+++ b/lib/screens/servers/servers.dart
@@ -1,5 +1,3 @@
-// ignore_for_file: use_build_context_synchronously
-
 import 'dart:io';
 
 import 'package:expandable/expandable.dart';
@@ -83,39 +81,35 @@ class _ServersPageState extends State<ServersPage> {
     }
 
     Future<void> openAddServer({Server? server}) async {
-      await Future.delayed(
-        Duration.zero,
-        () => {
-          if (width > ResponsiveConstants.medium)
-            {
-              showDialog(
-                context: context,
-                useRootNavigator:
-                    false, // Prevents unexpected app exit on mobile when pressing back
-                builder: (context) => AddServerFullscreen(
-                  server: server,
-                  window: true,
-                  title: AppLocalizations.of(context)!.createConnection,
-                ),
-                barrierDismissible: false,
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (!context.mounted) return;
+
+        if (width > ResponsiveConstants.medium) {
+          showDialog(
+            context: context,
+            useRootNavigator:
+                false, // Prevents unexpected app exit on mobile when pressing back
+            barrierDismissible: false,
+            builder: (context) => AddServerFullscreen(
+              server: server,
+              window: true,
+              title: AppLocalizations.of(context)!.createConnection,
+            ),
+          );
+        } else {
+          Navigator.push(
+            context,
+            MaterialPageRoute(
+              fullscreenDialog: true,
+              builder: (BuildContext context) => AddServerFullscreen(
+                server: server,
+                window: false,
+                title: AppLocalizations.of(context)!.createConnection,
               ),
-            }
-          else
-            {
-              Navigator.push(
-                context,
-                MaterialPageRoute(
-                  fullscreenDialog: true,
-                  builder: (BuildContext context) => AddServerFullscreen(
-                    server: server,
-                    window: false,
-                    title: AppLocalizations.of(context)!.createConnection,
-                  ),
-                ),
-              ),
-            },
-        },
-      );
+            ),
+          );
+        }
+      });
     }
 
     return PopScope(

--- a/lib/screens/servers/servers_list.dart
+++ b/lib/screens/servers/servers_list.dart
@@ -1,4 +1,3 @@
-// ignore_for_file: use_build_context_synchronously
 import 'package:expandable/expandable.dart';
 import 'package:flutter/material.dart';
 import 'package:pi_hole_client/l10n/generated/app_localizations.dart';

--- a/lib/screens/settings/app_settings/advanced_settings/app_lock/create_pass_code_modal.dart
+++ b/lib/screens/settings/app_settings/advanced_settings/app_lock/create_pass_code_modal.dart
@@ -1,5 +1,3 @@
-// ignore_for_file: use_build_context_synchronously
-
 import 'package:flutter/material.dart';
 import 'package:pi_hole_client/functions/snackbar.dart';
 import 'package:pi_hole_client/l10n/generated/app_localizations.dart';
@@ -28,6 +26,8 @@ class _CreatePassCodeModalState extends State<CreatePassCodeModal> {
     Future<void> finish() async {
       if (_code == _repeatedCode) {
         final result = await appConfigProvider.setPassCode(_repeatedCode);
+        if (!context.mounted) return;
+
         if (result == true) {
           await Navigator.maybePop(context);
         } else {

--- a/lib/screens/settings/app_settings/advanced_settings/app_lock/remove_passcode_modal.dart
+++ b/lib/screens/settings/app_settings/advanced_settings/app_lock/remove_passcode_modal.dart
@@ -1,5 +1,3 @@
-// ignore_for_file: use_build_context_synchronously
-
 import 'package:flutter/material.dart';
 import 'package:pi_hole_client/functions/snackbar.dart';
 import 'package:pi_hole_client/l10n/generated/app_localizations.dart';
@@ -17,6 +15,8 @@ class RemovePasscodeModal extends StatelessWidget {
 
     Future<void> removePasscode() async {
       final deleted = await appConfigProvider.setPassCode(null);
+      if (!context.mounted) return;
+
       if (deleted == true) {
         await Navigator.maybePop(context);
       } else {

--- a/lib/screens/settings/app_settings/advanced_settings/app_unlock_setup_modal.dart
+++ b/lib/screens/settings/app_settings/advanced_settings/app_unlock_setup_modal.dart
@@ -1,5 +1,3 @@
-// ignore_for_file: use_build_context_synchronously
-
 import 'package:flutter/material.dart';
 import 'package:local_auth/local_auth.dart';
 import 'package:pi_hole_client/functions/conversions.dart';
@@ -88,6 +86,7 @@ class _AppUnlockSetupModalState extends State<AppUnlockSetupModal> {
             );
             if (didAuthenticate == true) {
               final result = await appConfigProvider.setUseBiometrics(true);
+              if (!context.mounted) return;
               if (result == false) {
                 showErrorSnackBar(
                   context: context,
@@ -98,6 +97,7 @@ class _AppUnlockSetupModalState extends State<AppUnlockSetupModal> {
               }
             }
           } catch (e) {
+            if (!context.mounted) return;
             if (e.toString().contains('LockedOut')) {
               showErrorSnackBar(
                 context: context,
@@ -114,6 +114,7 @@ class _AppUnlockSetupModalState extends State<AppUnlockSetupModal> {
             }
           }
         } else {
+          if (!context.mounted) return;
           showNeutralSnackBar(
             context: context,
             appConfigProvider: appConfigProvider,
@@ -122,6 +123,7 @@ class _AppUnlockSetupModalState extends State<AppUnlockSetupModal> {
         }
       } else {
         final result = await appConfigProvider.setUseBiometrics(false);
+        if (!context.mounted) return;
         if (result == false) {
           showErrorSnackBar(
             context: context,

--- a/lib/screens/settings/app_settings/advanced_settings/enter_passcode_modal.dart
+++ b/lib/screens/settings/app_settings/advanced_settings/enter_passcode_modal.dart
@@ -1,5 +1,3 @@
-// ignore_for_file: use_build_context_synchronously
-
 import 'package:flutter/material.dart';
 import 'package:pi_hole_client/l10n/generated/app_localizations.dart';
 import 'package:pi_hole_client/providers/app_config_provider.dart';

--- a/lib/screens/unlock.dart
+++ b/lib/screens/unlock.dart
@@ -1,5 +1,3 @@
-// ignore_for_file: use_build_context_synchronously
-
 import 'package:flutter/material.dart';
 import 'package:flutter_app_lock/flutter_app_lock.dart';
 import 'package:local_auth/local_auth.dart';
@@ -37,6 +35,7 @@ class _UnlockState extends State<Unlock> {
     final biometrics = await auth.getAvailableBiometrics();
     if (appConfigProvider.useBiometrics == true && biometrics.isNotEmpty) {
       await auth.stopAuthentication();
+      if (!mounted) return;
       try {
         final didAuthenticate = await auth.authenticate(
           localizedReason: AppLocalizations.of(context)!.unlockWithFingerprint,

--- a/lib/widgets/start_warning_modal.dart
+++ b/lib/widgets/start_warning_modal.dart
@@ -1,5 +1,3 @@
-// ignore_for_file: use_build_context_synchronously
-
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:pi_hole_client/constants/urls.dart';
@@ -179,6 +177,7 @@ class StartInfoModal extends StatelessWidget {
                   TextButton(
                     onPressed: () async {
                       await appConfigProvider.setImportantInfoReaden(true);
+                      if (!context.mounted) return;
                       await Navigator.maybePop(context);
                     },
                     child: Text(AppLocalizations.of(context)!.close),


### PR DESCRIPTION
## Overview

The primary purpose of this PR is to **remove** the directive:

```dart
// ignore_for_file: use_build_context_synchronously
```

and instead adopt **explicit `context.mounted` checks** after asynchronous operations, to ensure safe and predictable usage of `BuildContext` throughout the app.

As a side benefit, it also **helps mitigate the crash reported in Sentry**:

> **TypeError: Null check operator used on a null value**
> Location: `snackbar.dart` at line 86

which likely resulted from unsafe context access after widget disposal.

##  Changes

* Removed all instances of `// ignore_for_file: use_build_context_synchronously`
* Added `if (!context.mounted) return;` after `await` calls that precede context usage
