### PR TITLE
fix(adlist): show loading indicator on subscription screen to prevent stale data flash

### DIFF
--- a/lib/providers/subscriptions_list_provider.dart
+++ b/lib/providers/subscriptions_list_provider.dart
@@ -60,6 +60,7 @@ class SubscriptionsListProvider with ChangeNotifier {
 
   void setLoadingStatus(LoadStatus status) {
     _loadingStatus = status;
+    notifyListeners();
   }
 
   void setWhitelistSubscriptions(List<Subscription> subscriptions) {

--- a/lib/screens/settings/server_settings/subscriptions.dart
+++ b/lib/screens/settings/server_settings/subscriptions.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:pi_hole_client/classes/process_modal.dart';
+import 'package:pi_hole_client/constants/enums.dart';
 import 'package:pi_hole_client/constants/responsive.dart';
 import 'package:pi_hole_client/functions/snackbar.dart';
 import 'package:pi_hole_client/l10n/generated/app_localizations.dart';
@@ -85,6 +86,11 @@ class _SubscriptionListsWidgetState extends State<SubscriptionListsWidget>
     super.initState();
 
     Future.microtask(() async {
+      widget.subscriptionsListProvider.setLoadingStatus(
+        LoadStatus.loading,
+      );
+      await widget.subscriptionsListProvider.fetchSubscriptionsList();
+
       if (!mounted) return;
       final groupsProvider = context.read<GroupsProvider>();
       await groupsProvider.loadGroups();
@@ -92,8 +98,6 @@ class _SubscriptionListsWidgetState extends State<SubscriptionListsWidget>
       if (!mounted) return;
       final gravityUpdateProvider = context.read<GravityUpdateProvider>();
       await gravityUpdateProvider.load();
-
-      await widget.subscriptionsListProvider.fetchSubscriptionsList();
     });
 
     widget.subscriptionsListProvider.setSelectedTab(0);

--- a/test/ut/providers/subscriptions_list_provider_test.dart
+++ b/test/ut/providers/subscriptions_list_provider_test.dart
@@ -99,7 +99,7 @@ void main() {
     test('setLoadingStatus updates loading status', () {
       provider.setLoadingStatus(LoadStatus.loaded);
       expect(provider.loadingStatus, LoadStatus.loaded);
-      expect(listenerCalled, false);
+      expect(listenerCalled, true);
     });
 
     test('setWhitelistSubscriptions updates allow adlists', () {


### PR DESCRIPTION
## Overview

This PR resolves an issue where stale subscription data briefly appears on the screen after switching servers.
