### PR TITLE
fix(api): improve realtimeStatus stability by splitting requests into batches

### DIFF
--- a/lib/functions/misc.dart
+++ b/lib/functions/misc.dart
@@ -21,21 +21,29 @@ String convertTemperatureUnit(String? unit) {
   }
 }
 
-/// Creates an instance of [HttpClient] with an optional configuration to allow
-/// self-signed certificates.
+/// Creates an instance of [HttpClient] with configurable certificate validation
+/// and connection keep-alive behavior.
 ///
-/// If [allowSelfSignedCert] is set to `true`, the client will accept all
-/// certificates, including self-signed ones, by overriding the
-/// `badCertificateCallback`. This can be useful for testing or connecting to
-/// servers with self-signed certificates, but it should be used with caution
-/// in production environments as it bypasses certificate validation.
+/// If [allowSelfSignedCert] is `true`, the client will accept all certificates,
+/// including self-signed ones. Use with caution in production.
 ///
-/// - [allowSelfSignedCert]: A boolean flag indicating whether to allow
-///   self-signed certificates. Defaults to `true`.
+/// If [keepAlive] is `true`, idle connections are kept open indefinitely
+/// (by setting `idleTimeout` to `Duration.zero`).
+/// If `false`, the default `HttpClient` idle timeout is used.
+///
+/// - [allowSelfSignedCert]: Whether to allow self-signed certificates. Defaults to `true`.
+/// - [keepAlive]: Whether to keep idle connections alive indefinitely. Defaults to `false`.
 ///
 /// Returns an instance of [HttpClient].
-HttpClient createHttpClient({bool allowSelfSignedCert = true}) {
+HttpClient createHttpClient({
+  bool allowSelfSignedCert = true,
+  bool keepAlive = false,
+}) {
   final client = HttpClient();
+
+  if (keepAlive) {
+    client.idleTimeout = Duration.zero;
+  }
   if (allowSelfSignedCert) {
     client.badCertificateCallback =
         (X509Certificate cert, String host, int port) => true;

--- a/lib/gateways/api_gateway_interface.dart
+++ b/lib/gateways/api_gateway_interface.dart
@@ -9,6 +9,12 @@ import 'package:pi_hole_client/models/subscriptions.dart';
 abstract interface class ApiGateway {
   Server get server;
 
+  /// Closes the underlying HTTP client and releases any associated resources.
+  ///
+  /// This should be called when the API gateway instance is no longer needed
+  /// to ensure that all open connections and resources are properly cleaned up.
+  void close();
+
   /// Handles the login process to a Pi-hole server using its API.
   ///
   /// ### Parameters

--- a/lib/gateways/v5/api_gateway_v5.dart
+++ b/lib/gateways/v5/api_gateway_v5.dart
@@ -91,6 +91,11 @@ class ApiGatewayV5 implements ApiGateway {
     }
   }
 
+  @override
+  void close() {
+    _client.close();
+  }
+
   /// Handles the login process to a Pi-hole server using its API.
   ///
   /// This function performs the following steps:

--- a/lib/gateways/v6/api_gateway_v6.dart
+++ b/lib/gateways/v6/api_gateway_v6.dart
@@ -239,6 +239,11 @@ class ApiGatewayV6 implements ApiGateway {
     throw Exception('Failed to execute streamed HTTP request');
   }
 
+  @override
+  void close() {
+    _client.close();
+  }
+
   /// Handles the login process to a Pi-hole server using its API.
   @override
   Future<LoginQueryResponse> loginQuery({bool refresh = false}) async {

--- a/lib/gateways/v6/api_gateway_v6.dart
+++ b/lib/gateways/v6/api_gateway_v6.dart
@@ -398,19 +398,20 @@ class ApiGatewayV6 implements ApiGateway {
   @override
   Future<RealtimeStatusResponse> realtimeStatus() async {
     try {
-      final response = await Future.wait([
+      // To improve stability, split into two batches.
+      // Some servers or networks may fail with too many simultaneous connections.
+      // This helps avoid "Connection closed before full header was received" errors.
+      final batch1 = await Future.wait([
+        httpClient(method: 'get', url: '${_server.address}/api/stats/summary'),
+        httpClient(method: 'get', url: '${_server.address}/api/info/ftl'),
+        httpClient(method: 'get', url: '${_server.address}/api/dns/blocking'),
         httpClient(
           method: 'get',
-          url: '${_server.address}/api/stats/summary',
+          url: '${_server.address}/api/stats/upstreams',
         ),
-        httpClient(
-          method: 'get',
-          url: '${_server.address}/api/info/ftl',
-        ),
-        httpClient(
-          method: 'get',
-          url: '${_server.address}/api/dns/blocking',
-        ),
+      ]);
+
+      final batch2 = await Future.wait([
         httpClient(
           method: 'get',
           url: '${_server.address}/api/stats/top_domains',
@@ -427,11 +428,10 @@ class ApiGatewayV6 implements ApiGateway {
           method: 'get',
           url: '${_server.address}/api/stats/top_clients?blocked=true',
         ),
-        httpClient(
-          method: 'get',
-          url: '${_server.address}/api/stats/upstreams',
-        ),
       ]);
+
+      final response = [...batch1, ...batch2];
+
       if (response[0].statusCode == 200 &&
           response[1].statusCode == 200 &&
           response[2].statusCode == 200 &&
@@ -443,15 +443,16 @@ class ApiGatewayV6 implements ApiGateway {
         final summary = StatsSummary.fromJson(jsonDecode(response[0].body));
         final infoFtl = InfoFtl.fromJson(jsonDecode(response[1].body));
         final blocking = Blocking.fromJson(jsonDecode(response[2].body));
+        final upstreams = StatsUpstreams.fromJson(jsonDecode(response[3].body));
+
         final topPermittedDomains =
-            StatsTopDomains.fromJson(jsonDecode(response[3].body));
-        final topBlockedDomains =
             StatsTopDomains.fromJson(jsonDecode(response[4].body));
+        final topBlockedDomains =
+            StatsTopDomains.fromJson(jsonDecode(response[5].body));
         final topClients =
-            StatsTopClients.fromJson(jsonDecode(response[5].body));
-        final topBlockedClients =
             StatsTopClients.fromJson(jsonDecode(response[6].body));
-        final upstreams = StatsUpstreams.fromJson(jsonDecode(response[7].body));
+        final topBlockedClients =
+            StatsTopClients.fromJson(jsonDecode(response[7].body));
 
         return RealtimeStatusResponse(
           result: APiResponseType.success,
@@ -580,6 +581,7 @@ class ApiGatewayV6 implements ApiGateway {
     } on HandshakeException {
       return FetchOverTimeDataResponse(result: APiResponseType.sslError);
     } catch (e) {
+      logger.e('Error fetching over-time data: $e');
       return FetchOverTimeDataResponse(result: APiResponseType.error);
     }
   }

--- a/lib/providers/servers_provider.dart
+++ b/lib/providers/servers_provider.dart
@@ -159,6 +159,7 @@ class ServersProvider with ChangeNotifier {
 
       // Update the API gateway if it exists
       if (_serverGateways.containsKey(server.address)) {
+        _serverGateways[server.address]?.close();
         _serverGateways[server.address] = ApiGatewayFactory.create(server);
       }
 


### PR DESCRIPTION
## Overview

Improve stability of realtimeStatus by splitting requests into two batches to avoid connection errors under heavy load.

## Changes

- Split 8 parallel requests into 2 batches of 4.
