### PR TITLE
fix(home): remove redundant near-simultaneous duplicate calls

### DIFF
--- a/lib/functions/misc.dart
+++ b/lib/functions/misc.dart
@@ -41,6 +41,8 @@ HttpClient createHttpClient({
 }) {
   final client = HttpClient();
 
+  client.maxConnectionsPerHost = 4;
+
   if (keepAlive) {
     client.idleTimeout = Duration.zero;
   }

--- a/lib/screens/home/widgets/home_appbar/server_label.dart
+++ b/lib/screens/home/widgets/home_appbar/server_label.dart
@@ -113,7 +113,7 @@ class ServerLabel extends StatelessWidget {
             server,
           );
 
-          statusUpdateService.startAutoRefresh();
+          statusUpdateService.startAutoRefresh(runImmediately: false);
         },
       ),
     );

--- a/lib/screens/servers/servers_tile_item_controller.dart
+++ b/lib/screens/servers/servers_tile_item_controller.dart
@@ -176,13 +176,10 @@ mixin ServersTileItemController<T extends StatefulWidget> on State<T> {
         ),
       );
 
-      // Run background task to handle get data
-      unawaited(
-        _handleConnectionSetup(
-          serversProvider: serversProvider,
-          statusProvider: statusProvider,
-          statusUpdateService: statusUpdateService,
-        ),
+      await _handleConnectionSetup(
+        serversProvider: serversProvider,
+        statusProvider: statusProvider,
+        statusUpdateService: statusUpdateService,
       );
     } else {
       process.close();
@@ -216,6 +213,7 @@ mixin ServersTileItemController<T extends StatefulWidget> on State<T> {
     required StatusProvider statusProvider,
     required StatusUpdateService statusUpdateService,
   }) async {
+    statusUpdateService.stopAutoRefresh();
     statusProvider.setStatusLoading(LoadStatus.loading);
     statusProvider.setOvertimeDataLoadingStatus(LoadStatus.loading);
 

--- a/lib/screens/servers/servers_tile_item_controller.dart
+++ b/lib/screens/servers/servers_tile_item_controller.dart
@@ -236,6 +236,6 @@ mixin ServersTileItemController<T extends StatefulWidget> on State<T> {
     }
 
     statusProvider.setIsServerConnected(true);
-    statusUpdateService.startAutoRefresh();
+    statusUpdateService.startAutoRefresh(runImmediately: false);
   }
 }

