### PR TITLE
refactor(statistics): restructure provider access to reduce widget rebuilds

### DIFF
--- a/lib/screens/statistics/animated_percent_indicator.dart
+++ b/lib/screens/statistics/animated_percent_indicator.dart
@@ -1,0 +1,58 @@
+import 'package:flutter/material.dart';
+import 'package:percent_indicator/percent_indicator.dart';
+
+class AnimatedPercentIndicator extends StatefulWidget {
+  const AnimatedPercentIndicator({
+    required this.value,
+    required this.total,
+    super.key,
+  });
+
+  final int value;
+  final int total;
+
+  @override
+  State<AnimatedPercentIndicator> createState() =>
+      _AnimatedPercentIndicatorState();
+}
+
+class _AnimatedPercentIndicatorState extends State<AnimatedPercentIndicator> {
+  late double _percent;
+
+  @override
+  void initState() {
+    super.initState();
+    _percent = _computePercent();
+  }
+
+  @override
+  void didUpdateWidget(covariant AnimatedPercentIndicator oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    final newPercent = _computePercent();
+    if (newPercent != _percent) {
+      setState(() {
+        _percent = newPercent;
+      });
+    }
+  }
+
+  double _computePercent() {
+    return widget.total == 0
+        ? 0.0
+        : (widget.value / widget.total).clamp(0.0, 1.0);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return LinearPercentIndicator(
+      animation: true,
+      lineHeight: 10,
+      curve: Curves.easeOut,
+      percent: _percent,
+      barRadius: const Radius.circular(5),
+      progressColor: theme.colorScheme.primary,
+      backgroundColor: theme.colorScheme.primaryContainer,
+    );
+  }
+}

--- a/lib/screens/statistics/statistics_queries_servers_tab.dart
+++ b/lib/screens/statistics/statistics_queries_servers_tab.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
+import 'package:pi_hole_client/constants/enums.dart';
 import 'package:pi_hole_client/constants/responsive.dart';
 import 'package:pi_hole_client/l10n/generated/app_localizations.dart';
+import 'package:pi_hole_client/models/realtime_status.dart';
 import 'package:pi_hole_client/providers/status_provider.dart';
 import 'package:pi_hole_client/screens/statistics/custom_pie_chart.dart';
 import 'package:pi_hole_client/screens/statistics/no_data_chart.dart';
@@ -21,7 +23,9 @@ class QueriesServersTab extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final statusProvider = Provider.of<StatusProvider>(context);
+    final statusLoading = context.select<StatusProvider, LoadStatus>(
+      (p) => p.getStatusLoading,
+    );
 
     return CustomTabContent(
       loadingGenerator: () => SizedBox(
@@ -67,7 +71,7 @@ class QueriesServersTab extends StatelessWidget {
           ],
         ),
       ),
-      loadStatus: statusProvider.getStatusLoading,
+      loadStatus: statusLoading,
       onRefresh: onRefresh,
       controller: controller,
     );
