### PR TITLE
fix(server): show server tile immediately after adding by recreating list for context.select()

### DIFF
--- a/lib/providers/servers_provider.dart
+++ b/lib/providers/servers_provider.dart
@@ -124,14 +124,16 @@ class ServersProvider with ChangeNotifier {
       if (server.defaultServer == true) {
         final defaultServer = await setDefaultServer(server);
         if (defaultServer == true) {
-          _serversList.add(server);
+          // Create new list so context.select() can detect the change
+          _serversList = [..._serversList, server];
           notifyListeners();
           return true;
         } else {
           return false;
         }
       } else {
-        _serversList.add(server);
+        // Create new list so context.select() can detect the change
+        _serversList = [..._serversList, server];
         notifyListeners();
         return true;
       }
@@ -199,7 +201,9 @@ class ServersProvider with ChangeNotifier {
 
       if (dbOperationSuccess) {
         _serverGateways.remove(serverAddress);
-        _serversList.removeWhere((server) => server.address == serverAddress);
+        // Create new list so context.select() can detect the change
+        _serversList =
+            _serversList.where((s) => s.address != serverAddress).toList();
 
         if (_selectedServer?.address == serverAddress) {
           _selectedServer = null;

--- a/lib/screens/servers/servers_list.dart
+++ b/lib/screens/servers/servers_list.dart
@@ -1,7 +1,6 @@
 import 'package:expandable/expandable.dart';
 import 'package:flutter/material.dart';
 import 'package:pi_hole_client/l10n/generated/app_localizations.dart';
-import 'package:pi_hole_client/models/server.dart';
 import 'package:pi_hole_client/providers/servers_provider.dart';
 import 'package:pi_hole_client/screens/servers/servers_tile_item.dart';
 import 'package:provider/provider.dart';
@@ -24,9 +23,7 @@ class ServersList extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final serversList = context.select<ServersProvider, List<Server>>(
-      (serversProvider) => serversProvider.getServersList,
-    );
+    final serversList = context.watch<ServersProvider>().getServersList;
 
     if (serversList.isNotEmpty) {
       return ListView(

--- a/lib/screens/servers/servers_list.dart
+++ b/lib/screens/servers/servers_list.dart
@@ -1,6 +1,7 @@
 import 'package:expandable/expandable.dart';
 import 'package:flutter/material.dart';
 import 'package:pi_hole_client/l10n/generated/app_localizations.dart';
+import 'package:pi_hole_client/models/server.dart';
 import 'package:pi_hole_client/providers/servers_provider.dart';
 import 'package:pi_hole_client/screens/servers/servers_tile_item.dart';
 import 'package:provider/provider.dart';
@@ -23,7 +24,9 @@ class ServersList extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final serversList = context.watch<ServersProvider>().getServersList;
+    final serversList = context.select<ServersProvider, List<Server>>(
+      (p) => p.getServersList,
+    );
 
     if (serversList.isNotEmpty) {
       return ListView(


### PR DESCRIPTION
## Overview
Fixed an issue where the server tile was not displayed immediately after adding a server.
