### PR TITLE
feat(settings/session): use skeleton loader instead of spinner

### DIFF
--- a/lib/screens/settings/server_settings/advanced_settings/sessions_screen.dart
+++ b/lib/screens/settings/server_settings/advanced_settings/sessions_screen.dart
@@ -87,27 +87,6 @@ class _SessionState extends State<SessionsScreen> {
     isLoading = false;
   }
 
-  Future<void> _loadSessions() async {
-    if (!mounted) return;
-
-    setState(() {
-      isLoading = true;
-    });
-
-    final result = await apiGateway!.getSessions();
-    if (!mounted) return;
-
-    setState(() {
-      if (result.result == APiResponseType.success) {
-        sessionsInfo = result.data;
-      } else {
-        isFetchError = true;
-        logger.e('Failed to load sessions');
-      }
-      isLoading = false;
-    });
-  }
-
   @override
   Widget build(BuildContext context) {
     if (apiGateway == null) {
@@ -213,5 +192,26 @@ class _SessionState extends State<SessionsScreen> {
         ),
       ),
     );
+  }
+
+  Future<void> _loadSessions() async {
+    if (!mounted) return;
+
+    setState(() {
+      isLoading = true;
+    });
+
+    final result = await apiGateway!.getSessions();
+    if (!mounted) return;
+
+    setState(() {
+      if (result.result == APiResponseType.success) {
+        sessionsInfo = result.data;
+      } else {
+        isFetchError = true;
+        logger.e('Failed to load sessions');
+      }
+      isLoading = false;
+    });
   }
 }

--- a/lib/screens/settings/server_settings/advanced_settings/sessions_screen.dart
+++ b/lib/screens/settings/server_settings/advanced_settings/sessions_screen.dart
@@ -18,7 +18,7 @@ import 'package:provider/provider.dart';
 import 'package:skeletonizer/skeletonizer.dart';
 
 // fake data for Skeletonizer
