### PR TITLE
fix(domains): show loading state when switching servers to prevent outdated domain data

### DIFF
--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -316,6 +316,7 @@
   "list": "Liste",
   "listDescription": "Zeigt die Daten in einer Liste mit Labeln und Nummern auf der linken Seite, sowie einer Anzeige auf der rechten Seite.",
   "loadingCharts": "Diagramme werden geladen...",
+  "loadingDomains": "Domains werden geladen...",
   "loadingList": "Liste wird geladen...",
   "loadingLogs": "Logs werden geladen...",
   "loadingStats": "Statistiken werden geladen...",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -316,6 +316,7 @@
   "list": "List",
   "listDescription": "Displays the data on a list with the label and the numeric value at the left side, and a bar at the right side.",
   "loadingCharts": "Loading charts...",
+  "loadingDomains": "Loading domains...",
   "loadingList": "Loading list...",
   "loadingLogs": "Loading logs...",
   "loadingStats": "Loading stats...",

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -317,6 +317,7 @@
   "list": "Lista",
   "listDescription": "Muestra los datos en una lista con la etiqueta y el valor numérico en el lado izquierdo y una barra en el lado derecho.",
   "loadingCharts": "Cargando gráficos...",
+  "loadingDomains": "Cargando dominios...",
   "loadingList": "Cargando lista...",
   "loadingLogs": "Cargando registros...",
   "loadingStats": "Cargando estadísticas...",

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -316,6 +316,7 @@
   "list": "リスト",
   "listDescription": "ラベルと数値を左側に、バーを右側に表示するリストでデータを表示します。",
   "loadingCharts": "チャートを読み込み中...",
+  "loadingDomains": "ドメインを読み込んでいます...",
   "loadingList": "リストを読み込み中...",
   "loadingLogs": "ログを読み込み中...",
   "loadingStats": "統計を読み込み中...",

--- a/lib/l10n/app_pl.arb
+++ b/lib/l10n/app_pl.arb
@@ -316,6 +316,7 @@
   "list": "Lista",
   "listDescription": "Wyświetla dane na liście z etykietą i wartością liczbową po lewej stronie oraz paskiem po prawej stronie.",
   "loadingCharts": "Ładowanie wykresów...",
+  "loadingDomains": "Ładowanie domen...",
   "loadingList": "Ładowanie list...",
   "loadingLogs": "Ładowanie logów...",
   "loadingStats": "Ładowanie statystyk...",