@@ -79,13 +83,16 @@ class QueriesServersTabContent extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final statusProvider = Provider.of<StatusProvider>(context);
+    // final statusProvider = Provider.of<StatusProvider>(context);
+    final realtimeStatus = context.select<StatusProvider, RealtimeStatus?>(
+      (provider) => provider.getRealtimeStatus,
+    );
 
     final width = MediaQuery.of(context).size.width;
 
     return Column(
       children: [
-        if (statusProvider.getRealtimeStatus!.queryTypes.isEmpty == false)
+        if (realtimeStatus?.queryTypes.isEmpty == false)
           Padding(
             padding: const EdgeInsets.only(top: 20, bottom: 10),
             child: Column(
@@ -107,8 +114,7 @@ class QueriesServersTabContent extends StatelessWidget {
                               maxHeight: 200,
                             ),
                             child: CustomPieChart(
-                              data:
-                                  statusProvider.getRealtimeStatus!.queryTypes,
+                              data: realtimeStatus!.queryTypes,
                             ),
                           ),
                         ),
@@ -116,7 +122,7 @@ class QueriesServersTabContent extends StatelessWidget {
                       Expanded(
                         flex: 3,
                         child: PieChartLegend(
-                          data: statusProvider.getRealtimeStatus!.queryTypes,
+                          data: realtimeStatus.queryTypes,
                           dataUnit: '%',
                         ),
                       ),
@@ -126,12 +132,12 @@ class QueriesServersTabContent extends StatelessWidget {
                   SizedBox(
                     width: width - 40,
                     child: CustomPieChart(
-                      data: statusProvider.getRealtimeStatus!.queryTypes,
+                      data: realtimeStatus!.queryTypes,
                     ),
                   ),
                   const SizedBox(height: 20),
                   PieChartLegend(
-                    data: statusProvider.getRealtimeStatus!.queryTypes,
+                    data: realtimeStatus.queryTypes,
                     dataUnit: '%',
                   ),
                 ],
@@ -142,8 +148,7 @@ class QueriesServersTabContent extends StatelessWidget {
           NoDataChart(
             topLabel: AppLocalizations.of(context)!.queryTypes,
           ),
-        if (statusProvider.getRealtimeStatus!.forwardDestinations.isEmpty ==
-            false)
+        if (realtimeStatus!.forwardDestinations.isEmpty == false)
           Padding(
             padding: const EdgeInsets.only(top: 20, bottom: 10),
             child: Column(
@@ -165,8 +170,7 @@ class QueriesServersTabContent extends StatelessWidget {
                               maxHeight: 200,
                             ),
                             child: CustomPieChart(
-                              data: statusProvider
-                                  .getRealtimeStatus!.forwardDestinations,
+                              data: realtimeStatus.forwardDestinations,
                             ),
                           ),
                         ),
@@ -174,8 +178,7 @@ class QueriesServersTabContent extends StatelessWidget {
                       Expanded(
                         flex: 3,
                         child: PieChartLegend(
-                          data: statusProvider
-                              .getRealtimeStatus!.forwardDestinations,
+                          data: realtimeStatus.forwardDestinations,
                           dataUnit: '%',
                         ),
                       ),
@@ -185,13 +188,12 @@ class QueriesServersTabContent extends StatelessWidget {
                   SizedBox(
                     width: width - 40,
                     child: CustomPieChart(
-                      data:
-                          statusProvider.getRealtimeStatus!.forwardDestinations,
+                      data: realtimeStatus.forwardDestinations,
                     ),
                   ),
                   const SizedBox(height: 20),
                   PieChartLegend(
-                    data: statusProvider.getRealtimeStatus!.forwardDestinations,
+                    data: realtimeStatus.forwardDestinations,
                     dataUnit: '%',
                   ),
                 ],

--- a/test/full_coverage_test.dart
+++ b/test/full_coverage_test.dart
@@ -197,6 +197,7 @@ import 'package:pi_hole_client/screens/settings/server_settings/widgets/subscrip
 import 'package:pi_hole_client/screens/settings/server_settings/widgets/subscriptions/subscription_tile.dart';
 import 'package:pi_hole_client/screens/settings/server_settings/widgets/subscriptions/subscriptions_list.dart';
 import 'package:pi_hole_client/screens/settings/settings.dart';
+import 'package:pi_hole_client/screens/statistics/animated_percent_indicator.dart';
 import 'package:pi_hole_client/screens/statistics/custom_pie_chart.dart';
 import 'package:pi_hole_client/screens/statistics/dns_tab.dart';
 import 'package:pi_hole_client/screens/statistics/no_data_chart.dart';


### PR DESCRIPTION
## Overview
This PR refactors parts of the statistics screen to improve the structure of Provider usage. The main goal is to isolate widget rebuilds more effectively by replacing watch with select where appropriate.

While the new AnimatedPercentIndicator was introduced to avoid unnecessary updates when values remain the same, the total number of LinearPercentIndicator builds remains high. No significant performance gains have been observed so far, but the refactor lays groundwork for future optimization.