-final fakeSessionInfo = SessionInfo(
+final _fakeSessionInfo = SessionInfo(
   id: 0,
   isValid: false,
   isCurrentSession: false,
@@ -31,8 +31,8 @@ final fakeSessionInfo = SessionInfo(
   clientIp: '192.168.1.100',
   userAgent: 'Dart/3.7 (dart:io)',
 );
-final fakeSessionsInfo =
-    SessionsInfo(sessions: List.filled(5, fakeSessionInfo));
+final _fakeSessionsInfo =
+    SessionsInfo(sessions: List.filled(5, _fakeSessionInfo));
 
 /// A screen that displays session information to the user.
 ///
@@ -154,7 +154,7 @@ class _SessionState extends State<SessionsScreen> {
                     highlightColor: Theme.of(context).colorScheme.surface,
                   ),
                   child: SessionListView(
-                    sessionsInfo: fakeSessionsInfo,
+                    sessionsInfo: _fakeSessionsInfo,
                     onSessionTap: (session) {},
                   ),
                 );

--- a/lib/screens/settings/server_settings/advanced_settings/sessions_screen.dart
+++ b/lib/screens/settings/server_settings/advanced_settings/sessions_screen.dart
@@ -1,10 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:pi_hole_client/classes/custom_scroll_behavior.dart';
 import 'package:pi_hole_client/classes/process_modal.dart';
-import 'package:pi_hole_client/config/theme.dart';
 import 'package:pi_hole_client/constants/enums.dart';
-import 'package:pi_hole_client/constants/formats.dart';
-import 'package:pi_hole_client/functions/format.dart';
 import 'package:pi_hole_client/functions/logger.dart';
 import 'package:pi_hole_client/functions/snackbar.dart';
 import 'package:pi_hole_client/gateways/api_gateway_interface.dart';
@@ -15,8 +12,27 @@ import 'package:pi_hole_client/providers/app_config_provider.dart';
 import 'package:pi_hole_client/providers/servers_provider.dart';
 import 'package:pi_hole_client/screens/common/empty_data_screen.dart';
 import 'package:pi_hole_client/screens/settings/server_settings/advanced_settings/sessions_screen/session_detail_screen.dart';
+import 'package:pi_hole_client/screens/settings/server_settings/advanced_settings/sessions_screen/session_list_view.dart';
 import 'package:pi_hole_client/widgets/error_message.dart';
 import 'package:provider/provider.dart';
+import 'package:skeletonizer/skeletonizer.dart';
+
+// fake data for Skeletonizer
+final fakeSessionInfo = SessionInfo(
+  id: 0,
+  isValid: false,
+  isCurrentSession: false,
+  tlsStatus: TlsStatus.none,
+  isApp: false,
+  isCli: false,
+  loginAt: DateTime(2025, 6, 28, 12),
+  lastActive: DateTime(2025, 6, 28, 15),
+  validUntil: DateTime(2025, 6, 28, 17),
+  clientIp: '192.168.1.100',
+  userAgent: 'Dart/3.7 (dart:io)',
+);
+final fakeSessionsInfo =
+    SessionsInfo(sessions: List.filled(5, fakeSessionInfo));
 
 /// A screen that displays session information to the user.
 ///
@@ -94,8 +110,6 @@ class _SessionState extends State<SessionsScreen> {
 
   @override
   Widget build(BuildContext context) {
-    final theme = Theme.of(context).extension<AppColors>()!;
-
     if (apiGateway == null) {
       return Scaffold(
         appBar: AppBar(
@@ -104,55 +118,6 @@ class _SessionState extends State<SessionsScreen> {
         body: const SafeArea(
           child: EmptyDataScreen(),
         ),
-      );
-    }
-
-    Widget buildStatusIcon(bool isValid) {
-      if (isValid) {
-        return Icon(
-          Icons.check_rounded,
-          color: theme.queryGreen,
-        );
-      }
-
-      return Icon(
-        Icons.close_rounded,
-        color: theme.queryGrey,
-      );
-    }
-
-    Widget buildTlsLine(TlsStatus tlsStatus) {
-      IconData iconData;
-      Color iconColor;
-      String statusText;
-
-      switch (tlsStatus) {
-        case TlsStatus.none:
-          iconData = Icons.no_encryption_rounded;
-          iconColor = theme.queryGrey ?? Colors.grey;
-          statusText = AppLocalizations.of(context)!.off;
-        case TlsStatus.login:
-          iconData = Icons.lock_rounded;
-          iconColor = theme.queryGreen ?? Colors.green;
-          statusText = AppLocalizations.of(context)!.on;
-        case TlsStatus.mixed:
-          iconData = Icons.lock_rounded;
-          iconColor = theme.queryGreen ?? Colors.green;
-          statusText = AppLocalizations.of(context)!.on;
-      }
-
-      return Row(
-        children: [
-          Icon(iconData, size: 14, color: iconColor),
-          const SizedBox(width: 4),
-          Text(
-            'TLS: $statusText',
-            style: TextStyle(
-              fontSize: 12,
-              color: iconColor,
-            ),
-          ),
-        ],
       );
     }
 
@@ -204,8 +169,15 @@ class _SessionState extends State<SessionsScreen> {
           child: Builder(
             builder: (context) {
               if (isLoading) {
-                return const Center(
-                  child: CircularProgressIndicator(),
+                return Skeletonizer(
+                  effect: ShimmerEffect(
+                    baseColor: Theme.of(context).colorScheme.secondaryContainer,
+                    highlightColor: Theme.of(context).colorScheme.surface,
+                  ),
+                  child: SessionListView(
+                    sessionsInfo: fakeSessionsInfo,
+                    onSessionTap: (session) {},
+                  ),
                 );
               }
 
@@ -219,53 +191,20 @@ class _SessionState extends State<SessionsScreen> {
                 return const EmptyDataScreen();
               }
 
-              return ListView.builder(
-                padding: const EdgeInsets.only(top: 32),
-                itemCount: sessionsInfo!.sessions.length,
-                itemBuilder: (context, index) {
-                  final session = sessionsInfo!.sessions[index];
-                  return ListTile(
-                    leading: buildStatusIcon(session.isValid),
-                    title: Column(
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      mainAxisSize: MainAxisSize.min,
-                      children: [
-                        buildTlsLine(session.tlsStatus),
-                        Text(
-                          session.clientIp,
-                          style: const TextStyle(
-                            fontSize: 16,
-                            fontWeight: FontWeight.bold,
-                          ),
-                        ),
-                      ],
-                    ),
-                    subtitle: Text(
-                      formatTimestamp(
-                        session.validUntil,
-                        kUnifiedDateTimeLogFormat,
+              return SessionListView(
+                sessionsInfo: sessionsInfo!,
+                onSessionTap: (session) {
+                  setState(() {
+                    selectedSession = session;
+                  });
+                  Navigator.push(
+                    context,
+                    MaterialPageRoute(
+                      builder: (context) => SessionDetailScreen(
+                        session: session,
+                        onDelete: removeSession,
                       ),
                     ),
-                    trailing: session.isCurrentSession
-                        ? Chip(
-                            avatar: const Icon(Icons.star_rounded),
-                            label: Text(AppLocalizations.of(context)!.inUse),
-                          )
-                        : null,
-                    onTap: () {
-                      setState(() {
-                        selectedSession = session;
-                      });
-                      Navigator.push(
-                        context,
-                        MaterialPageRoute(
-                          builder: (context) => SessionDetailScreen(
-                            session: session,
-                            onDelete: removeSession,
-                          ),
-                        ),
-                      );
-                    },
                   );
                 },
               );

--- a/lib/screens/settings/server_settings/advanced_settings/sessions_screen/session_list_view.dart
+++ b/lib/screens/settings/server_settings/advanced_settings/sessions_screen/session_list_view.dart
@@ -1,0 +1,152 @@
+import 'package:flutter/material.dart';
+import 'package:pi_hole_client/config/theme.dart';
+import 'package:pi_hole_client/constants/enums.dart';
+import 'package:pi_hole_client/constants/formats.dart';
+import 'package:pi_hole_client/functions/format.dart';
+import 'package:pi_hole_client/l10n/generated/app_localizations.dart';
+import 'package:pi_hole_client/models/sessions.dart';
+
+/// A stateless widget that displays a list of active Pi-hole sessions with their
+/// status, IP address, TLS status, and expiration time.
+///
+/// Each session is represented as a [ListTile] displaying:
+/// - A status icon indicating whether the session is valid.
+/// - A TLS status row with an icon and localized label (On/Off).
+/// - The client IP address in bold.
+/// - A subtitle showing the session's expiration timestamp.
+/// - A trailing chip if the session is currently active.
+///
+/// Tapping a session triggers the optional [onSessionTap] callback with the
+/// selected [SessionInfo] instance.
+///
+/// {@tool snippet}
+/// Example usage:
+/// ```dart
+/// SessionListView(
+///   sessionsInfo: mySessionsInfo,
+///   onSessionTap: (session) {
+///     print('Selected: ${session.clientIp}');
+///   },
+/// )
+/// ```
+/// {@end-tool}
+class SessionListView extends StatelessWidget {
+  const SessionListView({
+    required this.sessionsInfo,
+    this.onSessionTap,
+    super.key,
+  });
+
+  final SessionsInfo sessionsInfo;
+  final void Function(SessionInfo)? onSessionTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return ListView.builder(
+      padding: const EdgeInsets.only(top: 32),
+      itemCount: sessionsInfo.sessions.length,
+      itemBuilder: (context, index) {
+        final session = sessionsInfo.sessions[index];
+        return ListTile(
+          leading: _buildStatusIcon(context, session.isValid),
+          title: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              _buildTlsLine(context, session.tlsStatus),
+              Text(
+                session.clientIp,
+                style: const TextStyle(
+                  fontSize: 16,
+                  fontWeight: FontWeight.bold,
+                ),
+              ),
+            ],
+          ),
+          subtitle: Text(
+            formatTimestamp(session.validUntil, kUnifiedDateTimeLogFormat),
+          ),
+          trailing: session.isCurrentSession
+              ? Chip(
+                  avatar: const Icon(Icons.star_rounded),
+                  label: Text(AppLocalizations.of(context)!.inUse),
+                )
+              : null,
+          onTap: () => onSessionTap?.call(session),
+        );
+      },
+    );
+  }
+
+  /// Builds a status icon indicating whether a session is valid or not.
+  ///
+  /// Displays a green check icon if [isValid] is true, otherwise displays a grey close icon.
+  /// The icon colors are retrieved from the current [AppColors] theme extension.
+  ///
+  /// [context] - The build context used to access theme data.
+  /// [isValid] - Whether the session is valid (true) or invalid (false).
+  ///
+  /// Returns an [Icon] widget representing the session status.
+  Widget _buildStatusIcon(BuildContext context, bool isValid) {
+    final theme = Theme.of(context).extension<AppColors>()!;
+
+    if (isValid) {
+      return Icon(
+        Icons.check_rounded,
+        color: theme.queryGreen,
+      );
+    }
+
+    return Icon(
+      Icons.close_rounded,
+      color: theme.queryGrey,
+    );
+  }
+
+  /// Builds a row widget displaying the TLS (Transport Layer Security) status.
+  ///
+  /// The row contains an icon and a text label indicating whether TLS is enabled or not,
+  /// based on the provided [tlsStatus]. The icon and text color are determined by the
+  /// current theme and the TLS status. The text is localized using [AppLocalizations].
+  ///
+  /// - [context]: The build context used to access theme and localization.
+  /// - [tlsStatus]: The current TLS status, which determines the icon, color, and label.
+  ///
+  /// Returns a [Row] widget with an icon and a text label describing the TLS status.
+  Widget _buildTlsLine(BuildContext context, TlsStatus tlsStatus) {
+    final theme = Theme.of(context).extension<AppColors>()!;
+
+    IconData iconData;
+    Color iconColor;
+    String statusText;
+
+    switch (tlsStatus) {
+      case TlsStatus.none:
+        iconData = Icons.no_encryption_rounded;
+        iconColor = theme.queryGrey ?? Colors.grey;
+        statusText = AppLocalizations.of(context)!.off;
+      case TlsStatus.login:
+        iconData = Icons.lock_rounded;
+        iconColor = theme.queryGreen ?? Colors.green;
+        statusText = AppLocalizations.of(context)!.on;
+      case TlsStatus.mixed:
+        iconData = Icons.lock_rounded;
+        iconColor = theme.queryGreen ?? Colors.green;
+        statusText = AppLocalizations.of(context)!.on;
+    }
+
+    return Row(
+      children: [
+        Icon(iconData, size: 14, color: iconColor),
+        const SizedBox(width: 4),
+        Text(
+          'TLS: $statusText',
+          style: TextStyle(
+            fontSize: 12,
+            color: iconColor,
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/screens/settings/server_settings/advanced_settings/sessions_screen/session_list_view.dart
+++ b/lib/screens/settings/server_settings/advanced_settings/sessions_screen/session_list_view.dart
@@ -126,9 +126,6 @@ class SessionListView extends StatelessWidget {
         iconColor = theme.queryGrey ?? Colors.grey;
         statusText = AppLocalizations.of(context)!.off;
       case TlsStatus.login:
-        iconData = Icons.lock_rounded;
-        iconColor = theme.queryGreen ?? Colors.green;
-        statusText = AppLocalizations.of(context)!.on;
       case TlsStatus.mixed:
         iconData = Icons.lock_rounded;
         iconColor = theme.queryGreen ?? Colors.green;

--- a/test/full_coverage_test.dart
+++ b/test/full_coverage_test.dart
@@ -110,6 +110,7 @@ import 'package:pi_hole_client/screens/app_logs/app_log_details_modal.dart';
 import 'package:pi_hole_client/screens/app_logs/app_logs.dart';
 import 'package:pi_hole_client/screens/common/empty_data_screen.dart';
 import 'package:pi_hole_client/screens/common/pi_hole_v5_not_supported_screen.dart';
+import 'package:pi_hole_client/screens/common/pi_hole_v6_not_supported_screen.dart';
 import 'package:pi_hole_client/screens/domains/domains.dart';
 import 'package:pi_hole_client/screens/domains/widgets/add_domain_modal.dart';
 import 'package:pi_hole_client/screens/domains/widgets/domain_details_screen.dart';
@@ -167,6 +168,7 @@ import 'package:pi_hole_client/screens/settings/server_settings/advanced_setting
 import 'package:pi_hole_client/screens/settings/server_settings/advanced_settings/network_screen/network_detail_screen.dart';
 import 'package:pi_hole_client/screens/settings/server_settings/advanced_settings/sessions_screen.dart';
 import 'package:pi_hole_client/screens/settings/server_settings/advanced_settings/sessions_screen/session_detail_screen.dart';
+import 'package:pi_hole_client/screens/settings/server_settings/advanced_settings/sessions_screen/session_list_view.dart';
 import 'package:pi_hole_client/screens/settings/server_settings/server_info.dart';
 import 'package:pi_hole_client/screens/settings/server_settings/subscriptions.dart';
 import 'package:pi_hole_client/screens/settings/server_settings/widgets/net_interface/net_interface_section.dart';


### PR DESCRIPTION
##  Overview

This PR improves the user experience of the **Session Screen** (located in *Settings > Advanced > Sessions*) by replacing the existing loading spinner (`CircularProgressIndicator`) with a **skeleton-based placeholder** using the `skeletonizer` package.

This makes the loading state more visually informative and consistent with other parts of the app that use skeleton loading patterns.

## Changes

* Replaced the loading spinner with a `Skeletonizer` + `SessionListView` using fake data.
* Extracted session list rendering logic into a dedicated `SessionListView` widget.
* Removed inline `buildStatusIcon` and `buildTlsLine` from `SessionsScreen`, as they're now encapsulated in `SessionListView`.

## ScreenShots

|before|after|
|---|---|
|![before](https://github.com/user-attachments/assets/ce0c55d4-b547-428f-8c33-64654c828187)|![after](https://github.com/user-attachments/assets/4aef0b8d-713f-409c-8619-a9f65cf463ce)|