--- a/lib/l10n/generated/app_localizations.dart
+++ b/lib/l10n/generated/app_localizations.dart
@@ -2006,6 +2006,12 @@ abstract class AppLocalizations {
   /// **'Loading charts...'**
   String get loadingCharts;
 
+  /// No description provided for @loadingDomains.
+  ///
+  /// In en, this message translates to:
+  /// **'Loading domains...'**
+  String get loadingDomains;
+
   /// No description provided for @loadingList.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/generated/app_localizations_de.dart
+++ b/lib/l10n/generated/app_localizations_de.dart
@@ -1018,6 +1018,9 @@ class AppLocalizationsDe extends AppLocalizations {
   String get loadingCharts => 'Diagramme werden geladen...';
 
   @override
+  String get loadingDomains => 'Domains werden geladen...';
+
+  @override
   String get loadingList => 'Liste wird geladen...';
 
   @override

--- a/lib/l10n/generated/app_localizations_en.dart
+++ b/lib/l10n/generated/app_localizations_en.dart
@@ -998,6 +998,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get loadingCharts => 'Loading charts...';
 
   @override
+  String get loadingDomains => 'Loading domains...';
+
+  @override
   String get loadingList => 'Loading list...';
 
   @override

--- a/lib/l10n/generated/app_localizations_es.dart
+++ b/lib/l10n/generated/app_localizations_es.dart
@@ -1018,6 +1018,9 @@ class AppLocalizationsEs extends AppLocalizations {
   String get loadingCharts => 'Cargando gráficos...';
 
   @override
+  String get loadingDomains => 'Cargando dominios...';
+
+  @override
   String get loadingList => 'Cargando lista...';
 
   @override

--- a/lib/l10n/generated/app_localizations_ja.dart
+++ b/lib/l10n/generated/app_localizations_ja.dart
@@ -971,6 +971,9 @@ class AppLocalizationsJa extends AppLocalizations {
   String get loadingCharts => 'チャートを読み込み中...';
 
   @override
+  String get loadingDomains => 'ドメインを読み込んでいます...';
+
+  @override
   String get loadingList => 'リストを読み込み中...';
 
   @override

--- a/lib/l10n/generated/app_localizations_pl.dart
+++ b/lib/l10n/generated/app_localizations_pl.dart
@@ -1003,6 +1003,9 @@ class AppLocalizationsPl extends AppLocalizations {
   String get loadingCharts => 'Ładowanie wykresów...';
 
   @override
+  String get loadingDomains => 'Ładowanie domen...';
+
+  @override
   String get loadingList => 'Ładowanie list...';
 
   @override

--- a/lib/providers/domains_list_provider.dart
+++ b/lib/providers/domains_list_provider.dart
@@ -60,6 +60,7 @@ class DomainsListProvider with ChangeNotifier {
 
   void setLoadingStatus(LoadStatus status) {
     _loadingStatus = status;
+    notifyListeners();
   }
 
   void setWhitelistDomains(List<Domain> domains) {

--- a/lib/screens/domains/domains.dart
+++ b/lib/screens/domains/domains.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:pi_hole_client/classes/process_modal.dart';
+import 'package:pi_hole_client/constants/enums.dart';
 import 'package:pi_hole_client/constants/responsive.dart';
 import 'package:pi_hole_client/functions/snackbar.dart';
 import 'package:pi_hole_client/l10n/generated/app_localizations.dart';
@@ -58,17 +59,30 @@ class _DomainListsWidgetState extends State<DomainListsWidget>
     super.initState();
 
     Future.microtask(() async {
+      widget.domainsListProvider.setLoadingStatus(
+        LoadStatus.loading,
+      );
+
+      await widget.domainsListProvider.fetchDomainsList();
+
       if (!mounted) return;
       final groupsProvider = context.read<GroupsProvider>();
       await groupsProvider.loadGroups();
     });
 
-    widget.domainsListProvider.fetchDomainsList();
     widget.domainsListProvider.setSelectedTab(0);
     tabController = TabController(
       length: 2,
       vsync: this,
     );
+  }
+
+  @override
+  void dispose() {
+    tabController.dispose();
+    scrollController.dispose();
+    searchController.dispose();
+    super.dispose();
   }
 
   @override

--- a/lib/screens/domains/widgets/domains_list.dart
+++ b/lib/screens/domains/widgets/domains_list.dart
@@ -192,7 +192,7 @@ class _DomainsListState extends State<DomainsList> {
                 const CircularProgressIndicator(),
                 const SizedBox(height: 50),
                 Text(
-                  AppLocalizations.of(context)!.loadingList,
+                  AppLocalizations.of(context)!.loadingDomains,
                   textAlign: TextAlign.center,
                   style: TextStyle(
                     color: Theme.of(context).colorScheme.onSurfaceVariant,

--- a/test/ut/providers/domains_list_provider_test.dart
+++ b/test/ut/providers/domains_list_provider_test.dart
@@ -75,7 +75,7 @@ void main() {
     test('setLoadingStatus updates loading status', () {
       provider.setLoadingStatus(LoadStatus.loaded);
       expect(provider.loadingStatus, LoadStatus.loaded);
-      expect(listenerCalled, false);
+      expect(listenerCalled, true);
     });
 
     test('setWhitelistDomains updates whitelist domains', () {

--- a/test/widgets/screens/domains/domains_test.dart
+++ b/test/widgets/screens/domains/domains_test.dart
@@ -272,7 +272,7 @@ void main() async {
         );
 
         expect(find.byType(DomainLists), findsOneWidget);
-        expect(find.text('Loading list...'), findsOneWidget);
+        expect(find.text('Loading domains...'), findsOneWidget);
       },
     );
 


### PR DESCRIPTION
## Overview

This PR fixes a bug where the "Domains" screen sometimes displayed outdated domain data from a previously selected server after switching servers.

## Changes

- Set `LoadStatus.loading` immediately when switching servers to ensure a proper loading state is shown.
- Added missing `notifyListeners()` call in `setLoadingStatus()` to ensure UI updates when the loading status changes.
- Updated loading message from "Loading list..." to "Loading domains..." for better clarity.
- Updated related unit tests to reflect the updated behavior of `setLoadingStatus()`.