### PR TITLE
fix(log): display all clients

### DIFF
--- a/lib/functions/refresh_server_status.dart
+++ b/lib/functions/refresh_server_status.dart
@@ -16,7 +16,7 @@ Future<dynamic> refreshServerStatus(BuildContext context) async {
       Provider.of<AppConfigProvider>(context, listen: false);
   final apiGateway = serversProvider.selectedApiGateway;
 
-  final result = await apiGateway?.realtimeStatus();
+  final result = await apiGateway?.realtimeStatus(clientCount: 0);
   if (!context.mounted) return;
   if (result?.result == APiResponseType.success) {
     serversProvider.updateselectedServerStatus(

--- a/lib/gateways/api_gateway_interface.dart
+++ b/lib/gateways/api_gateway_interface.dart
@@ -49,9 +49,20 @@ abstract interface class ApiGateway {
 
   /// Fetches over-time data from a Pi-hole server.
   ///
+  /// **Note:** This method is only supported for Pi-hole API v6.
+  ///
+  /// ### Parameters
+  /// - [clientCount]: The number of clients to include in the over-time data.
+  ///   - Default is `10` if not specified.
+  ///   - If `clientCount` is `0`, data for all clients will be returned without aggregation.
+  ///   - The top (clientCount - 1) clients will be included individually, and
+  ///     the remaining clients will be grouped under "others".
+  ///   - For example, if `clientCount` is 10, the response will contain data
+  ///     for 9 individual clients and one aggregated "others" entry.
+  ///
   /// ### Returns
   /// - A [FetchOverTimeDataResponse] object containing the result of the over-time data query.
-  Future<FetchOverTimeDataResponse> fetchOverTimeData();
+  Future<FetchOverTimeDataResponse> fetchOverTimeData({int? clientCount});
 
   /// Fetches log data from a Pi-hole server within a specified time range.
   ///

--- a/lib/gateways/api_gateway_interface.dart
+++ b/lib/gateways/api_gateway_interface.dart
@@ -28,9 +28,16 @@ abstract interface class ApiGateway {
 
   /// Fetches real-time status information from a Pi-hole server.
   ///
+  /// **Note:** The `clientCount` parameter is only supported for Pi-hole API v6.
+  ///
+  /// ### Parameters
+  /// - [clientCount]: The number of clients to include in the over-time data.
+  ///   - Default is `10` if not specified.
+  ///   - If `clientCount` is `0`, data for all clients will be returned without aggregation.
+  ///
   /// ### Returns
   /// - A [RealtimeStatusResponse] object containing the result of the real-time status query.
-  Future<RealtimeStatusResponse> realtimeStatus();
+  Future<RealtimeStatusResponse> realtimeStatus({int? clientCount});
 
   /// Disables a Pi-hole server
   ///
@@ -49,7 +56,7 @@ abstract interface class ApiGateway {
 
   /// Fetches over-time data from a Pi-hole server.
   ///
-  /// **Note:** This method is only supported for Pi-hole API v6.
+  /// **Note:** The `clientCount` parameter is only supported for Pi-hole API v6.
   ///
   /// ### Parameters
   /// - [clientCount]: The number of clients to include in the over-time data.

--- a/lib/gateways/v5/api_gateway_v5.dart
+++ b/lib/gateways/v5/api_gateway_v5.dart
@@ -349,7 +349,9 @@ class ApiGatewayV5 implements ApiGateway {
   /// Pi-hole server, including queries over time (in 10-minute intervals), client
   /// activity, and client names. The data is parsed and returned in a structured format.
   @override
-  Future<FetchOverTimeDataResponse> fetchOverTimeData() async {
+  Future<FetchOverTimeDataResponse> fetchOverTimeData({
+    int? clientCount,
+  }) async {
     try {
       final response = await httpClient(
         method: 'get',

--- a/lib/gateways/v5/api_gateway_v5.dart
+++ b/lib/gateways/v5/api_gateway_v5.dart
@@ -254,7 +254,7 @@ class ApiGatewayV5 implements ApiGateway {
   /// query sources, and query types. It parses the response and returns the
   /// data in a structured format.
   @override
-  Future<RealtimeStatusResponse> realtimeStatus() async {
+  Future<RealtimeStatusResponse> realtimeStatus({int? clientCount}) async {
     try {
       final response = await httpClient(
         method: 'get',

--- a/lib/gateways/v6/api_gateway_v6.dart
+++ b/lib/gateways/v6/api_gateway_v6.dart
@@ -396,8 +396,10 @@ class ApiGatewayV6 implements ApiGateway {
   /// query sources, and query types. It parses the response and returns the
   /// data in a structured format.
   @override
-  Future<RealtimeStatusResponse> realtimeStatus() async {
+  Future<RealtimeStatusResponse> realtimeStatus({int? clientCount}) async {
     try {
+      final count = clientCount ?? 10;
+
       // To improve stability, split into two batches.
       // Some servers or networks may fail with too many simultaneous connections.
       // This helps avoid "Connection closed before full header was received" errors.
@@ -422,7 +424,7 @@ class ApiGatewayV6 implements ApiGateway {
         ),
         httpClient(
           method: 'get',
-          url: '${_server.address}/api/stats/top_clients',
+          url: '${_server.address}/api/stats/top_clients?count=$count',
         ),
         httpClient(
           method: 'get',

--- a/lib/gateways/v6/api_gateway_v6.dart
+++ b/lib/gateways/v6/api_gateway_v6.dart
@@ -550,7 +550,11 @@ class ApiGatewayV6 implements ApiGateway {
   /// Pi-hole server, including queries over time (in 10-minute intervals), client
   /// activity, and client names. The data is parsed and returned in a structured format.
   @override
-  Future<FetchOverTimeDataResponse> fetchOverTimeData() async {
+  Future<FetchOverTimeDataResponse> fetchOverTimeData({
+    int? clientCount,
+  }) async {
+    final count = clientCount ?? 10;
+
     try {
       final response = await Future.wait([
         httpClient(
@@ -559,7 +563,7 @@ class ApiGatewayV6 implements ApiGateway {
         ),
         httpClient(
           method: 'get',
-          url: '${_server.address}/api/history/clients',
+          url: '${_server.address}/api/history/clients?N=$count',
         ),
       ]);
 

--- a/lib/screens/home/widgets/home_appbar.dart
+++ b/lib/screens/home/widgets/home_appbar.dart
@@ -30,7 +30,8 @@ class HomeAppBar extends StatelessWidget implements PreferredSizeWidget {
     Future<void> refresh() async {
       final process = ProcessModal(context: context);
       process.open(AppLocalizations.of(context)!.refreshingData);
-      final result = await serversProvider.selectedApiGateway?.realtimeStatus();
+      final result = await serversProvider.selectedApiGateway
+          ?.realtimeStatus(clientCount: 0);
       process.close();
       if (!context.mounted) return;
 
@@ -77,8 +78,8 @@ class HomeAppBar extends StatelessWidget implements PreferredSizeWidget {
             allowSelfSignedCert: server.allowSelfSignedCert,
           ),
         );
-        final statusResult =
-            await serversProvider.selectedApiGateway?.realtimeStatus();
+        final statusResult = await serversProvider.selectedApiGateway
+            ?.realtimeStatus(clientCount: 0);
         if (statusResult?.result == APiResponseType.success) {
           statusProvider.setRealtimeStatus(statusResult!.data!);
         }

--- a/lib/screens/logs/log_details_screen.dart
+++ b/lib/screens/logs/log_details_screen.dart
@@ -1,6 +1,7 @@
 // ignore_for_file: prefer_single_quotes
 
 import 'package:flutter/material.dart';
+import 'package:pi_hole_client/constants/formats.dart';
 import 'package:pi_hole_client/constants/search_domain_base_url.dart';
 import 'package:pi_hole_client/functions/format.dart';
 import 'package:pi_hole_client/functions/open_url.dart';
@@ -111,7 +112,8 @@ class LogDetailsScreen extends StatelessWidget {
             CustomListTile(
               leadingIcon: Icons.access_time_outlined,
               label: AppLocalizations.of(context)!.time,
-              description: formatTimestamp(log.dateTime, 'HH:mm:ss'),
+              description:
+                  formatTimestamp(log.dateTime, kUnifiedDateTimeLogFormat),
             ),
             if (log.status != null)
               item(

--- a/lib/screens/servers/servers_tile_item.dart
+++ b/lib/screens/servers/servers_tile_item.dart
@@ -113,7 +113,7 @@ class _ServersTileItemState extends State<ServersTileItem>
           ),
         );
         final apiGateway = serversProvider.selectedApiGateway;
-        final statusResult = await apiGateway?.realtimeStatus();
+        final statusResult = await apiGateway?.realtimeStatus(clientCount: 0);
         if (statusResult?.result == APiResponseType.success) {
           statusProvider.setRealtimeStatus(statusResult!.data!);
         }

--- a/lib/screens/statistics/statistics_list.dart
+++ b/lib/screens/statistics/statistics_list.dart
@@ -99,6 +99,7 @@ class StatisticsListContent extends StatelessWidget {
     final statusProvider = Provider.of<StatusProvider>(context);
     final appConfigProvider = Provider.of<AppConfigProvider>(context);
     final filtersProvider = Provider.of<FiltersProvider>(context);
+    const topk = 10;
 
     void navigateFilter(String value) {
       if (type == 'clients') {
@@ -257,14 +258,19 @@ class StatisticsListContent extends StatelessWidget {
         children: [
           if (statusProvider.getRealtimeStatus!.topSources.isNotEmpty)
             generateList(
-              statusProvider.getRealtimeStatus!.topSources,
+              Map.fromEntries(
+                statusProvider.getRealtimeStatus!.topSources.entries.take(topk),
+              ),
               AppLocalizations.of(context)!.topClients,
             )
           else
             NoDataChart(topLabel: AppLocalizations.of(context)!.topClients),
           if (statusProvider.getRealtimeStatus!.topSourcesBlocked.isNotEmpty)
             generateList(
-              statusProvider.getRealtimeStatus!.topSourcesBlocked,
+              Map.fromEntries(
+                statusProvider.getRealtimeStatus!.topSourcesBlocked.entries
+                    .take(topk),
+              ),
               AppLocalizations.of(context)!.topClientsBlocked,
             )
           else

--- a/lib/services/status_update_service.dart
+++ b/lib/services/status_update_service.dart
@@ -35,6 +35,26 @@ class StatusUpdateService {
 
   bool get isAutoRefreshRunning => _isAutoRefreshRunning;
 
+  /// Extracts client names from the RealtimeStatusResponse and sets them in the filters provider.
+  ///
+  /// In topSources, client keys are formatted as either:
+  /// - `hostname|ip`  (if hostname is available)
+  /// - `ip`           (if no hostname is available)
+  ///
+  /// This method extracts only the hostname part when available.
+  /// If no hostname is present, the IP address is used as-is.
+  void setClientsFromTopSources(RealtimeStatusResponse statusResult) {
+    final rawClients = statusResult.data!.topSources.keys.toList();
+    final clients = rawClients.map((client) {
+      if (client.contains('|')) {
+        return client.split('|')[0];
+      } else {
+        return client;
+      }
+    }).toList();
+    _filtersProvider.setClients(List<String>.from(clients));
+  }
+
   /// Start timer for auto refresh
   void startAutoRefresh() {
     if (!_isAutoRefreshRunning) {
@@ -100,10 +120,13 @@ class StatusUpdateService {
     if (_serversProvider.selectedServer == null) return false;
 
     final apiGateway = _serversProvider.selectedApiGateway;
-    final statusResult = await apiGateway?.realtimeStatus();
+    final statusResult = await apiGateway?.realtimeStatus(clientCount: 0);
 
     if (statusResult?.result == APiResponseType.success) {
       _statusProvider.setRealtimeStatus(statusResult!.data!);
+
+      setClientsFromTopSources(statusResult);
+
       _serversProvider.updateselectedServerStatus(
         statusResult.data!.status == 'enabled',
       );
@@ -124,11 +147,6 @@ class StatusUpdateService {
       _statusProvider.setOvertimeData(statusResult!.data!);
       _statusProvider.setOvertimeDataLoadingStatus(1);
       _statusProvider.setStatusLoading(LoadStatus.loaded);
-
-      final List<String?> clients = statusResult.data!.clients.map((client) {
-        return client.name.isNotEmpty ? client.name : client.ip;
-      }).toList();
-      _filtersProvider.setClients(List<String>.from(clients));
 
       return true;
     } else {
@@ -174,13 +192,15 @@ class StatusUpdateService {
       final selectedUrlBefore = currentServer.address;
 
       final apiGateway = _serversProvider.selectedApiGateway;
-      final statusResult = await apiGateway?.realtimeStatus();
+      final statusResult = await apiGateway?.realtimeStatus(clientCount: 0);
 
       if (statusResult?.result == APiResponseType.success) {
         _serversProvider.updateselectedServerStatus(
           statusResult!.data!.status == 'enabled',
         );
         _statusProvider.setRealtimeStatus(statusResult.data!);
+
+        setClientsFromTopSources(statusResult);
 
         if (!_statusProvider.isServerConnected) {
           _statusProvider.setIsServerConnected(true);
@@ -224,11 +244,6 @@ class StatusUpdateService {
 
       if (statusResult?.result == APiResponseType.success) {
         _statusProvider.setOvertimeData(statusResult!.data!);
-
-        final List<String?> clients = statusResult.data!.clients.map((client) {
-          return client.name.isNotEmpty ? client.name : client.ip;
-        }).toList();
-        _filtersProvider.setClients(List<String>.from(clients));
 
         _statusProvider.setOvertimeDataLoadingStatus(1);
 

--- a/lib/services/status_update_service.dart
+++ b/lib/services/status_update_service.dart
@@ -44,14 +44,9 @@ class StatusUpdateService {
   /// This method extracts only the hostname part when available.
   /// If no hostname is present, the IP address is used as-is.
   void setClientsFromTopSources(RealtimeStatusResponse statusResult) {
-    final rawClients = statusResult.data!.topSources.keys.toList();
-    final clients = rawClients.map((client) {
-      if (client.contains('|')) {
-        return client.split('|')[0];
-      } else {
-        return client;
-      }
-    }).toList();
+    final clients = statusResult.data!.topSources.keys
+        .map((client) => client.split('|').first)
+        .toList();
     _filtersProvider.setClients(List<String>.from(clients));
   }
 

--- a/test/ut/gateways/v6/api_gateway_v6_test.dart
+++ b/test/ut/gateways/v6/api_gateway_v6_test.dart
@@ -787,13 +787,218 @@ void main() async {
       for (var i = 0; i < urls.length; i++) {
         when(
           mockClient.get(
-            Uri.parse(urls[i]),
+            urls[i] == 'http://example.com/api/stats/top_clients'
+                ? Uri.parse('http://example.com/api/stats/top_clients?count=10')
+                : Uri.parse(urls[i]),
             headers: anyNamed('headers'),
           ),
         ).thenAnswer((_) async => http.Response(jsonEncode(data[i]), 200));
       }
 
       final response = await apiGateway.realtimeStatus();
+
+      expect(response.result, APiResponseType.success);
+      expect(response.data, isNotNull);
+    });
+
+    test('Return success with count params', () async {
+      final mockClient = MockClient();
+      final apiGateway = ApiGatewayV6(server, client: mockClient);
+      final data = [
+        {
+          'queries': {
+            'total': 7497,
+            'blocked': 3465,
+            'percent_blocked': 34.5,
+            'unique_domains': 445,
+            'forwarded': 4574,
+            'cached': 9765,
+            'types': {
+              'A': 3643,
+              'AAAA': 123,
+              'ANY': 3423,
+              'SRV': 345,
+              'SOA': 7567,
+              'PTR': 456,
+              'TXT': 85,
+              'NAPTR': 346,
+              'MX': 457,
+              'DS': 456,
+              'RRSIG': 345,
+              'DNSKEY': 55,
+              'NS': 868,
+              'SVCB': 645,
+              'HTTPS': 4,
+              'OTHER': 845,
+            },
+            'status': {
+              'UNKNOWN': 3,
+              'GRAVITY': 72,
+              'FORWARDED': 533,
+              'CACHE': 32,
+              'REGEX': 84,
+              'DENYLIST': 31,
+              'EXTERNAL_BLOCKED_IP': 0,
+              'EXTERNAL_BLOCKED_NULL': 0,
+              'EXTERNAL_BLOCKED_NXRA': 0,
+              'GRAVITY_CNAME': 0,
+              'REGEX_CNAME': 0,
+              'DENYLIST_CNAME': 0,
+              'RETRIED': 0,
+              'RETRIED_DNSSEC': 0,
+              'IN_PROGRESS': 0,
+              'DBBUSY': 0,
+              'SPECIAL_DOMAIN': 0,
+              'CACHE_STALE': 0,
+            },
+            'replies': {
+              'UNKNOWN': 3,
+              'NODATA': 72,
+              'NXDOMAIN': 533,
+              'CNAME': 32,
+              'IP': 84,
+              'DOMAIN': 31,
+              'RRNAME': 0,
+              'SERVFAIL': 0,
+              'REFUSED': 0,
+              'NOTIMP': 0,
+              'OTHER': 0,
+              'DNSSEC': 31,
+              'NONE': 0,
+              'BLOB': 0,
+            },
+          },
+          'clients': {'active': 10, 'total': 22},
+          'gravity': {
+            'domains_being_blocked': 104756,
+            'last_update': 1725194639,
+          },
+          'took': 0.003,
+        },
+        {
+          'ftl': {
+            'database': {
+              'gravity': 67906,
+              'groups': 6,
+              'lists': 1,
+              'clients': 5,
+              'domains': {'allowed': 10, 'denied': 3},
+            },
+            'privacy_level': 0,
+            'clients': {'total': 10, 'active': 8},
+            'pid': 1234,
+            'uptime': 123456789,
+            '%mem': 0.1,
+            '%cpu': 1.2,
+            'allow_destructive': true,
+            'dnsmasq': {
+              'dns_cache_inserted': 8,
+              'dns_cache_live_freed': 0,
+              'dns_queries_forwarded': 2,
+              'dns_auth_answered': 0,
+              'dns_local_answered': 74,
+              'dns_stale_answered': 0,
+              'dns_unanswered': 0,
+              'bootp': 0,
+              'pxe': 0,
+              'dhcp_ack': 0,
+              'dhcp_decline': 0,
+              'dhcp_discover': 0,
+              'dhcp_inform': 0,
+              'dhcp_nak': 0,
+              'dhcp_offer': 0,
+              'dhcp_release': 0,
+              'dhcp_request': 0,
+              'noanswer': 0,
+              'leases_allocated_4': 0,
+              'leases_pruned_4': 0,
+              'leases_allocated_6': 0,
+              'leases_pruned_6': 0,
+              'tcp_connections': 0,
+              'dnssec_max_crypto_use': 0,
+              'dnssec_max_sig_fail': 0,
+              'dnssec_max_work': 0,
+            },
+          },
+          'took': 0.003,
+        },
+        {'blocking': 'enabled', 'timer': 15, 'took': 0.003},
+        {
+          'domains': [
+            {'domain': 'pi-hole.net', 'count': 8516},
+          ],
+          'total_queries': 29160,
+          'blocked_queries': 6379,
+          'took': 0.003,
+        },
+        {
+          'domains': [
+            {'domain': 'pi-hole.net', 'count': 8516},
+          ],
+          'total_queries': 29160,
+          'blocked_queries': 6379,
+          'took': 0.003,
+        },
+        {
+          'clients': [
+            {'ip': '192.168.0.44', 'name': 'raspberrypi.lan', 'count': 5896},
+          ],
+          'total_queries': 29160,
+          'blocked_queries': 6379,
+          'took': 0.003,
+        },
+        {
+          'clients': [
+            {'ip': '192.168.0.44', 'name': 'raspberrypi.lan', 'count': 5896},
+          ],
+          'total_queries': 29160,
+          'blocked_queries': 6379,
+          'took': 0.003,
+        },
+        {
+          'upstreams': [
+            {
+              'ip': 'blocklist',
+              'name': 'blocklist',
+              'port': -1,
+              'count': 0,
+              'statistics': {'response': 0, 'variance': 0},
+            },
+            {
+              'ip': 'cache',
+              'name': 'cache',
+              'port': -1,
+              'count': 2,
+              'statistics': {'response': 0, 'variance': 0},
+            },
+            {
+              'ip': '8.8.8.8',
+              'name': 'dns.google',
+              'port': 53,
+              'count': 8,
+              'statistics': {
+                'response': 0.0516872935824924,
+                'variance': 0.0049697216173868828,
+              },
+            },
+          ],
+          'total_queries': 8,
+          'forwarded_queries': 6,
+          'took': 5.6982040405273438e-05,
+        },
+      ];
+      for (var i = 0; i < urls.length; i++) {
+        when(
+          mockClient.get(
+            urls[i] == 'http://example.com/api/stats/top_clients'
+                ? Uri.parse('http://example.com/api/stats/top_clients?count=1')
+                : Uri.parse(urls[i]),
+            headers: anyNamed('headers'),
+          ),
+        ).thenAnswer((_) async => http.Response(jsonEncode(data[i]), 200));
+      }
+
+      final response = await apiGateway.realtimeStatus(clientCount: 1);
 
       expect(response.result, APiResponseType.success);
       expect(response.data, isNotNull);

--- a/test/ut/gateways/v6/api_gateway_v6_test.dart
+++ b/test/ut/gateways/v6/api_gateway_v6_test.dart
@@ -985,16 +985,92 @@ void main() async {
         },
       ];
 
-      for (var i = 0; i < urls.length; i++) {
-        when(
-          mockClient.get(
-            Uri.parse(urls[i]),
-            headers: anyNamed('headers'),
-          ),
-        ).thenAnswer((_) async => http.Response(jsonEncode(data[i]), 200));
-      }
+      when(
+        mockClient.get(
+          Uri.parse(urls[0]),
+          headers: anyNamed('headers'),
+        ),
+      ).thenAnswer((_) async => http.Response(jsonEncode(data[0]), 200));
+
+      when(
+        mockClient.get(
+          Uri.parse('${urls[1]}?N=10'),
+          headers: anyNamed('headers'),
+        ),
+      ).thenAnswer((_) async => http.Response(jsonEncode(data[1]), 200));
 
       final response = await apiGateway.fetchOverTimeData();
+
+      expect(response.result, APiResponseType.success);
+      expect(response.data, isNotNull);
+    });
+
+    test('Return success with N params', () async {
+      final mockClient = MockClient();
+      final apiGateway = ApiGatewayV6(server, client: mockClient);
+      final data = [
+        {
+          'history': [
+            {
+              'timestamp': 1511819900.539157,
+              'total': 2134,
+              'cached': 525,
+              'blocked': 413,
+              'forwarded': 1196,
+            },
+            {
+              'timestamp': 1511820500.583821,
+              'total': 2014,
+              'cached': 52,
+              'blocked': 43,
+              'forwarded': 1910,
+            },
+          ],
+          'took': 0.003,
+        },
+        {
+          'clients': {
+            '127.0.0.1': {'name': 'localhost', 'total': 13428},
+            '::1': {'name': 'ip6-localnet', 'total': 2100},
+            '192.168.1.1': {'name': null, 'total': 254},
+            '::': {'name': 'pi.hole', 'total': 29},
+            '0.0.0.0': {'name': 'other clients', 'total': 14},
+          },
+          'history': [
+            {
+              'timestamp': 1511819900.539157,
+              'data': {
+                '127.0.0.1': 35,
+                '::1': 63,
+                '192.168.1.1': 20,
+                '::': 9,
+                '0.0.0.0': 0,
+              },
+            },
+            {
+              'timestamp': 1511820500.583821,
+              'data': {'127.0.0.1': 10, '::1': 44, '192.168.1.1': 56, '::': 52},
+            },
+          ],
+          'took': 0.003,
+        },
+      ];
+
+      when(
+        mockClient.get(
+          Uri.parse(urls[0]),
+          headers: anyNamed('headers'),
+        ),
+      ).thenAnswer((_) async => http.Response(jsonEncode(data[0]), 200));
+
+      when(
+        mockClient.get(
+          Uri.parse('${urls[1]}?N=5'),
+          headers: anyNamed('headers'),
+        ),
+      ).thenAnswer((_) async => http.Response(jsonEncode(data[1]), 200));
+
+      final response = await apiGateway.fetchOverTimeData(clientCount: 5);
 
       expect(response.result, APiResponseType.success);
       expect(response.data, isNotNull);

--- a/test/ut/providers/domains_list_provider_test.mocks.dart
+++ b/test/ut/providers/domains_list_provider_test.mocks.dart
@@ -787,6 +787,15 @@ class MockApiGatewayV6 extends _i1.Mock implements _i13.ApiGatewayV6 {
       ) as _i10.Future<_i4.StreamedResponse>);
 
   @override
+  void close() => super.noSuchMethod(
+        Invocation.method(
+          #close,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
   _i10.Future<_i5.LoginQueryResponse> loginQuery({bool? refresh = false}) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -806,11 +815,12 @@ class MockApiGatewayV6 extends _i1.Mock implements _i13.ApiGatewayV6 {
       ) as _i10.Future<_i5.LoginQueryResponse>);
 
   @override
-  _i10.Future<_i5.RealtimeStatusResponse> realtimeStatus() =>
+  _i10.Future<_i5.RealtimeStatusResponse> realtimeStatus({int? clientCount}) =>
       (super.noSuchMethod(
         Invocation.method(
           #realtimeStatus,
           [],
+          {#clientCount: clientCount},
         ),
         returnValue: _i10.Future<_i5.RealtimeStatusResponse>.value(
             _FakeRealtimeStatusResponse_5(
@@ -818,6 +828,7 @@ class MockApiGatewayV6 extends _i1.Mock implements _i13.ApiGatewayV6 {
           Invocation.method(
             #realtimeStatus,
             [],
+            {#clientCount: clientCount},
           ),
         )),
       ) as _i10.Future<_i5.RealtimeStatusResponse>);
@@ -857,11 +868,13 @@ class MockApiGatewayV6 extends _i1.Mock implements _i13.ApiGatewayV6 {
       ) as _i10.Future<_i5.EnableServerResponse>);
 
   @override
-  _i10.Future<_i5.FetchOverTimeDataResponse> fetchOverTimeData() =>
+  _i10.Future<_i5.FetchOverTimeDataResponse> fetchOverTimeData(
+          {int? clientCount}) =>
       (super.noSuchMethod(
         Invocation.method(
           #fetchOverTimeData,
           [],
+          {#clientCount: clientCount},
         ),
         returnValue: _i10.Future<_i5.FetchOverTimeDataResponse>.value(
             _FakeFetchOverTimeDataResponse_8(
@@ -869,6 +882,7 @@ class MockApiGatewayV6 extends _i1.Mock implements _i13.ApiGatewayV6 {
           Invocation.method(
             #fetchOverTimeData,
             [],
+            {#clientCount: clientCount},
           ),
         )),
       ) as _i10.Future<_i5.FetchOverTimeDataResponse>);

--- a/test/ut/providers/gravity_provider_test.mocks.dart
+++ b/test/ut/providers/gravity_provider_test.mocks.dart
@@ -1147,6 +1147,15 @@ class MockApiGatewayV6 extends _i1.Mock implements _i15.ApiGatewayV6 {
       ) as _i12.Future<_i6.StreamedResponse>);
 
   @override
+  void close() => super.noSuchMethod(
+        Invocation.method(
+          #close,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
   _i12.Future<_i7.LoginQueryResponse> loginQuery({bool? refresh = false}) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -1166,11 +1175,12 @@ class MockApiGatewayV6 extends _i1.Mock implements _i15.ApiGatewayV6 {
       ) as _i12.Future<_i7.LoginQueryResponse>);
 
   @override
-  _i12.Future<_i7.RealtimeStatusResponse> realtimeStatus() =>
+  _i12.Future<_i7.RealtimeStatusResponse> realtimeStatus({int? clientCount}) =>
       (super.noSuchMethod(
         Invocation.method(
           #realtimeStatus,
           [],
+          {#clientCount: clientCount},
         ),
         returnValue: _i12.Future<_i7.RealtimeStatusResponse>.value(
             _FakeRealtimeStatusResponse_8(
@@ -1178,6 +1188,7 @@ class MockApiGatewayV6 extends _i1.Mock implements _i15.ApiGatewayV6 {
           Invocation.method(
             #realtimeStatus,
             [],
+            {#clientCount: clientCount},
           ),
         )),
       ) as _i12.Future<_i7.RealtimeStatusResponse>);
@@ -1217,11 +1228,13 @@ class MockApiGatewayV6 extends _i1.Mock implements _i15.ApiGatewayV6 {
       ) as _i12.Future<_i7.EnableServerResponse>);
 
   @override
-  _i12.Future<_i7.FetchOverTimeDataResponse> fetchOverTimeData() =>
+  _i12.Future<_i7.FetchOverTimeDataResponse> fetchOverTimeData(
+          {int? clientCount}) =>
       (super.noSuchMethod(
         Invocation.method(
           #fetchOverTimeData,
           [],
+          {#clientCount: clientCount},
         ),
         returnValue: _i12.Future<_i7.FetchOverTimeDataResponse>.value(
             _FakeFetchOverTimeDataResponse_11(
@@ -1229,6 +1242,7 @@ class MockApiGatewayV6 extends _i1.Mock implements _i15.ApiGatewayV6 {
           Invocation.method(
             #fetchOverTimeData,
             [],
+            {#clientCount: clientCount},
           ),
         )),
       ) as _i12.Future<_i7.FetchOverTimeDataResponse>);

--- a/test/ut/providers/groups_provider_test.mocks.dart
+++ b/test/ut/providers/groups_provider_test.mocks.dart
@@ -787,6 +787,15 @@ class MockApiGatewayV6 extends _i1.Mock implements _i13.ApiGatewayV6 {
       ) as _i10.Future<_i4.StreamedResponse>);
 
   @override
+  void close() => super.noSuchMethod(
+        Invocation.method(
+          #close,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
   _i10.Future<_i5.LoginQueryResponse> loginQuery({bool? refresh = false}) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -806,11 +815,12 @@ class MockApiGatewayV6 extends _i1.Mock implements _i13.ApiGatewayV6 {
       ) as _i10.Future<_i5.LoginQueryResponse>);
 
   @override
-  _i10.Future<_i5.RealtimeStatusResponse> realtimeStatus() =>
+  _i10.Future<_i5.RealtimeStatusResponse> realtimeStatus({int? clientCount}) =>
       (super.noSuchMethod(
         Invocation.method(
           #realtimeStatus,
           [],
+          {#clientCount: clientCount},
         ),
         returnValue: _i10.Future<_i5.RealtimeStatusResponse>.value(
             _FakeRealtimeStatusResponse_5(
@@ -818,6 +828,7 @@ class MockApiGatewayV6 extends _i1.Mock implements _i13.ApiGatewayV6 {
           Invocation.method(
             #realtimeStatus,
             [],
+            {#clientCount: clientCount},
           ),
         )),
       ) as _i10.Future<_i5.RealtimeStatusResponse>);
@@ -857,11 +868,13 @@ class MockApiGatewayV6 extends _i1.Mock implements _i13.ApiGatewayV6 {
       ) as _i10.Future<_i5.EnableServerResponse>);
 
   @override
-  _i10.Future<_i5.FetchOverTimeDataResponse> fetchOverTimeData() =>
+  _i10.Future<_i5.FetchOverTimeDataResponse> fetchOverTimeData(
+          {int? clientCount}) =>
       (super.noSuchMethod(
         Invocation.method(
           #fetchOverTimeData,
           [],
+          {#clientCount: clientCount},
         ),
         returnValue: _i10.Future<_i5.FetchOverTimeDataResponse>.value(
             _FakeFetchOverTimeDataResponse_8(
@@ -869,6 +882,7 @@ class MockApiGatewayV6 extends _i1.Mock implements _i13.ApiGatewayV6 {
           Invocation.method(
             #fetchOverTimeData,
             [],
+            {#clientCount: clientCount},
           ),
         )),
       ) as _i10.Future<_i5.FetchOverTimeDataResponse>);

--- a/test/ut/providers/subscriptions_list_provider_test.mocks.dart
+++ b/test/ut/providers/subscriptions_list_provider_test.mocks.dart
@@ -787,6 +787,15 @@ class MockApiGatewayV6 extends _i1.Mock implements _i13.ApiGatewayV6 {
       ) as _i10.Future<_i4.StreamedResponse>);
 
   @override
+  void close() => super.noSuchMethod(
+        Invocation.method(
+          #close,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
   _i10.Future<_i5.LoginQueryResponse> loginQuery({bool? refresh = false}) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -806,11 +815,12 @@ class MockApiGatewayV6 extends _i1.Mock implements _i13.ApiGatewayV6 {
       ) as _i10.Future<_i5.LoginQueryResponse>);
 
   @override
-  _i10.Future<_i5.RealtimeStatusResponse> realtimeStatus() =>
+  _i10.Future<_i5.RealtimeStatusResponse> realtimeStatus({int? clientCount}) =>
       (super.noSuchMethod(
         Invocation.method(
           #realtimeStatus,
           [],
+          {#clientCount: clientCount},
         ),
         returnValue: _i10.Future<_i5.RealtimeStatusResponse>.value(
             _FakeRealtimeStatusResponse_5(
@@ -818,6 +828,7 @@ class MockApiGatewayV6 extends _i1.Mock implements _i13.ApiGatewayV6 {
           Invocation.method(
             #realtimeStatus,
             [],
+            {#clientCount: clientCount},
           ),
         )),
       ) as _i10.Future<_i5.RealtimeStatusResponse>);
@@ -857,11 +868,13 @@ class MockApiGatewayV6 extends _i1.Mock implements _i13.ApiGatewayV6 {
       ) as _i10.Future<_i5.EnableServerResponse>);
 
   @override
-  _i10.Future<_i5.FetchOverTimeDataResponse> fetchOverTimeData() =>
+  _i10.Future<_i5.FetchOverTimeDataResponse> fetchOverTimeData(
+          {int? clientCount}) =>
       (super.noSuchMethod(
         Invocation.method(
           #fetchOverTimeData,
           [],
+          {#clientCount: clientCount},
         ),
         returnValue: _i10.Future<_i5.FetchOverTimeDataResponse>.value(
             _FakeFetchOverTimeDataResponse_8(
@@ -869,6 +882,7 @@ class MockApiGatewayV6 extends _i1.Mock implements _i13.ApiGatewayV6 {
           Invocation.method(
             #fetchOverTimeData,
             [],
+            {#clientCount: clientCount},
           ),
         )),
       ) as _i10.Future<_i5.FetchOverTimeDataResponse>);

--- a/test/ut/services/status_update_service_test.dart
+++ b/test/ut/services/status_update_service_test.dart
@@ -73,7 +73,11 @@ void main() async {
 
       when(mockFiltersProvider.setClients(any)).thenReturn(null);
 
-      when(mockApiGatewayV6.realtimeStatus()).thenAnswer(
+      when(
+        mockApiGatewayV6.realtimeStatus(
+          clientCount: anyNamed('clientCount'),
+        ),
+      ).thenAnswer(
         (_) async => RealtimeStatusResponse(
           result: APiResponseType.success,
           data: realtimeStatus,
@@ -139,7 +143,11 @@ void main() async {
     test(
         'startAutoRefresh should fail when fetching data from the server fails',
         () async {
-      when(mockApiGatewayV6.realtimeStatus()).thenAnswer(
+      when(
+        mockApiGatewayV6.realtimeStatus(
+          clientCount: anyNamed('clientCount'),
+        ),
+      ).thenAnswer(
         (_) async => RealtimeStatusResponse(
           result: APiResponseType.socket,
         ),
@@ -175,7 +183,11 @@ void main() async {
     test(
         'startAutoRefresh should not raise a type error when selectedServer becomes null during asynchronous processing in _setupStatusDataTimer',
         () async {
-      when(mockApiGatewayV6.realtimeStatus()).thenAnswer((_) async {
+      when(
+        mockApiGatewayV6.realtimeStatus(
+          clientCount: anyNamed('clientCount'),
+        ),
+      ).thenAnswer((_) async {
         when(mockServersProvider.selectedServer).thenReturn(null);
         return RealtimeStatusResponse(
           result: APiResponseType.socket,
@@ -232,7 +244,11 @@ void main() async {
 
     test('refreshOnce should succeed', () async {
       await statusUpdateService.refreshOnce();
-      verify(mockApiGatewayV6.realtimeStatus()).called(1);
+      verify(
+        mockApiGatewayV6.realtimeStatus(
+          clientCount: anyNamed('clientCount'),
+        ),
+      ).called(1);
       verify(mockApiGatewayV6.fetchOverTimeData()).called(1);
       verify(mockServersProvider.updateselectedServerStatus(any)).called(1);
       verify(mockStatusProvider.setRealtimeStatus(any)).called(1);
@@ -241,7 +257,11 @@ void main() async {
 
     test('refreshOnce should fail when fetching data from the server fails',
         () async {
-      when(mockApiGatewayV6.realtimeStatus()).thenAnswer(
+      when(
+        mockApiGatewayV6.realtimeStatus(
+          clientCount: anyNamed('clientCount'),
+        ),
+      ).thenAnswer(
         (_) async => RealtimeStatusResponse(
           result: APiResponseType.socket,
         ),
@@ -254,7 +274,11 @@ void main() async {
       );
 
       await statusUpdateService.refreshOnce();
-      verify(mockApiGatewayV6.realtimeStatus()).called(1);
+      verify(
+        mockApiGatewayV6.realtimeStatus(
+          clientCount: anyNamed('clientCount'),
+        ),
+      ).called(1);
       verify(mockApiGatewayV6.fetchOverTimeData()).called(1);
       verifyNever(mockServersProvider.updateselectedServerStatus(any))
           .called(0);

--- a/test/ut/services/status_update_service_test.mocks.dart
+++ b/test/ut/services/status_update_service_test.mocks.dart
@@ -1522,6 +1522,15 @@ class MockApiGatewayV6 extends _i1.Mock implements _i25.ApiGatewayV6 {
       ) as _i12.Future<_i4.StreamedResponse>);
 
   @override
+  void close() => super.noSuchMethod(
+        Invocation.method(
+          #close,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
   _i12.Future<_i5.LoginQueryResponse> loginQuery({bool? refresh = false}) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -1541,11 +1550,12 @@ class MockApiGatewayV6 extends _i1.Mock implements _i25.ApiGatewayV6 {
       ) as _i12.Future<_i5.LoginQueryResponse>);
 
   @override
-  _i12.Future<_i5.RealtimeStatusResponse> realtimeStatus() =>
+  _i12.Future<_i5.RealtimeStatusResponse> realtimeStatus({int? clientCount}) =>
       (super.noSuchMethod(
         Invocation.method(
           #realtimeStatus,
           [],
+          {#clientCount: clientCount},
         ),
         returnValue: _i12.Future<_i5.RealtimeStatusResponse>.value(
             _FakeRealtimeStatusResponse_5(
@@ -1553,6 +1563,7 @@ class MockApiGatewayV6 extends _i1.Mock implements _i25.ApiGatewayV6 {
           Invocation.method(
             #realtimeStatus,
             [],
+            {#clientCount: clientCount},
           ),
         )),
       ) as _i12.Future<_i5.RealtimeStatusResponse>);
@@ -1592,11 +1603,13 @@ class MockApiGatewayV6 extends _i1.Mock implements _i25.ApiGatewayV6 {
       ) as _i12.Future<_i5.EnableServerResponse>);
 
   @override
-  _i12.Future<_i5.FetchOverTimeDataResponse> fetchOverTimeData() =>
+  _i12.Future<_i5.FetchOverTimeDataResponse> fetchOverTimeData(
+          {int? clientCount}) =>
       (super.noSuchMethod(
         Invocation.method(
           #fetchOverTimeData,
           [],
+          {#clientCount: clientCount},
         ),
         returnValue: _i12.Future<_i5.FetchOverTimeDataResponse>.value(
             _FakeFetchOverTimeDataResponse_8(
@@ -1604,6 +1617,7 @@ class MockApiGatewayV6 extends _i1.Mock implements _i25.ApiGatewayV6 {
           Invocation.method(
             #fetchOverTimeData,
             [],
+            {#clientCount: clientCount},
           ),
         )),
       ) as _i12.Future<_i5.FetchOverTimeDataResponse>);

--- a/test/widgets/helpers.dart
+++ b/test/widgets/helpers.dart
@@ -1991,7 +1991,8 @@ class TestSetupHelper {
       ),
     );
 
-    when(mockApiGatewayV6.realtimeStatus()).thenAnswer(
+    when(mockApiGatewayV6.realtimeStatus(clientCount: anyNamed('clientCount')))
+        .thenAnswer(
       (_) async => RealtimeStatusResponse(
         result: APiResponseType.success,
         data: realtimeStatus,

--- a/test/widgets/helpers.mocks.dart
+++ b/test/widgets/helpers.mocks.dart
@@ -1658,6 +1658,15 @@ class MockApiGatewayV5 extends _i1.Mock implements _i27.ApiGatewayV5 {
       ) as _i12.Future<_i4.Response>);
 
   @override
+  void close() => super.noSuchMethod(
+        Invocation.method(
+          #close,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
   _i12.Future<_i5.LoginQueryResponse> loginQuery({bool? refresh = false}) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -1677,11 +1686,12 @@ class MockApiGatewayV5 extends _i1.Mock implements _i27.ApiGatewayV5 {
       ) as _i12.Future<_i5.LoginQueryResponse>);
 
   @override
-  _i12.Future<_i5.RealtimeStatusResponse> realtimeStatus() =>
+  _i12.Future<_i5.RealtimeStatusResponse> realtimeStatus({int? clientCount}) =>
       (super.noSuchMethod(
         Invocation.method(
           #realtimeStatus,
           [],
+          {#clientCount: clientCount},
         ),
         returnValue: _i12.Future<_i5.RealtimeStatusResponse>.value(
             _FakeRealtimeStatusResponse_4(
@@ -1689,6 +1699,7 @@ class MockApiGatewayV5 extends _i1.Mock implements _i27.ApiGatewayV5 {
           Invocation.method(
             #realtimeStatus,
             [],
+            {#clientCount: clientCount},
           ),
         )),
       ) as _i12.Future<_i5.RealtimeStatusResponse>);
@@ -1728,11 +1739,13 @@ class MockApiGatewayV5 extends _i1.Mock implements _i27.ApiGatewayV5 {
       ) as _i12.Future<_i5.EnableServerResponse>);
 
   @override
-  _i12.Future<_i5.FetchOverTimeDataResponse> fetchOverTimeData() =>
+  _i12.Future<_i5.FetchOverTimeDataResponse> fetchOverTimeData(
+          {int? clientCount}) =>
       (super.noSuchMethod(
         Invocation.method(
           #fetchOverTimeData,
           [],
+          {#clientCount: clientCount},
         ),
         returnValue: _i12.Future<_i5.FetchOverTimeDataResponse>.value(
             _FakeFetchOverTimeDataResponse_7(
@@ -1740,6 +1753,7 @@ class MockApiGatewayV5 extends _i1.Mock implements _i27.ApiGatewayV5 {
           Invocation.method(
             #fetchOverTimeData,
             [],
+            {#clientCount: clientCount},
           ),
         )),
       ) as _i12.Future<_i5.FetchOverTimeDataResponse>);
@@ -2582,6 +2596,15 @@ class MockApiGatewayV6 extends _i1.Mock implements _i31.ApiGatewayV6 {
       ) as _i12.Future<_i4.StreamedResponse>);
 
   @override
+  void close() => super.noSuchMethod(
+        Invocation.method(
+          #close,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
   _i12.Future<_i5.LoginQueryResponse> loginQuery({bool? refresh = false}) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -2601,11 +2624,12 @@ class MockApiGatewayV6 extends _i1.Mock implements _i31.ApiGatewayV6 {
       ) as _i12.Future<_i5.LoginQueryResponse>);
 
   @override
-  _i12.Future<_i5.RealtimeStatusResponse> realtimeStatus() =>
+  _i12.Future<_i5.RealtimeStatusResponse> realtimeStatus({int? clientCount}) =>
       (super.noSuchMethod(
         Invocation.method(
           #realtimeStatus,
           [],
+          {#clientCount: clientCount},
         ),
         returnValue: _i12.Future<_i5.RealtimeStatusResponse>.value(
             _FakeRealtimeStatusResponse_4(
@@ -2613,6 +2637,7 @@ class MockApiGatewayV6 extends _i1.Mock implements _i31.ApiGatewayV6 {
           Invocation.method(
             #realtimeStatus,
             [],
+            {#clientCount: clientCount},
           ),
         )),
       ) as _i12.Future<_i5.RealtimeStatusResponse>);
@@ -2652,11 +2677,13 @@ class MockApiGatewayV6 extends _i1.Mock implements _i31.ApiGatewayV6 {
       ) as _i12.Future<_i5.EnableServerResponse>);
 
   @override
-  _i12.Future<_i5.FetchOverTimeDataResponse> fetchOverTimeData() =>
+  _i12.Future<_i5.FetchOverTimeDataResponse> fetchOverTimeData(
+          {int? clientCount}) =>
       (super.noSuchMethod(
         Invocation.method(
           #fetchOverTimeData,
           [],
+          {#clientCount: clientCount},
         ),
         returnValue: _i12.Future<_i5.FetchOverTimeDataResponse>.value(
             _FakeFetchOverTimeDataResponse_7(
@@ -2664,6 +2691,7 @@ class MockApiGatewayV6 extends _i1.Mock implements _i31.ApiGatewayV6 {
           Invocation.method(
             #fetchOverTimeData,
             [],
+            {#clientCount: clientCount},
           ),
         )),
       ) as _i12.Future<_i5.FetchOverTimeDataResponse>);
@@ -3378,6 +3406,16 @@ class MockStatusUpdateService extends _i1.Mock
         Invocation.getter(#isAutoRefreshRunning),
         returnValue: false,
       ) as bool);
+
+  @override
+  void setClientsFromTopSources(_i5.RealtimeStatusResponse? statusResult) =>
+      super.noSuchMethod(
+        Invocation.method(
+          #setClientsFromTopSources,
+          [statusResult],
+        ),
+        returnValueForMissingStub: null,
+      );
 
   @override
   void startAutoRefresh() => super.noSuchMethod(


### PR DESCRIPTION
## Overview

Partially addresses issue #313 

This PR resolves an issue where the Query Log would only display the top 9 clients. The "other clients" filter previously failed to load additional clients and their queries. This fix ensures all clients are displayed and the filter functions as expected.

## Changes:

- Updated Query Log client list retrieval to include all clients.
- Switched client list source from `fetchOverTimeData`to `realtimeStatus`.
- Delete `other clients`

