### PR TITLE
fix(home): resolved delayed status feedback on server change in v5

### DIFF
--- a/lib/screens/home/widgets/home_appbar.dart
+++ b/lib/screens/home/widgets/home_appbar.dart
@@ -91,7 +91,6 @@ class HomeAppBar extends StatelessWidget implements PreferredSizeWidget {
         } else {
           statusProvider.setOvertimeDataLoadingStatus(2);
         }
-        statusProvider.setIsServerConnected(true);
         await statusUpdateService.refreshOnce();
       }
 

--- a/lib/services/status_update_service.dart
+++ b/lib/services/status_update_service.dart
@@ -159,6 +159,9 @@ class StatusUpdateService {
     if (metricsResult?.result == APiResponseType.success) {
       _statusProvider.setMetricsInfo(metricsResult!.data!);
       return true;
+    } else if (metricsResult?.result == APiResponseType.notSupported) {
+      // pihole v5
+      return true;
     } else {
       return false;
     }


### PR DESCRIPTION
##  Overview

This pull request addresses a compatibility issue with Pi-hole v5.
In version 5, the metrics API endpoint returns `APiResponseType.notSupported`, which was previously unhandled. As a result, the UI status indicator would remain stuck or delayed after a server switch, giving the impression that no update occurred.

By explicitly handling the `notSupported` response, we ensure that the system gracefully skips metric updates when unsupported — avoiding misleading UI feedback.


##  Changes

* Added explicit handling for `APiResponseType.notSupported` in the metrics fetch logic
* Treated unsupported responses as a non-blocking success (`return true`)
