### PR TITLE
feat(settings/netowork): use skeleton loader instead of spinner

### DIFF
--- a/lib/screens/settings/server_settings/advanced_settings/network_screen.dart
+++ b/lib/screens/settings/server_settings/advanced_settings/network_screen.dart
@@ -200,23 +200,39 @@ class _NetworkState extends State<NetworkScreen> {
 
     setState(() {
       isLoading = true;
+      isFetchError = false;
     });
 
-    final result = await Future.wait<BaseInfoResponse<dynamic>>(
-      [apiGateway!.getDevices(), apiGateway!.getClient()],
-    );
-    if (!mounted) return;
+    try {
+      final result = await Future.wait<BaseInfoResponse<dynamic>>(
+        [apiGateway!.getDevices(), apiGateway!.getClient()],
+      );
+      if (!mounted) return;
 
-    setState(() {
-      if (result[0].result == APiResponseType.success &&
-          result[1].result == APiResponseType.success) {
-        devicesInfo = result[0].data;
-        currentClientIp = result[1].data?.addr;
-      } else {
-        isFetchError = true;
-        logger.e('Failed to load network devices or client info');
+      setState(() {
+        if (result[0].result == APiResponseType.success &&
+            result[1].result == APiResponseType.success) {
+          devicesInfo = result[0].data;
+          currentClientIp = result[1].data?.addr;
+        } else {
+          isFetchError = true;
+          logger.e('Failed to load network devices or client info');
+        }
+      });
+    } catch (e) {
+      logger.e('Failed to load network devices or client info', error: e);
+
+      if (mounted) {
+        setState(() {
+          isFetchError = true;
+        });
       }
-      isLoading = false;
-    });
+    } finally {
+      if (mounted) {
+        setState(() {
+          isLoading = false;
+        });
+      }
+    }
   }
 }