--- a/lib/services/status_update_service.dart
+++ b/lib/services/status_update_service.dart
@@ -57,7 +57,7 @@ class StatusUpdateService {
   /// - [isDelay]: If true, the refresh will be delayed by a short duration.
   void startAutoRefresh({
     bool runImmediately = true,
-    bool isDelay = true,
+    bool isDelay = false,
   }) {
     if (!_isAutoRefreshRunning) {
       logger.d(
@@ -85,7 +85,7 @@ class StatusUpdateService {
   /// Start timer for auto refresh
   void _startAutoRefresh({
     bool runImmediately = true,
-    bool isDelay = true,
+    bool isDelay = false,
   }) {
     if (_isAutoRefreshRunning) return;
     _isAutoRefreshRunning = true;
@@ -252,7 +252,7 @@ class StatusUpdateService {
   // ----------------------------------------
   void _setupOverTimeDataTimer({
     bool runImmediately = true,
-    bool isDelay = true,
+    bool isDelay = false,
   }) {
     Future<void> timerFn({Timer? timer}) async {
       final currentServer = _serversProvider.selectedServer;
@@ -311,7 +311,7 @@ class StatusUpdateService {
   // ----------------------------------------
   void _setupMetricsDataTimer({
     bool runImmediately = true,
-    bool isDelay = true,
+    bool isDelay = false,
   }) {
     Future<void> timerFn({Timer? timer}) async {
       final currentServer = _serversProvider.selectedServer;

--- a/lib/services/status_update_service.dart
+++ b/lib/services/status_update_service.dart
@@ -51,12 +51,19 @@ class StatusUpdateService {
   }
 
   /// Start timer for auto refresh
-  void startAutoRefresh() {
+  ///
+  /// Parameters:
+  /// - [runImmediately]: If true, the refresh will start immediately.
+  /// - [isDelay]: If true, the refresh will be delayed by a short duration.
+  void startAutoRefresh({
+    bool runImmediately = true,
+    bool isDelay = true,
+  }) {
     if (!_isAutoRefreshRunning) {
       logger.d(
         'Starting Auto Refresh: (${_serversProvider.selectedServer?.alias}) ${_serversProvider.selectedServer?.address}',
       );
-      _startAutoRefresh();
+      _startAutoRefresh(runImmediately: runImmediately, isDelay: isDelay);
     }
   }
 
@@ -76,13 +83,16 @@ class StatusUpdateService {
   }
 
   /// Start timer for auto refresh
-  void _startAutoRefresh() {
+  void _startAutoRefresh({
+    bool runImmediately = true,
+    bool isDelay = true,
+  }) {
     if (_isAutoRefreshRunning) return;
     _isAutoRefreshRunning = true;
 
-    _setupStatusDataTimer();
-    _setupOverTimeDataTimer();
-    _setupMetricsDataTimer();
+    _setupStatusDataTimer(runImmediately: runImmediately);
+    _setupOverTimeDataTimer(runImmediately: runImmediately, isDelay: isDelay);
+    _setupMetricsDataTimer(runImmediately: runImmediately, isDelay: isDelay);
   }
 
   /// Stop timer for auto refresh
@@ -98,8 +108,17 @@ class StatusUpdateService {
 
   /// Refresh the status data once
   Future<void> _refreshOnce() async {
+    // _fetchStatusData issues 8 HTTP requests (4 APIs in 2 batches),
+    // so we start it immediately to give it a head start.
+    // The others are slightly delayed to avoid overwhelming the connection pool.
     if ((await Future.wait(
-      [_fetchStatusData(), _fetchOverTimeData(), _fetchMetricsData()],
+      [
+        _fetchStatusData(),
+        Future.delayed(const Duration(milliseconds: 100))
+            .then((_) => _fetchOverTimeData()),
+        Future.delayed(const Duration(milliseconds: 100))
+            .then((_) => _fetchMetricsData()),
+      ],
     ))
         .every((result) => result)) {
       _statusProvider.setIsServerConnected(true);
@@ -170,7 +189,7 @@ class StatusUpdateService {
   // ----------------------------------------
   // Callbacks for StatusData
   // ----------------------------------------
-  void _setupStatusDataTimer() {
+  void _setupStatusDataTimer({bool runImmediately = true}) {
     _previousRefreshTime ??= _appConfigProvider.getAutoRefreshTime;
 
     Future<void> timerFn({Timer? timer}) async {
@@ -218,7 +237,10 @@ class StatusUpdateService {
       }
     }
 
-    timerFn();
+    if (runImmediately) {
+      timerFn();
+    }
+
     _statusDataTimer = Timer.periodic(
       Duration(seconds: _appConfigProvider.getAutoRefreshTime!),
       (timer) => timerFn(timer: timer),
@@ -228,7 +250,10 @@ class StatusUpdateService {
   // ----------------------------------------
   // Callbacks for OverTimeData
   // ----------------------------------------
-  void _setupOverTimeDataTimer() {
+  void _setupOverTimeDataTimer({
+    bool runImmediately = true,
+    bool isDelay = true,
+  }) {
     Future<void> timerFn({Timer? timer}) async {
       final currentServer = _serversProvider.selectedServer;
       if (currentServer == null) {
@@ -263,17 +288,31 @@ class StatusUpdateService {
       }
     }
 
-    timerFn();
-    _overTimeDataTimer = Timer.periodic(
-      const Duration(minutes: 1),
-      (timer) => timerFn(timer: timer),
-    );
+    void start() {
+      if (runImmediately) {
+        timerFn();
+      }
+
+      _overTimeDataTimer = Timer.periodic(
+        const Duration(minutes: 1),
+        (timer) => timerFn(timer: timer),
+      );
+    }
+
+    if (isDelay) {
+      Future.delayed(const Duration(milliseconds: 100), start);
+    } else {
+      start();
+    }
   }
 
   // ----------------------------------------
   // Callbacks for MetricsData
   // ----------------------------------------
-  void _setupMetricsDataTimer() {
+  void _setupMetricsDataTimer({
+    bool runImmediately = true,
+    bool isDelay = true,
+  }) {
     Future<void> timerFn({Timer? timer}) async {
       final currentServer = _serversProvider.selectedServer;
       if (currentServer == null) {
@@ -289,10 +328,21 @@ class StatusUpdateService {
       }
     }
 
-    timerFn();
-    _metricsDataTimer = Timer.periodic(
-      Duration(seconds: _appConfigProvider.getAutoRefreshTime!),
-      (timer) => timerFn(timer: timer),
-    );
+    void start() {
+      if (runImmediately) {
+        timerFn();
+      }
+
+      _metricsDataTimer = Timer.periodic(
+        Duration(seconds: _appConfigProvider.getAutoRefreshTime!),
+        (timer) => timerFn(timer: timer),
+      );
+    }
+
+    if (isDelay) {
+      Future.delayed(const Duration(milliseconds: 200), start);
+    } else {
+      start();
+    }
   }
 }

--- a/lib/services/status_update_service.dart
+++ b/lib/services/status_update_service.dart
@@ -340,7 +340,7 @@ class StatusUpdateService {
     }
 
     if (isDelay) {
-      Future.delayed(const Duration(milliseconds: 200), start);
+      Future.delayed(const Duration(milliseconds: 100), start);
     } else {
       start();
     }

--- a/test/widgets/helpers.mocks.dart
+++ b/test/widgets/helpers.mocks.dart
@@ -3454,10 +3454,18 @@ class MockStatusUpdateService extends _i1.Mock
       );
 
   @override
-  void startAutoRefresh() => super.noSuchMethod(
+  void startAutoRefresh({
+    bool? runImmediately = true,
+    bool? isDelay = false,
+  }) =>
+      super.noSuchMethod(
         Invocation.method(
           #startAutoRefresh,
           [],
+          {
+            #runImmediately: runImmediately,
+            #isDelay: isDelay,
+          },
         ),
         returnValueForMissingStub: null,
       );


### PR DESCRIPTION
## Overview

This PR fixes an issue where certain API requests (`status` and `overtime`) were being triggered twice at nearly the same time.  

## Changes

- Removed redundant or overlapping calls to `realtimeStatus` and `fetchOverTimeData`

## Error log (before fix)

```plaintext
ClientException: Connection closed before full header was received, uri=https://192.168.11.3/api/history
#0      IOClient.send (package:http/src/io_client.dart:156:7)
#1      BaseClient._sendUnstreamed (package:http/src/base_client.dart:93:32)
#2      Future.timeout.<anonymous closure> (dart:async/future_impl.dart:1064:7)
#3      ApiGatewayV6.httpClient (package:pi_hole_client/gateways/v6/api_gateway_v6.dart:174:24)
#4      ApiGatewayV6.fetchOverTimeData (package:pi_hole_client/gateways/v6/api_gateway_v6.dart:561:24)
#5      StatusUpdateService._setupOverTimeDataTimer.timerFn (package:pi_hole_client/services/status_update_service.dart:241:28)
```