--- a/lib/screens/settings/server_settings/advanced_settings/network_screen/network_list_view.dart
+++ b/lib/screens/settings/server_settings/advanced_settings/network_screen/network_list_view.dart
@@ -80,7 +80,7 @@ class NetworkListView extends StatelessWidget {
     IconData iconData;
     Color iconColor;
 
-    if (lastQuery == DateTime.fromMillisecondsSinceEpoch(0)) {
+    if (lastQuery.millisecondsSinceEpoch == 0) {
       iconData = Icons.question_mark_rounded;
       iconColor = theme.queryGrey ?? Colors.grey;
     } else {

--- a/lib/screens/settings/server_settings/advanced_settings/network_screen/network_list_view.dart
+++ b/lib/screens/settings/server_settings/advanced_settings/network_screen/network_list_view.dart
@@ -1,0 +1,132 @@
+import 'package:flutter/material.dart';
+import 'package:pi_hole_client/config/theme.dart';
+import 'package:pi_hole_client/constants/formats.dart';
+import 'package:pi_hole_client/functions/format.dart';
+import 'package:pi_hole_client/l10n/generated/app_localizations.dart';
+import 'package:pi_hole_client/models/devices.dart';
+
+/// A [StatelessWidget] that displays a list of network devices with their status,
+/// last query time, and IP addresses.
+///
+/// Each device is represented as a [ListTile] showing:
+/// - A status icon indicating the device's activity (active, inactive, or unknown).
+/// - The device's IP addresses and optional names.
+/// - The last query timestamp or a "never" label if the device was never active.
+/// - A trailing chip if the device is currently in use (matches [currentClientIp]).
+///
+/// Tapping a device triggers the [onDeviceTap] callback with the selected [DeviceInfo].
+///
+/// {@tool snippet}
+/// Example usage:
+/// ```dart
+/// NetworkListView(
+///   devicesInfo: myDevicesInfo,
+///  currentClientIp: currentIp,
+///   onDeviceTap: (device) {
+///    print('Selected device: ${device.ips.first.ip}');
+///  },
+// )
+/// ```
+/// {@end-tool}
+class NetworkListView extends StatelessWidget {
+  const NetworkListView({
+    required this.devicesInfo,
+    required this.currentClientIp,
+    required this.onDeviceTap,
+    super.key,
+  });
+
+  final DevicesInfo devicesInfo;
+  final String currentClientIp;
+  final void Function(DeviceInfo)? onDeviceTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return ListView.builder(
+      itemCount: devicesInfo.devices.length,
+      itemBuilder: (context, index) {
+        final device = devicesInfo.devices[index];
+        return ListTile(
+          leading: _buildStatusIcon(context, device.lastQuery),
+          title: _buildDeviceTitle(context, device),
+          subtitle: Text(
+            device.lastQuery == DateTime.fromMillisecondsSinceEpoch(0)
+                ? AppLocalizations.of(context)!.never
+                : formatTimestamp(
+                    device.lastQuery,
+                    kUnifiedDateTimeLogFormat,
+                  ),
+          ),
+          trailing: device.ips.any((ip) => ip.ip == currentClientIp)
+              ? Chip(
+                  avatar: const Icon(Icons.star_rounded),
+                  label: Text(AppLocalizations.of(context)!.inUse),
+                )
+              : null,
+          onTap: () => onDeviceTap?.call(device),
+        );
+      },
+    );
+  }
+
+  /// Builds the status icon based on the device's last query timestamp.
+  /// - Green check: active within 24h
+  /// - Yellow warning: active within 24-48h
+  /// - Red error: inactive >48h
+  /// - Grey unknown: never active (lastQuery == UnixTime(0))
+  Widget _buildStatusIcon(BuildContext context, DateTime lastQuery) {
+    final theme = Theme.of(context).extension<AppColors>()!;
+
+    IconData iconData;
+    Color iconColor;
+
+    if (lastQuery == DateTime.fromMillisecondsSinceEpoch(0)) {
+      iconData = Icons.question_mark_rounded;
+      iconColor = theme.queryGrey ?? Colors.grey;
+    } else {
+      final now = DateTime.now();
+      final hours = now.difference(lastQuery).inHours;
+
+      if (hours < 24) {
+        iconData = Icons.check_rounded;
+        iconColor = theme.queryGreen ?? Colors.green;
+      } else if (hours < 48) {
+        iconData = Icons.access_time_rounded;
+        iconColor = theme.queryOrange ?? Colors.orange;
+      } else {
+        iconData = Icons.hourglass_bottom;
+        iconColor = theme.queryRed ?? Colors.red;
+      }
+    }
+
+    return Icon(iconData, size: 24, color: iconColor);
+  }
+
+  /// Builds a widget displaying the device's IP addresses and their optional names.
+  ///
+  /// If the device has no IP addresses, displays a localized "unknown" label.
+  /// Otherwise, lists each IP address, appending its name in parentheses if available.
+  ///
+  /// [context] - The build context used for localization.
+  /// [device] - The device information containing IP addresses and optional names.
+  ///
+  /// Returns a [Text] widget with the formatted device IP information.
+  Widget _buildDeviceTitle(BuildContext context, DeviceInfo device) {
+    if (device.ips.isEmpty) {
+      return Text(
+        AppLocalizations.of(context)!.unknown,
+        style: const TextStyle(fontSize: 16, fontWeight: FontWeight.bold),
+      );
+    }
+
+    final ipLines = device.ips.map((ip) {
+      final namePart = ip.name != null ? ' (${ip.name})' : '';
+      return '${ip.ip}$namePart';
+    }).join('\n');
+
+    return Text(
+      ipLines,
+      style: const TextStyle(fontSize: 16, fontWeight: FontWeight.bold),
+    );
+  }
+}

--- a/test/full_coverage_test.dart
+++ b/test/full_coverage_test.dart
@@ -166,6 +166,7 @@ import 'package:pi_hole_client/screens/settings/server_settings/advanced_setting
 import 'package:pi_hole_client/screens/settings/server_settings/advanced_settings/interface_screen/statistics_detail_screen.dart';
 import 'package:pi_hole_client/screens/settings/server_settings/advanced_settings/network_screen.dart';
 import 'package:pi_hole_client/screens/settings/server_settings/advanced_settings/network_screen/network_detail_screen.dart';
+import 'package:pi_hole_client/screens/settings/server_settings/advanced_settings/network_screen/network_list_view.dart';
 import 'package:pi_hole_client/screens/settings/server_settings/advanced_settings/sessions_screen.dart';
 import 'package:pi_hole_client/screens/settings/server_settings/advanced_settings/sessions_screen/session_detail_screen.dart';
 import 'package:pi_hole_client/screens/settings/server_settings/advanced_settings/sessions_screen/session_list_view.dart';


### PR DESCRIPTION
##  Overview

This PR improves the user experience of the **Network Screen** (located in *Settings > Advanced > Network*) by replacing the existing loading spinner (`CircularProgressIndicator`) with a **skeleton-based placeholder** using the `skeletonizer` package.

This makes the loading state more visually informative and consistent with other parts of the app that use skeleton loading patterns.

## Changes

* Replaced the loading spinner with a `Skeletonizer` + `SessionListView` using fake data.
* Extracted session list rendering logic into a dedicated `SessionListView` widget.
* Removed inline `buildStatusIcon` and `buildDeviceTitle` from `NetworkScreen`, as they're now encapsulated in `NetworkListView`.

## ScreenShots

|before|after|
|---|---|
|![before](https://github.com/user-attachments/assets/efad47c2-7664-4115-8e87-981c2cef8aef)|![after](https://github.com/user-attachments/assets/4dc1e867-a7dc-4085-ba02-f025f2c4c13a)|
