### PR TITLE
fix(home, servers): retain selected server during navigation while connecting 

### DIFF
--- a/lib/config/globals.dart
+++ b/lib/config/globals.dart
@@ -2,3 +2,6 @@ import 'package:flutter/material.dart';
 
 final GlobalKey<ScaffoldMessengerState> scaffoldMessengerKey =
     GlobalKey<ScaffoldMessengerState>();
+
+final GlobalKey<NavigatorState> globalNavigatorKey =
+    GlobalKey<NavigatorState>();

--- a/lib/functions/refresh_server_status.dart
+++ b/lib/functions/refresh_server_status.dart
@@ -22,13 +22,13 @@ Future<dynamic> refreshServerStatus(BuildContext context) async {
     serversProvider.updateselectedServerStatus(
       result!.data?.status == 'enabled' ? true : false,
     );
-    statusProvider.setIsServerConnected(true);
+    statusProvider.setServerStatus(LoadStatus.loaded);
     statusProvider.setRealtimeStatus(result.data!);
   } else if (result?.result == APiResponseType.sslError) {
     logger.w(
       'SSL Error while fetching server status',
     );
-    statusProvider.setIsServerConnected(false);
+    statusProvider.setServerStatus(LoadStatus.error);
     if (statusProvider.getStatusLoading == LoadStatus.loading) {
       statusProvider.setStatusLoading(LoadStatus.error);
     }
@@ -41,7 +41,7 @@ Future<dynamic> refreshServerStatus(BuildContext context) async {
     logger.w(
       'Error while fetching server status: ${result?.result.name}',
     );
-    statusProvider.setIsServerConnected(false);
+    statusProvider.setServerStatus(LoadStatus.error);
     if (statusProvider.getStatusLoading == LoadStatus.loading) {
       statusProvider.setStatusLoading(LoadStatus.error);
     }

--- a/lib/functions/snackbar.dart
+++ b/lib/functions/snackbar.dart
@@ -1,22 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:pi_hole_client/config/globals.dart';
 import 'package:pi_hole_client/config/theme.dart';
-import 'package:pi_hole_client/l10n/generated/app_localizations.dart';
 import 'package:pi_hole_client/providers/app_config_provider.dart';
-
-void showGlobalConnectServerErrorSnackBar({
-  required AppConfigProvider appConfigProvider,
-}) {
-  final rootContext = globalNavigatorKey.currentContext;
-  if (rootContext == null) return;
-
-  showErrorSnackBar(
-    context: rootContext,
-    appConfigProvider: appConfigProvider,
-    label: AppLocalizations.of(rootContext)!.couldNotConnectServerFallback,
-    duration: 5,
-  );
-}
 
 void showSuccessSnackBar({
   required BuildContext context,

--- a/lib/functions/snackbar.dart
+++ b/lib/functions/snackbar.dart
@@ -1,7 +1,22 @@
 import 'package:flutter/material.dart';
 import 'package:pi_hole_client/config/globals.dart';
 import 'package:pi_hole_client/config/theme.dart';
+import 'package:pi_hole_client/l10n/generated/app_localizations.dart';
 import 'package:pi_hole_client/providers/app_config_provider.dart';
+
+void showGlobalConnectServerErrorSnackBar({
+  required AppConfigProvider appConfigProvider,
+}) {
+  final rootContext = globalNavigatorKey.currentContext;
+  if (rootContext == null) return;
+
+  showErrorSnackBar(
+    context: rootContext,
+    appConfigProvider: appConfigProvider,
+    label: AppLocalizations.of(rootContext)!.couldNotConnectServerFallback,
+    duration: 5,
+  );
+}
 
 void showSuccessSnackBar({
   required BuildContext context,

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -121,7 +121,7 @@
   "connecting": "Connecting...",
   "connectingServer": "Connecting Server",
   "connectingTo": "Connecting to",
-  "connectingToServer": "Connecting to server",
+  "connectingToServer": "Connecting to server...",
   "connection": "Connection",
   "connectionAlreadyExists": "This connection already exists",
   "connectionCannotBeRemoved": "Connection cannot be removed.",

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -122,7 +122,7 @@
   "connecting": "Conectando...",
   "connectingServer": "Conectando al Servidor",
   "connectingTo": "Conectando a",
-  "connectingToServer": "Conectando al servidor",
+  "connectingToServer": "Conectando al servidor...",
   "connection": "Conexión",
   "connectionAlreadyExists": "Esta conexión ya existe",
   "connectionCannotBeRemoved": "No se ha podido eliminar la conexión.",

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -121,7 +121,7 @@
   "connecting": "接続中...",
   "connectingServer": "接続中のサーバー",
   "connectingTo": "接続先",
-  "connectingToServer": "サーバーに接続中",
+  "connectingToServer": "サーバーに接続中...",
   "connection": "接続",
   "connectionAlreadyExists": "この接続は既に存在します",
   "connectionCannotBeRemoved": "接続を削除できません。",

--- a/lib/l10n/app_pl.arb
+++ b/lib/l10n/app_pl.arb
@@ -121,7 +121,7 @@
   "connecting": "Łączenie...",
   "connectingServer": "Łączenie z serwerem",
   "connectingTo": "Łączenie z",
-  "connectingToServer": "Łączenie z serwerem",
+  "connectingToServer": "Łączenie z serwerem...",
   "connection": "Połączenie",
   "connectionAlreadyExists": "To połączenie już istnieje",
   "connectionCannotBeRemoved": "Nie można usunąć połączenia.",

--- a/lib/l10n/generated/app_localizations.dart
+++ b/lib/l10n/generated/app_localizations.dart
@@ -839,7 +839,7 @@ abstract class AppLocalizations {
   /// No description provided for @connectingToServer.
   ///
   /// In en, this message translates to:
-  /// **'Connecting to server'**
+  /// **'Connecting to server...'**
   String get connectingToServer;
 
   /// No description provided for @connection.

--- a/lib/l10n/generated/app_localizations_en.dart
+++ b/lib/l10n/generated/app_localizations_en.dart
@@ -386,7 +386,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get connectingTo => 'Connecting to';
 
   @override
-  String get connectingToServer => 'Connecting to server';
+  String get connectingToServer => 'Connecting to server...';
 
   @override
   String get connection => 'Connection';

--- a/lib/l10n/generated/app_localizations_es.dart
+++ b/lib/l10n/generated/app_localizations_es.dart
@@ -392,7 +392,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get connectingTo => 'Conectando a';
 
   @override
-  String get connectingToServer => 'Conectando al servidor';
+  String get connectingToServer => 'Conectando al servidor...';
 
   @override
   String get connection => 'Conexión';

--- a/lib/l10n/generated/app_localizations_ja.dart
+++ b/lib/l10n/generated/app_localizations_ja.dart
@@ -377,7 +377,7 @@ class AppLocalizationsJa extends AppLocalizations {
   String get connectingTo => '接続先';
 
   @override
-  String get connectingToServer => 'サーバーに接続中';
+  String get connectingToServer => 'サーバーに接続中...';
 
   @override
   String get connection => '接続';

--- a/lib/l10n/generated/app_localizations_pl.dart
+++ b/lib/l10n/generated/app_localizations_pl.dart
@@ -388,7 +388,7 @@ class AppLocalizationsPl extends AppLocalizations {
   String get connectingTo => 'Łączenie z';
 
   @override
-  String get connectingToServer => 'Łączenie z serwerem';
+  String get connectingToServer => 'Łączenie z serwerem...';
 
   @override
   String get connection => 'Połączenie';

--- a/lib/pi_hole_client.dart
+++ b/lib/pi_hole_client.dart
@@ -33,6 +33,7 @@ class PiHoleClient extends StatelessWidget {
           navigatorObservers: [
             SentryNavigatorObserver(),
           ],
+          navigatorKey: globalNavigatorKey,
           title: 'Pi-hole client',
           theme: lightTheme(lightDynamic),
           darkTheme: darkTheme(darkDynamic),

--- a/lib/providers/servers_provider.dart
+++ b/lib/providers/servers_provider.dart
@@ -26,6 +26,8 @@ class ServersProvider with ChangeNotifier {
 
   Server? _selectedServer;
 
+  Server? _connectingServer;
+
   final Map<String, ApiGateway> _serverGateways = {};
 
   AppColors get colors => _appConfigProvider!.selectedTheme == ThemeMode.light
@@ -41,6 +43,8 @@ class ServersProvider with ChangeNotifier {
   Server? get selectedServer {
     return _selectedServer;
   }
+
+  Server? get connectingServer => _connectingServer;
 
   /// Returns the gateway for the selected server if a server is selected,
   /// otherwise returns null.
@@ -72,6 +76,14 @@ class ServersProvider with ChangeNotifier {
 
   void update(AppConfigProvider? provider) {
     _appConfigProvider = provider;
+  }
+
+  void setConnectingServer(Server server) {
+    _connectingServer = server;
+  }
+
+  void clearConnectingServer() {
+    _connectingServer = null;
   }
 
   ApiGateway? loadApiGateway(Server server) {

--- a/lib/providers/status_provider.dart
+++ b/lib/providers/status_provider.dart
@@ -5,7 +5,7 @@ import 'package:pi_hole_client/models/overtime_data.dart';
 import 'package:pi_hole_client/models/realtime_status.dart';
 
 class StatusProvider with ChangeNotifier {
-  bool _isServerConnected = false;
+  LoadStatus _serverStatus = LoadStatus.loading;
 
   LoadStatus _statusLoading = LoadStatus.loading;
   RealtimeStatus? _realtimeStatus;
@@ -14,8 +14,12 @@ class StatusProvider with ChangeNotifier {
   LoadStatus _overtimeDataLoading = LoadStatus.loading;
   OverTimeData? _overtimeData;
 
-  bool get isServerConnected {
-    return _isServerConnected;
+  LoadStatus get getServerStatus {
+    return _serverStatus;
+  }
+
+  bool get isServerLoading {
+    return _serverStatus == LoadStatus.loading;
   }
 
   RealtimeStatus? get getRealtimeStatus {
@@ -62,8 +66,8 @@ class StatusProvider with ChangeNotifier {
     return _overtimeDataLoading;
   }
 
-  void setIsServerConnected(bool value) {
-    _isServerConnected = value;
+  void setServerStatus(LoadStatus status) {
+    _serverStatus = status;
     notifyListeners();
   }
 

--- a/lib/screens/home/home.dart
+++ b/lib/screens/home/home.dart
@@ -65,7 +65,7 @@ class _HomeState extends State<Home> {
     );
 
     final isServerConnected = context.select<StatusProvider, bool>(
-      (provider) => provider.isServerConnected,
+      (p) => !p.isServerLoading,
     );
 
     final width = MediaQuery.of(context).size.width;

--- a/lib/screens/home/home.dart
+++ b/lib/screens/home/home.dart
@@ -64,14 +64,15 @@ class _HomeState extends State<Home> {
       (provider) => provider.getStatusLoading,
     );
 
-    final isServerConnected = context.select<StatusProvider, bool>(
+    final isConnectionAttemptFinished = context.select<StatusProvider, bool>(
       (p) => !p.isServerLoading,
     );
 
     final width = MediaQuery.of(context).size.width;
 
     Future<void> enableDisableServer() async {
-      if (isServerConnected == true && serversProvider.selectedServer != null) {
+      if (isConnectionAttemptFinished == true &&
+          serversProvider.selectedServer != null) {
         if (serversProvider.selectedServer?.enabled == true) {
           if (width > ResponsiveConstants.medium) {
             await showDialog(

--- a/lib/screens/home/widgets/home_appbar/adblock_status_icon.dart
+++ b/lib/screens/home/widgets/home_appbar/adblock_status_icon.dart
@@ -21,7 +21,7 @@ class AdBlockStatusIcon extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final isServerConnected = context.select<StatusProvider, bool>(
+    final isConnectionAttemptFinished = context.select<StatusProvider, bool>(
       (p) => !p.isServerLoading,
     );
 
@@ -34,13 +34,13 @@ class AdBlockStatusIcon extends StatelessWidget {
     );
 
     return Icon(
-      isServerConnected
+      isConnectionAttemptFinished
           ? enableSelectedServer
               ? Icons.verified_user_rounded
               : Icons.gpp_bad_rounded
           : Icons.shield_rounded,
       size: 30,
-      color: isServerConnected
+      color: isConnectionAttemptFinished
           ? enableSelectedServer
               ? convertColor(colors, Colors.green)
               : convertColor(colors, Colors.red)

--- a/lib/screens/home/widgets/home_appbar/adblock_status_icon.dart
+++ b/lib/screens/home/widgets/home_appbar/adblock_status_icon.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:pi_hole_client/config/theme.dart';
+import 'package:pi_hole_client/constants/enums.dart';
 import 'package:pi_hole_client/functions/conversions.dart';
 import 'package:pi_hole_client/providers/servers_provider.dart';
 import 'package:pi_hole_client/providers/status_provider.dart';
@@ -21,8 +22,8 @@ class AdBlockStatusIcon extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final isConnectionAttemptFinished = context.select<StatusProvider, bool>(
-      (p) => !p.isServerLoading,
+    final serverStatus = context.select<StatusProvider, LoadStatus>(
+      (p) => p.getServerStatus,
     );
 
     final colors = context.select<ServersProvider, AppColors>(
@@ -33,18 +34,31 @@ class AdBlockStatusIcon extends StatelessWidget {
       (p) => p.selectedServer?.enabled ?? false,
     );
 
+    IconData iconData;
+    Color iconColor;
+
+    switch (serverStatus) {
+      case LoadStatus.loaded:
+        iconData = enableSelectedServer
+            ? Icons.gpp_good_rounded
+            : Icons.gpp_bad_rounded;
+        iconColor = enableSelectedServer
+            ? convertColor(colors, Colors.green)
+            : convertColor(colors, Colors.red);
+
+      case LoadStatus.loading:
+        iconData = Icons.shield_rounded;
+        iconColor = convertColor(colors, Colors.grey);
+
+      case LoadStatus.error:
+        iconData = Icons.gpp_maybe_rounded;
+        iconColor = convertColor(colors, Colors.orange);
+    }
+
     return Icon(
-      isConnectionAttemptFinished
-          ? enableSelectedServer
-              ? Icons.verified_user_rounded
-              : Icons.gpp_bad_rounded
-          : Icons.shield_rounded,
+      iconData,
       size: 30,
-      color: isConnectionAttemptFinished
-          ? enableSelectedServer
-              ? convertColor(colors, Colors.green)
-              : convertColor(colors, Colors.red)
-          : Colors.grey,
+      color: iconColor,
     );
   }
 }

--- a/lib/screens/home/widgets/home_appbar/adblock_status_icon.dart
+++ b/lib/screens/home/widgets/home_appbar/adblock_status_icon.dart
@@ -22,7 +22,7 @@ class AdBlockStatusIcon extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final isServerConnected = context.select<StatusProvider, bool>(
-      (p) => p.isServerConnected,
+      (p) => !p.isServerLoading,
     );
 
     final colors = context.select<ServersProvider, AppColors>(

--- a/lib/screens/home/widgets/home_appbar/server_actions_menu.dart
+++ b/lib/screens/home/widgets/home_appbar/server_actions_menu.dart
@@ -44,7 +44,7 @@ class ServerActionsMenu extends StatelessWidget {
     final appConfigProvider = context.read<AppConfigProvider>();
 
     final isConnected = context.select<StatusProvider, bool>(
-      (p) => p.isServerConnected,
+      (p) => !p.isServerLoading,
     );
     final isServerSelected = context.select<ServersProvider, bool>(
       (p) => p.selectedServer != null,
@@ -208,13 +208,13 @@ class ServerActionsMenu extends StatelessWidget {
       serversProvider.updateselectedServerStatus(
         result!.data!.status == 'enabled' ? true : false,
       );
-      statusProvider.setIsServerConnected(true);
+      statusProvider.setServerStatus(LoadStatus.loaded);
       statusProvider.setRealtimeStatus(result.data!);
     } else {
       logger.w(
         'Error while fetching server status: ${result?.result.name}',
       );
-      statusProvider.setIsServerConnected(false);
+      statusProvider.setServerStatus(LoadStatus.error);
       if (statusProvider.getStatusLoading == LoadStatus.loading) {
         statusProvider.setStatusLoading(LoadStatus.error);
       }

--- a/lib/screens/home/widgets/home_appbar/server_label.dart
+++ b/lib/screens/home/widgets/home_appbar/server_label.dart
@@ -29,8 +29,8 @@ class ServerLabel extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final isServerConnected = context.select<StatusProvider, bool>(
-      (p) => p.isServerConnected,
+    final isServerLoading = context.select<StatusProvider, bool>(
+      (p) => p.isServerLoading,
     );
 
     final serversProvider = context.watch<ServersProvider>();
@@ -56,7 +56,11 @@ class ServerLabel extends StatelessWidget {
           children: [
             Expanded(
               child: Skeletonizer(
-                enabled: !isServerConnected,
+                enabled: isServerLoading,
+                effect: ShimmerEffect(
+                  baseColor: Theme.of(context).colorScheme.secondaryContainer,
+                  highlightColor: Theme.of(context).colorScheme.surface,
+                ),
                 child: const _ServerLabelText(),
               ),
             ),
@@ -76,7 +80,6 @@ class ServerLabel extends StatelessWidget {
   /// When a server is selected, it:
   /// - Closes the dialog.
   /// - Stops the status auto-refresh to prevent updating the status of the previous server.
-  /// - Connects to the newly selected server by calling [_connectToServer].
   /// - Restarts the status auto-refresh for the new server.
   ///
   /// Parameters:
@@ -102,7 +105,7 @@ class ServerLabel extends StatelessWidget {
           final previouslySelectedServer = serversProvider.selectedServer;
 
           statusUpdateService.stopAutoRefresh();
-          statusProvider.setIsServerConnected(false);
+          statusProvider.setServerStatus(LoadStatus.loading);
           statusProvider.setStatusLoading(LoadStatus.loading);
           statusProvider.setOvertimeDataLoadingStatus(LoadStatus.loading);
 
@@ -129,7 +132,7 @@ class ServerLabel extends StatelessWidget {
                 sm: server.sm,
               ),
             );
-            statusProvider.setIsServerConnected(true);
+            statusProvider.setServerStatus(LoadStatus.loaded);
 
             statusUpdateService.startAutoRefresh();
           } else {
@@ -139,7 +142,7 @@ class ServerLabel extends StatelessWidget {
             serversProvider.setselectedServer(
               server: previouslySelectedServer,
             );
-            statusProvider.setIsServerConnected(true);
+            statusProvider.setServerStatus(LoadStatus.loaded);
             statusUpdateService.startAutoRefresh();
 
             if (!context.mounted) return;

--- a/lib/screens/home/widgets/home_appbar/server_label.dart
+++ b/lib/screens/home/widgets/home_appbar/server_label.dart
@@ -104,6 +104,7 @@ class ServerLabel extends StatelessWidget {
 
           final previouslySelectedServer = serversProvider.selectedServer;
 
+          serversProvider.setConnectingServer(server);
           statusUpdateService.stopAutoRefresh();
           statusProvider.setServerStatus(LoadStatus.loading);
           statusProvider.setStatusLoading(LoadStatus.loading);
@@ -114,7 +115,7 @@ class ServerLabel extends StatelessWidget {
 
           // If another server (other than B) is selected while switching from server A to B, abort the process.
           // Without this check, it may appear as if the app is connected to B, even though a different server was actually selected.
-          if (previouslySelectedServer != serversProvider.selectedServer) {
+          if (serversProvider.connectingServer != server) {
             logger.w(
               'Server switch interrupted: '
               '${previouslySelectedServer?.address}(${previouslySelectedServer?.alias}) '
@@ -123,6 +124,8 @@ class ServerLabel extends StatelessWidget {
             );
             return;
           }
+
+          serversProvider.clearConnectingServer();
 
           if (result?.result == APiResponseType.success) {
             logger.d(

--- a/lib/screens/home/widgets/home_appbar/server_label.dart
+++ b/lib/screens/home/widgets/home_appbar/server_label.dart
@@ -111,19 +111,20 @@ class ServerLabel extends StatelessWidget {
 
           final result =
               await serversProvider.loadApiGateway(server)?.loginQuery();
-          if (result?.result == APiResponseType.success) {
-            // If another server (other than B) is selected while switching from server A to B, abort the process.
-            // Without this check, it may appear as if the app is connected to B, even though a different server was actually selected.
-            if (previouslySelectedServer != serversProvider.selectedServer) {
-              logger.w(
-                'Server switch interrupted: '
-                '${previouslySelectedServer?.address}(${previouslySelectedServer?.alias}) '
-                '-> ${server.address}(${server.alias}) '
-                '-> ${serversProvider.selectedServer?.address}(${serversProvider.selectedServer?.alias})',
-              );
-              return;
-            }
 
+          // If another server (other than B) is selected while switching from server A to B, abort the process.
+          // Without this check, it may appear as if the app is connected to B, even though a different server was actually selected.
+          if (previouslySelectedServer != serversProvider.selectedServer) {
+            logger.w(
+              'Server switch interrupted: '
+              '${previouslySelectedServer?.address}(${previouslySelectedServer?.alias}) '
+              '-> ${server.address}(${server.alias}) '
+              '-> ${serversProvider.selectedServer?.address}(${serversProvider.selectedServer?.alias})',
+            );
+            return;
+          }
+
+          if (result?.result == APiResponseType.success) {
             logger.d(
               '<*> Server connection successful: ${previouslySelectedServer?.address} -> ${server.address}',
             );

--- a/lib/screens/home/widgets/home_appbar/server_label.dart
+++ b/lib/screens/home/widgets/home_appbar/server_label.dart
@@ -1,14 +1,9 @@
 import 'package:flutter/material.dart';
-import 'package:pi_hole_client/constants/enums.dart';
-import 'package:pi_hole_client/functions/logger.dart';
-import 'package:pi_hole_client/functions/snackbar.dart';
-import 'package:pi_hole_client/l10n/generated/app_localizations.dart';
-import 'package:pi_hole_client/models/gateways.dart';
-import 'package:pi_hole_client/models/server.dart';
 import 'package:pi_hole_client/providers/app_config_provider.dart';
 import 'package:pi_hole_client/providers/servers_provider.dart';
 import 'package:pi_hole_client/providers/status_provider.dart';
 import 'package:pi_hole_client/screens/home/widgets/home_appbar/switch_server_modal.dart';
+import 'package:pi_hole_client/services/server_connection_service.dart';
 import 'package:pi_hole_client/services/status_update_service.dart';
 import 'package:provider/provider.dart';
 import 'package:skeletonizer/skeletonizer.dart';
@@ -102,77 +97,16 @@ class ServerLabel extends StatelessWidget {
         onServerSelect: (server) async {
           Navigator.pop(dialogContext);
 
-          final previouslySelectedServer = serversProvider.selectedServer;
+          final service = ServerConnectionService(
+            context: context,
+            appConfigProvider: appConfigProvider,
+            statusProvider: statusProvider,
+            serversProvider: serversProvider,
+            statusUpdateService: statusUpdateService,
+            server: server,
+          );
 
-          serversProvider.setConnectingServer(server);
-          statusUpdateService.stopAutoRefresh();
-          statusProvider.setServerStatus(LoadStatus.loading);
-
-          final result =
-              await serversProvider.loadApiGateway(server)?.loginQuery();
-
-          // If another server (other than B) is selected while switching from server A to B, abort the process.
-          // Without this check, it may appear as if the app is connected to B, even though a different server was actually selected.
-          if (serversProvider.connectingServer != server) {
-            logger.w(
-              'Server switch interrupted: '
-              '${previouslySelectedServer?.address}(${previouslySelectedServer?.alias}) '
-              '-> ${server.address}(${server.alias}) '
-              '-> ${serversProvider.selectedServer?.address}(${serversProvider.selectedServer?.alias})',
-            );
-            return;
-          }
-
-          serversProvider.clearConnectingServer();
-
-          if (result?.result == APiResponseType.success) {
-            logger.d(
-              '<*> Server connection successful: ${previouslySelectedServer?.address} -> ${server.address}',
-            );
-            // appScreensNotSelected Layout only. Go to settings
-            if (serversProvider.selectedServer == null &&
-                appConfigProvider.selectedTab == 1) {
-              appConfigProvider.setSelectedTab(4);
-            }
-
-            serversProvider.setselectedServer(
-              server: Server(
-                address: server.address,
-                alias: server.alias,
-                defaultServer: server.defaultServer,
-                apiVersion: server.apiVersion,
-                enabled: result!.status == 'enabled',
-                allowSelfSignedCert: server.allowSelfSignedCert,
-                sm: server.sm,
-              ),
-            );
-            statusProvider.setServerStatus(LoadStatus.loaded);
-
-            statusUpdateService.startAutoRefresh();
-          } else {
-            logger.d(
-              'Fallback to previously selected server: ${previouslySelectedServer?.address} <- ${server.address}',
-            );
-
-            if (previouslySelectedServer != null) {
-              serversProvider.setselectedServer(
-                server: previouslySelectedServer,
-              );
-              statusProvider.setServerStatus(LoadStatus.loading);
-              statusUpdateService.startAutoRefresh();
-            } else {
-              statusProvider.setServerStatus(LoadStatus.error);
-            }
-
-            if (!context.mounted) return;
-            showErrorSnackBar(
-              context: context,
-              appConfigProvider: appConfigProvider,
-              label:
-                  AppLocalizations.of(context)!.couldNotConnectServerFallback,
-              duration: 5,
-            );
-          }
+          await service.connect();
         },
       ),
     );

--- a/lib/screens/home/widgets/home_appbar/server_label.dart
+++ b/lib/screens/home/widgets/home_appbar/server_label.dart
@@ -99,197 +99,60 @@ class ServerLabel extends StatelessWidget {
         onServerSelect: (server) async {
           Navigator.pop(dialogContext);
 
-          // Prevent the previous server's status from being refreshed during server switching.
-          // Without this, the auto-refresh might update the status using the previous server's data
-          // before the new connection completes, causing the UI to briefly show outdated information.
+          final previouslySelectedServer = serversProvider.selectedServer;
+
           statusUpdateService.stopAutoRefresh();
+          statusProvider.setIsServerConnected(false);
+          statusProvider.setStatusLoading(LoadStatus.loading);
+          statusProvider.setOvertimeDataLoadingStatus(LoadStatus.loading);
 
-          await _connectToServer(
-            context,
-            appConfigProvider,
-            statusProvider,
-            serversProvider,
-            statusUpdateService,
-            server,
-          );
+          final result =
+              await serversProvider.loadApiGateway(server)?.loginQuery();
+          if (result?.result == APiResponseType.success) {
+            logger.d(
+              '<*> Server connection successful: ${previouslySelectedServer?.address} -> ${server.address}',
+            );
+            // appScreensNotSelected Layout only. Go to settings
+            if (serversProvider.selectedServer == null &&
+                appConfigProvider.selectedTab == 1) {
+              appConfigProvider.setSelectedTab(4);
+            }
 
-          statusUpdateService.startAutoRefresh(runImmediately: false);
+            serversProvider.setselectedServer(
+              server: Server(
+                address: server.address,
+                alias: server.alias,
+                defaultServer: server.defaultServer,
+                apiVersion: server.apiVersion,
+                enabled: result!.status == 'enabled',
+                allowSelfSignedCert: server.allowSelfSignedCert,
+                sm: server.sm,
+              ),
+            );
+            statusProvider.setIsServerConnected(true);
+
+            statusUpdateService.startAutoRefresh();
+          } else {
+            logger.d(
+              'Fallback to previously selected server: ${previouslySelectedServer?.address} <- ${server.address}',
+            );
+            serversProvider.setselectedServer(
+              server: previouslySelectedServer,
+            );
+            statusProvider.setIsServerConnected(true);
+            statusUpdateService.startAutoRefresh();
+
+            if (!context.mounted) return;
+            showErrorSnackBar(
+              context: context,
+              appConfigProvider: appConfigProvider,
+              label:
+                  AppLocalizations.of(context)!.couldNotConnectServerFallback,
+            );
+          }
         },
       ),
     );
-  }
-
-  /// Attempts to connect to the given [server], updating the status and UI accordingly.
-  ///
-  /// This method performs the following steps:
-  /// 1. Sets both the main status and overtime data loading indicators to `loading`.
-  /// 2. Attempts to log in to the API gateway for the provided [server].
-  /// 3. If the login is successful:
-  ///    - Marks the server as connected.
-  ///    - Delegates to [_handleServerConnectSuccess] to update server and fetch data.
-  /// 4. If the login fails:
-  ///    - Marks the server as disconnected.
-  ///    - Delegates to [_handleServerConnectFailure] to show an error and fallback status.
-  ///
-  /// This method ensures that UI-related updates only occur if [context] is still mounted.
-  ///
-  /// Parameters:
-  /// - [context]: The current [BuildContext], used for UI interaction.
-  /// - [appConfigProvider]: The app configuration provider for snackbar control.
-  /// - [statusProvider]: Provider managing realtime and overtime status states.
-  /// - [serversProvider]: Provider managing the selected server and gateway logic.
-  /// - [statusUpdateService]: Fallback status refresher service.
-  /// - [server]: The [Server] instance to attempt connecting to.
-  ///
-  /// Returns:
-  /// A [Future] that completes once the full connection process has finished.
-  Future<void> _connectToServer(
-    BuildContext context,
-    AppConfigProvider appConfigProvider,
-    StatusProvider statusProvider,
-    ServersProvider serversProvider,
-    StatusUpdateService statusUpdateService,
-    Server server,
-  ) async {
-    statusProvider.setStatusLoading(LoadStatus.loading);
-    statusProvider.setOvertimeDataLoadingStatus(LoadStatus.loading);
-    statusProvider.setIsServerConnected(false);
-
-    final result = await serversProvider.loadApiGateway(server)?.loginQuery();
-    if (!context.mounted) return;
-
-    if (result?.result == APiResponseType.success) {
-      statusProvider.setIsServerConnected(true);
-      await _handleServerConnectSuccess(
-        statusProvider,
-        serversProvider,
-        server,
-        result,
-      );
-    } else {
-      await _handleServerConnectFailure(
-        context,
-        appConfigProvider,
-        statusProvider,
-        statusUpdateService,
-        result,
-      );
-    }
-  }
-
-  /// Handles the logic for a successful server login.
-  ///
-  /// This method updates the selected server in the provider, and then concurrently
-  /// fetches the real-time status and overtime data from the API gateway. It then updates
-  /// the corresponding providers based on the result of each API call.
-  ///
-  /// Parameters:
-  /// - [statusProvider]: Provider for updating the realtime and overtime status.
-  /// - [serversProvider]: Provider used to set the selected server and resolve the gateway.
-  /// - [server]: The connected [Server] instance.
-  /// - [result]: The successful login response containing server state information.
-  ///
-  /// Returns:
-  /// A [Future] that completes after the status data has been fetched and applied.
-  Future<void> _handleServerConnectSuccess(
-    StatusProvider statusProvider,
-    ServersProvider serversProvider,
-    Server server,
-    LoginQueryResponse? result,
-  ) async {
-    serversProvider.setselectedServer(
-      server: Server(
-        address: server.address,
-        alias: server.alias,
-        defaultServer: server.defaultServer,
-        apiVersion: server.apiVersion,
-        enabled: result?.status == 'enabled',
-        allowSelfSignedCert: server.allowSelfSignedCert,
-      ),
-    );
-
-    final apiGateway = serversProvider.selectedApiGateway;
-    if (apiGateway == null) {
-      logger.w('Selected API Gateway is null');
-      return;
-    }
-
-    final results = await Future.wait([
-      apiGateway.realtimeStatus(clientCount: 0),
-      apiGateway.fetchOverTimeData(),
-    ]);
-
-    final statusResult = results[0] as RealtimeStatusResponse;
-    final overtimeDataResult = results[1] as FetchOverTimeDataResponse;
-
-    if (statusResult.result == APiResponseType.success) {
-      statusProvider.setRealtimeStatus(statusResult.data!);
-      statusProvider.setStatusLoading(LoadStatus.loaded);
-    } else {
-      logger.w(
-        'Error while fetching realtime status: ${statusResult.result.name}',
-      );
-      statusProvider.setStatusLoading(LoadStatus.error);
-    }
-
-    if (overtimeDataResult.result == APiResponseType.success) {
-      statusProvider.setOvertimeData(overtimeDataResult.data!);
-      statusProvider.setOvertimeDataLoadingStatus(LoadStatus.loaded);
-    } else {
-      logger.w(
-        'Error while fetching overtime data: ${overtimeDataResult.result.name}',
-      );
-      statusProvider.setOvertimeDataLoadingStatus(LoadStatus.error);
-    }
-  }
-
-  /// Handles the failure case for server login attempts.
-  ///
-  /// This method logs the failure, sets both main and overtime status loading indicators
-  /// to `error`, shows a localized error snackbar, and triggers a one-time fallback
-  /// status refresh using the [statusUpdateService].
-  ///
-  /// Parameters:
-  /// - [context]: The [BuildContext] used to show the snackbar.
-  /// - [appConfigProvider]: The app configuration provider for snackbar control.
-  /// - [statusProvider]: The provider used to update error status.
-  /// - [statusUpdateService]: The service used to trigger a one-time fallback refresh.
-  /// - [result]: The login failure response used for logging (nullable).
-  ///
-  /// Returns:
-  /// A [Future] that completes once the error state and fallback logic has finished.
-  Future<void> _handleServerConnectFailure(
-    BuildContext context,
-    AppConfigProvider appConfigProvider,
-    StatusProvider statusProvider,
-    StatusUpdateService statusUpdateService,
-    LoginQueryResponse? result,
-  ) async {
-    /// Returns immediately if either the main status or overtime data has already finished loading.
-    /// This prevents any actions from being taken if the user has switched to another server while loading.
-    if (statusProvider.getStatusLoading == LoadStatus.loaded ||
-        statusProvider.getOvertimeDataLoadStatus == LoadStatus.loaded) {
-      logger.i(
-        'Status or overtime data already loaded, skipping error handling.',
-      );
-      return;
-    }
-
-    logger.w(
-      'Error while connecting to server: ${result?.result.name}. Falling back to the previous server and triggering refresh.',
-    );
-
-    statusProvider.setStatusLoading(LoadStatus.error);
-    statusProvider.setOvertimeDataLoadingStatus(LoadStatus.error);
-
-    showErrorSnackBar(
-      context: context,
-      appConfigProvider: appConfigProvider,
-      label: AppLocalizations.of(context)!.couldNotConnectServerFallback,
-      duration: 5,
-    );
-
-    await statusUpdateService.refreshOnce();
   }
 }
 

--- a/lib/screens/home/widgets/home_appbar/server_label.dart
+++ b/lib/screens/home/widgets/home_appbar/server_label.dart
@@ -107,8 +107,6 @@ class ServerLabel extends StatelessWidget {
           serversProvider.setConnectingServer(server);
           statusUpdateService.stopAutoRefresh();
           statusProvider.setServerStatus(LoadStatus.loading);
-          statusProvider.setStatusLoading(LoadStatus.loading);
-          statusProvider.setOvertimeDataLoadingStatus(LoadStatus.loading);
 
           final result =
               await serversProvider.loadApiGateway(server)?.loginQuery();
@@ -155,11 +153,16 @@ class ServerLabel extends StatelessWidget {
             logger.d(
               'Fallback to previously selected server: ${previouslySelectedServer?.address} <- ${server.address}',
             );
-            serversProvider.setselectedServer(
-              server: previouslySelectedServer,
-            );
-            statusProvider.setServerStatus(LoadStatus.loaded);
-            statusUpdateService.startAutoRefresh();
+
+            if (previouslySelectedServer != null) {
+              serversProvider.setselectedServer(
+                server: previouslySelectedServer,
+              );
+              statusProvider.setServerStatus(LoadStatus.loading);
+              statusUpdateService.startAutoRefresh();
+            } else {
+              statusProvider.setServerStatus(LoadStatus.error);
+            }
 
             if (!context.mounted) return;
             showErrorSnackBar(

--- a/lib/screens/home/widgets/home_appbar/server_label.dart
+++ b/lib/screens/home/widgets/home_appbar/server_label.dart
@@ -151,6 +151,7 @@ class ServerLabel extends StatelessWidget {
               appConfigProvider: appConfigProvider,
               label:
                   AppLocalizations.of(context)!.couldNotConnectServerFallback,
+              duration: 5,
             );
           }
         },

--- a/lib/screens/home/widgets/home_appbar/server_label.dart
+++ b/lib/screens/home/widgets/home_appbar/server_label.dart
@@ -112,6 +112,18 @@ class ServerLabel extends StatelessWidget {
           final result =
               await serversProvider.loadApiGateway(server)?.loginQuery();
           if (result?.result == APiResponseType.success) {
+            // If another server (other than B) is selected while switching from server A to B, abort the process.
+            // Without this check, it may appear as if the app is connected to B, even though a different server was actually selected.
+            if (previouslySelectedServer != serversProvider.selectedServer) {
+              logger.w(
+                'Server switch interrupted: '
+                '${previouslySelectedServer?.address}(${previouslySelectedServer?.alias}) '
+                '-> ${server.address}(${server.alias}) '
+                '-> ${serversProvider.selectedServer?.address}(${serversProvider.selectedServer?.alias})',
+              );
+              return;
+            }
+
             logger.d(
               '<*> Server connection successful: ${previouslySelectedServer?.address} -> ${server.address}',
             );

--- a/lib/screens/home/widgets/home_charts/client_activity_chart_section.dart
+++ b/lib/screens/home/widgets/home_charts/client_activity_chart_section.dart
@@ -129,6 +129,10 @@ class ClientActivityChartSection extends StatelessWidget {
     );
 
     return Skeletonizer(
+      effect: ShimmerEffect(
+        baseColor: Theme.of(context).colorScheme.secondaryContainer,
+        highlightColor: Theme.of(context).colorScheme.surface,
+      ),
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [

--- a/lib/screens/home/widgets/home_charts/queries/queries_skeleton.dart
+++ b/lib/screens/home/widgets/home_charts/queries/queries_skeleton.dart
@@ -24,6 +24,10 @@ class QueriesSkeleton extends StatelessWidget {
     final appConfigProvider = context.read<AppConfigProvider>();
 
     return Skeletonizer(
+      effect: ShimmerEffect(
+        baseColor: Theme.of(context).colorScheme.secondaryContainer,
+        highlightColor: Theme.of(context).colorScheme.surface,
+      ),
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [

--- a/lib/screens/servers/server_tile_actions.dart
+++ b/lib/screens/servers/server_tile_actions.dart
@@ -34,7 +34,7 @@ class ServerTileActions extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final isServerConnected = context.select<StatusProvider, bool>(
+    final isConnectionAttemptFinished = context.select<StatusProvider, bool>(
       (p) => !p.isServerLoading,
     );
     final selectedServer = context.select<ServersProvider, Server?>(
@@ -73,7 +73,7 @@ class ServerTileActions extends StatelessWidget {
           padding: const EdgeInsets.only(right: 16),
           child: isSelected
               ? _ConnectionStatus(
-                  isConnected: isServerConnected,
+                  isConnected: isConnectionAttemptFinished,
                 )
               : FilledButton.icon(
                   onPressed: onConnect,

--- a/lib/screens/servers/server_tile_actions.dart
+++ b/lib/screens/servers/server_tile_actions.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:pi_hole_client/config/theme.dart';
+import 'package:pi_hole_client/constants/enums.dart';
 import 'package:pi_hole_client/l10n/generated/app_localizations.dart';
 import 'package:pi_hole_client/models/server.dart';
 import 'package:pi_hole_client/providers/servers_provider.dart';
@@ -34,8 +35,8 @@ class ServerTileActions extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final isConnectionAttemptFinished = context.select<StatusProvider, bool>(
-      (p) => !p.isServerLoading,
+    final isConnected = context.select<StatusProvider, bool>(
+      (p) => p.getServerStatus == LoadStatus.loaded,
     );
     final selectedServer = context.select<ServersProvider, Server?>(
       (p) => p.selectedServer,
@@ -73,7 +74,7 @@ class ServerTileActions extends StatelessWidget {
           padding: const EdgeInsets.only(right: 16),
           child: isSelected
               ? _ConnectionStatus(
-                  isConnected: isConnectionAttemptFinished,
+                  isConnected: isConnected,
                 )
               : FilledButton.icon(
                   onPressed: onConnect,

--- a/lib/screens/servers/server_tile_actions.dart
+++ b/lib/screens/servers/server_tile_actions.dart
@@ -35,7 +35,7 @@ class ServerTileActions extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final isServerConnected = context.select<StatusProvider, bool>(
-      (p) => p.isServerConnected,
+      (p) => !p.isServerLoading,
     );
     final selectedServer = context.select<ServersProvider, Server?>(
       (p) => p.selectedServer,

--- a/lib/screens/servers/server_tile_header.dart
+++ b/lib/screens/servers/server_tile_header.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:pi_hole_client/config/theme.dart';
+import 'package:pi_hole_client/constants/enums.dart';
 import 'package:pi_hole_client/models/server.dart';
 import 'package:pi_hole_client/providers/servers_provider.dart';
 import 'package:pi_hole_client/providers/status_provider.dart';
@@ -29,8 +30,8 @@ class ServerTileHeader extends StatelessWidget {
       (p) => p.selectedServer,
     );
 
-    final isConnectionAttemptFinished = context.select<StatusProvider, bool>(
-      (p) => !p.isServerLoading,
+    final isConnected = context.select<StatusProvider, bool>(
+      (p) => p.getServerStatus == LoadStatus.loaded,
     );
 
     final isSelected = selectedServer?.address == server.address;
@@ -46,7 +47,7 @@ class ServerTileHeader extends StatelessWidget {
                 child: _LeadingIcon(
                   isDefault: server.defaultServer,
                   isSelected: isSelected,
-                  isConnected: isConnectionAttemptFinished,
+                  isConnected: isConnected,
                 ),
               ),
               Expanded(

--- a/lib/screens/servers/server_tile_header.dart
+++ b/lib/screens/servers/server_tile_header.dart
@@ -29,7 +29,7 @@ class ServerTileHeader extends StatelessWidget {
       (p) => p.selectedServer,
     );
 
-    final isServerConnected = context.select<StatusProvider, bool>(
+    final isConnectionAttemptFinished = context.select<StatusProvider, bool>(
       (p) => !p.isServerLoading,
     );
 
@@ -46,7 +46,7 @@ class ServerTileHeader extends StatelessWidget {
                 child: _LeadingIcon(
                   isDefault: server.defaultServer,
                   isSelected: isSelected,
-                  isConnected: isServerConnected,
+                  isConnected: isConnectionAttemptFinished,
                 ),
               ),
               Expanded(

--- a/lib/screens/servers/server_tile_header.dart
+++ b/lib/screens/servers/server_tile_header.dart
@@ -30,7 +30,7 @@ class ServerTileHeader extends StatelessWidget {
     );
 
     final isServerConnected = context.select<StatusProvider, bool>(
-      (p) => p.isServerConnected,
+      (p) => !p.isServerLoading,
     );
 
     final isSelected = selectedServer?.address == server.address;

--- a/lib/screens/servers/servers_tile_item_controller.dart
+++ b/lib/screens/servers/servers_tile_item_controller.dart
@@ -200,7 +200,14 @@ mixin ServersTileItemController<T extends StatefulWidget> on State<T> {
         statusProvider.setServerStatus(LoadStatus.error);
       }
 
-      if (!mounted) return;
+      // If the system back button is pressed and returns to HOME before completion (while the modal is displayed)
+      if (!mounted) {
+        showGlobalConnectServerErrorSnackBar(
+          appConfigProvider: appConfigProvider,
+        );
+        return;
+      }
+
       showErrorSnackBar(
         context: context,
         appConfigProvider: appConfigProvider,

--- a/lib/screens/servers/servers_tile_item_controller.dart
+++ b/lib/screens/servers/servers_tile_item_controller.dart
@@ -171,13 +171,6 @@ mixin ServersTileItemController<T extends StatefulWidget> on State<T> {
       statusProvider.setIsServerConnected(true);
 
       statusUpdateService.startAutoRefresh();
-
-      if (!mounted) return;
-      showSuccessSnackBar(
-        context: context,
-        appConfigProvider: appConfigProvider,
-        label: AppLocalizations.of(context)!.connectedSuccessfully,
-      );
     } else {
       process.close();
       logger.d(

--- a/lib/screens/servers/servers_tile_item_controller.dart
+++ b/lib/screens/servers/servers_tile_item_controller.dart
@@ -139,7 +139,7 @@ mixin ServersTileItemController<T extends StatefulWidget> on State<T> {
     final previouslySelectedServer = serversProvider.selectedServer;
 
     statusUpdateService.stopAutoRefresh();
-    statusProvider.setIsServerConnected(false);
+    statusProvider.setServerStatus(LoadStatus.loading);
     statusProvider.setStatusLoading(LoadStatus.loading);
     statusProvider.setOvertimeDataLoadingStatus(LoadStatus.loading);
 
@@ -168,7 +168,7 @@ mixin ServersTileItemController<T extends StatefulWidget> on State<T> {
           sm: server.sm,
         ),
       );
-      statusProvider.setIsServerConnected(true);
+      statusProvider.setServerStatus(LoadStatus.loaded);
 
       statusUpdateService.startAutoRefresh();
     } else {
@@ -179,7 +179,7 @@ mixin ServersTileItemController<T extends StatefulWidget> on State<T> {
       serversProvider.setselectedServer(
         server: previouslySelectedServer,
       );
-      statusProvider.setIsServerConnected(true);
+      statusProvider.setServerStatus(LoadStatus.error);
       statusUpdateService.startAutoRefresh();
 
       if (!mounted) return;

--- a/lib/screens/servers/servers_tile_item_controller.dart
+++ b/lib/screens/servers/servers_tile_item_controller.dart
@@ -179,7 +179,7 @@ mixin ServersTileItemController<T extends StatefulWidget> on State<T> {
       serversProvider.setselectedServer(
         server: previouslySelectedServer,
       );
-      statusProvider.setServerStatus(LoadStatus.error);
+      statusProvider.setServerStatus(LoadStatus.loaded);
       statusUpdateService.startAutoRefresh();
 
       if (!mounted) return;

--- a/lib/screens/servers/servers_tile_item_controller.dart
+++ b/lib/screens/servers/servers_tile_item_controller.dart
@@ -141,8 +141,6 @@ mixin ServersTileItemController<T extends StatefulWidget> on State<T> {
     serversProvider.setConnectingServer(server);
     statusUpdateService.stopAutoRefresh();
     statusProvider.setServerStatus(LoadStatus.loading);
-    statusProvider.setStatusLoading(LoadStatus.loading);
-    statusProvider.setOvertimeDataLoadingStatus(LoadStatus.loading);
 
     final process = ProcessModal(context: context);
     process.open(AppLocalizations.of(context)!.connecting);
@@ -151,7 +149,6 @@ mixin ServersTileItemController<T extends StatefulWidget> on State<T> {
 
     // If another server (other than B) is selected while switching from server A to B, abort the process.
     // Without this check, it may appear as if the app is connected to B, even though a different server was actually selected.
-    if (!mounted) return;
     if (serversProvider.connectingServer != server) {
       logger.w(
         'Server switch interrupted: '
@@ -192,11 +189,16 @@ mixin ServersTileItemController<T extends StatefulWidget> on State<T> {
       logger.d(
         'Fallback to previously selected server: ${previouslySelectedServer?.address} <- ${server.address}',
       );
-      serversProvider.setselectedServer(
-        server: previouslySelectedServer,
-      );
-      statusProvider.setServerStatus(LoadStatus.loaded);
-      statusUpdateService.startAutoRefresh();
+
+      if (previouslySelectedServer != null) {
+        serversProvider.setselectedServer(
+          server: previouslySelectedServer,
+        );
+        statusProvider.setServerStatus(LoadStatus.loading);
+        statusUpdateService.startAutoRefresh();
+      } else {
+        statusProvider.setServerStatus(LoadStatus.error);
+      }
 
       if (!mounted) return;
       showErrorSnackBar(

--- a/lib/screens/settings/settings.dart
+++ b/lib/screens/settings/settings.dart
@@ -75,7 +75,7 @@ class _SettingsWidgetState extends State<SettingsWidget> {
       (p) => p.selectedServer,
     );
     final isServerConnected = context.select<StatusProvider, bool>(
-      (p) => p.isServerConnected,
+      (p) => !p.isServerLoading,
     );
     final appConfigProvider = Provider.of<AppConfigProvider>(context);
 

--- a/lib/screens/settings/settings.dart
+++ b/lib/screens/settings/settings.dart
@@ -74,7 +74,7 @@ class _SettingsWidgetState extends State<SettingsWidget> {
     final selectedServer = context.select<ServersProvider, Server?>(
       (p) => p.selectedServer,
     );
-    final isServerConnected = context.select<StatusProvider, bool>(
+    final isConnectionAttemptFinished = context.select<StatusProvider, bool>(
       (p) => !p.isServerLoading,
     );
     final appConfigProvider = Provider.of<AppConfigProvider>(context);
@@ -170,7 +170,7 @@ class _SettingsWidgetState extends State<SettingsWidget> {
             icon: Icons.storage_rounded,
             title: AppLocalizations.of(context)!.servers,
             subtitle: selectedServer != null
-                ? isServerConnected
+                ? isConnectionAttemptFinished
                     ? '${AppLocalizations.of(context)!.connectedTo} ${selectedServer.alias}'
                     : AppLocalizations.of(context)!.notConnectServer
                 : AppLocalizations.of(context)!.notSelected,
@@ -199,7 +199,7 @@ class _SettingsWidgetState extends State<SettingsWidget> {
             icon: Icons.connected_tv_rounded,
             title: AppLocalizations.of(context)!.serverInfo,
             subtitle: selectedServer != null
-                ? isServerConnected
+                ? isConnectionAttemptFinished
                     ? selectedServer.alias
                     : AppLocalizations.of(context)!.notConnectServer
                 : AppLocalizations.of(context)!.notSelected,

--- a/lib/screens/settings/settings.dart
+++ b/lib/screens/settings/settings.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_split_view/flutter_split_view.dart';
 import 'package:flutter_svg/svg.dart';
+import 'package:pi_hole_client/constants/enums.dart';
 import 'package:pi_hole_client/constants/languages.dart';
 import 'package:pi_hole_client/constants/responsive.dart';
 import 'package:pi_hole_client/constants/urls.dart';
@@ -74,8 +75,8 @@ class _SettingsWidgetState extends State<SettingsWidget> {
     final selectedServer = context.select<ServersProvider, Server?>(
       (p) => p.selectedServer,
     );
-    final isConnectionAttemptFinished = context.select<StatusProvider, bool>(
-      (p) => !p.isServerLoading,
+    final serverStatus = context.select<StatusProvider, LoadStatus>(
+      (p) => p.getServerStatus,
     );
     final appConfigProvider = Provider.of<AppConfigProvider>(context);
 
@@ -169,11 +170,12 @@ class _SettingsWidgetState extends State<SettingsWidget> {
           settingsTile(
             icon: Icons.storage_rounded,
             title: AppLocalizations.of(context)!.servers,
-            subtitle: selectedServer != null
-                ? isConnectionAttemptFinished
-                    ? '${AppLocalizations.of(context)!.connectedTo} ${selectedServer.alias}'
-                    : AppLocalizations.of(context)!.notConnectServer
-                : AppLocalizations.of(context)!.notSelected,
+            subtitle: _buildServerSubtitle(
+              context: context,
+              selectedServer: selectedServer,
+              serverStatus: serverStatus,
+              isAliasOnly: false,
+            ),
             screenToNavigate: const ServersPage(),
             thisItem: 2,
           ),
@@ -198,11 +200,12 @@ class _SettingsWidgetState extends State<SettingsWidget> {
           settingsTile(
             icon: Icons.connected_tv_rounded,
             title: AppLocalizations.of(context)!.serverInfo,
-            subtitle: selectedServer != null
-                ? isConnectionAttemptFinished
-                    ? selectedServer.alias
-                    : AppLocalizations.of(context)!.notConnectServer
-                : AppLocalizations.of(context)!.notSelected,
+            subtitle: _buildServerSubtitle(
+              context: context,
+              selectedServer: selectedServer,
+              serverStatus: serverStatus,
+              isAliasOnly: true,
+            ),
             screenToNavigate: const ServerInfoScreen(),
             thisItem: 4,
           ),
@@ -343,5 +346,28 @@ class _SettingsWidgetState extends State<SettingsWidget> {
         ),
       ),
     );
+  }
+
+  String _buildServerSubtitle({
+    required BuildContext context,
+    required Server? selectedServer,
+    required LoadStatus serverStatus,
+    required bool isAliasOnly,
+  }) {
+    if (selectedServer == null) {
+      return AppLocalizations.of(context)!.notSelected;
+    }
+
+    switch (serverStatus) {
+      case LoadStatus.loaded:
+        if (isAliasOnly) {
+          return selectedServer.alias;
+        }
+        return '${AppLocalizations.of(context)!.connectedTo} ${selectedServer.alias}';
+      case LoadStatus.loading:
+        return AppLocalizations.of(context)!.connectingToServer;
+      case LoadStatus.error:
+        return AppLocalizations.of(context)!.notConnectServer;
+    }
   }
 }

--- a/lib/services/server_connection_service.dart
+++ b/lib/services/server_connection_service.dart
@@ -1,0 +1,157 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:pi_hole_client/classes/process_modal.dart';
+import 'package:pi_hole_client/config/globals.dart';
+import 'package:pi_hole_client/constants/enums.dart';
+import 'package:pi_hole_client/functions/logger.dart';
+import 'package:pi_hole_client/functions/snackbar.dart';
+import 'package:pi_hole_client/l10n/generated/app_localizations.dart';
+import 'package:pi_hole_client/models/gateways.dart';
+import 'package:pi_hole_client/models/server.dart';
+import 'package:pi_hole_client/providers/app_config_provider.dart';
+import 'package:pi_hole_client/providers/servers_provider.dart';
+import 'package:pi_hole_client/providers/status_provider.dart';
+import 'package:pi_hole_client/services/status_update_service.dart';
+
+class ServerConnectionService {
+  ServerConnectionService({
+    required this.context,
+    required this.appConfigProvider,
+    required this.statusProvider,
+    required this.serversProvider,
+    required this.statusUpdateService,
+    required this.server,
+    this.useRootContextOnFailure = false,
+    this.showModal = false,
+  });
+
+  final BuildContext context;
+  final AppConfigProvider appConfigProvider;
+  final StatusProvider statusProvider;
+  final ServersProvider serversProvider;
+  final StatusUpdateService statusUpdateService;
+  final Server server;
+  final bool useRootContextOnFailure;
+  final bool showModal;
+
+  Future<void> connect() async {
+    final previouslySelectedServer = serversProvider.selectedServer;
+
+    _startConnection();
+
+    final result = await _runLoginQuery();
+
+    // If another server (other than B) is selected while switching from server A to B, abort the process.
+    // Without this check, it may appear as if the app is connected to B, even though a different server was actually selected.
+    if (serversProvider.connectingServer != server) {
+      logger.w(
+        'Server switch interrupted: '
+        '${previouslySelectedServer?.address}(${previouslySelectedServer?.alias}) '
+        '-> ${server.address}(${server.alias}) '
+        '-> ${serversProvider.selectedServer?.address}(${serversProvider.selectedServer?.alias})',
+      );
+      return;
+    }
+
+    serversProvider.clearConnectingServer();
+
+    if (result?.result == APiResponseType.success) {
+      logger.d(
+        '<*> Server connection successful: '
+        '${previouslySelectedServer?.address}(${previouslySelectedServer?.alias}) '
+        '-> ${server.address}(${server.alias})',
+      );
+      _onSuccess(result!);
+    } else {
+      logger.d(
+        'Fallback to previously selected server: '
+        '${previouslySelectedServer?.address}(${previouslySelectedServer?.alias}) '
+        '<- ${server.address}(${server.alias})',
+      );
+      _onFailure(previouslySelectedServer);
+    }
+  }
+
+  void _startConnection() {
+    serversProvider.setConnectingServer(server);
+    statusUpdateService.stopAutoRefresh();
+    statusProvider.setServerStatus(LoadStatus.loading);
+  }
+
+  Future<LoginQueryResponse?> _runLoginQuery() async {
+    ProcessModal? process;
+    if (showModal) {
+      process = ProcessModal(context: context);
+      process.open(AppLocalizations.of(context)!.connecting);
+    }
+
+    final result = await serversProvider.loadApiGateway(server)?.loginQuery();
+    process?.close();
+    return result;
+  }
+
+  void _onSuccess(LoginQueryResponse result) {
+    if (serversProvider.selectedServer == null &&
+        appConfigProvider.selectedTab == 1) {
+      appConfigProvider.setSelectedTab(4);
+    }
+
+    serversProvider.setselectedServer(
+      server: Server(
+        address: server.address,
+        alias: server.alias,
+        defaultServer: server.defaultServer,
+        apiVersion: server.apiVersion,
+        enabled: result.status == 'enabled',
+        allowSelfSignedCert: server.allowSelfSignedCert,
+        sm: server.sm,
+      ),
+    );
+
+    statusProvider.setServerStatus(LoadStatus.loaded);
+    statusUpdateService.startAutoRefresh();
+  }
+
+  void _onFailure(Server? fallback) {
+    if (fallback != null) {
+      serversProvider.setselectedServer(server: fallback);
+      statusProvider.setServerStatus(LoadStatus.loading);
+      statusUpdateService.startAutoRefresh();
+    } else {
+      statusProvider.setServerStatus(LoadStatus.error);
+    }
+
+    // If the system back button is pressed and the user returns to the Home
+    // screen before the connection completes (while the modal is still visible)
+    if (!context.mounted) {
+      if (useRootContextOnFailure) {
+        final fallbackContext = globalNavigatorKey.currentContext!;
+        showErrorSnackBar(
+          context: fallbackContext,
+          appConfigProvider: appConfigProvider,
+          label: AppLocalizations.of(fallbackContext)!
+              .couldNotConnectServerFallback,
+          duration: 5,
+        );
+      } else {
+        return;
+      }
+    }
+
+    if (useRootContextOnFailure) {
+      showErrorSnackBar(
+        context: context,
+        appConfigProvider: appConfigProvider,
+        label: AppLocalizations.of(context)!.cannotConnect,
+      );
+    } else {
+      showErrorSnackBar(
+        context: context,
+        appConfigProvider: appConfigProvider,
+        label: AppLocalizations.of(context)!.couldNotConnectServerFallback,
+        duration: 5,
+      );
+    }
+  }
+}

--- a/lib/services/server_connection_service.dart
+++ b/lib/services/server_connection_service.dart
@@ -139,18 +139,37 @@ class ServerConnectionService {
       }
     }
 
+    BuildContext? targetContext;
+    String? label;
+    var duration = 3;
+
     if (useRootContextOnFailure) {
-      showErrorSnackBar(
-        context: context,
-        appConfigProvider: appConfigProvider,
-        label: AppLocalizations.of(context)!.cannotConnect,
-      );
+      if (context.mounted) {
+        targetContext = context;
+        label = AppLocalizations.of(context)!.cannotConnect;
+        duration = 3;
+      } else {
+        targetContext = globalNavigatorKey.currentContext;
+        if (targetContext != null) {
+          label =
+              AppLocalizations.of(targetContext)!.couldNotConnectServerFallback;
+          duration = 5;
+        }
+      }
     } else {
+      if (context.mounted) {
+        targetContext = context;
+        label = AppLocalizations.of(context)!.couldNotConnectServerFallback;
+        duration = 5;
+      }
+    }
+
+    if (targetContext != null && label != null) {
       showErrorSnackBar(
-        context: context,
+        context: targetContext,
         appConfigProvider: appConfigProvider,
-        label: AppLocalizations.of(context)!.couldNotConnectServerFallback,
-        duration: 5,
+        label: label,
+        duration: duration,
       );
     }
   }

--- a/lib/services/status_update_service.dart
+++ b/lib/services/status_update_service.dart
@@ -121,12 +121,12 @@ class StatusUpdateService {
       ],
     ))
         .every((result) => result)) {
-      _statusProvider.setIsServerConnected(true);
+      _statusProvider.setServerStatus(LoadStatus.loaded);
     } else {
       logger.w(
         'Failed to fetch all status data. ',
       );
-      _statusProvider.setIsServerConnected(false);
+      _statusProvider.setServerStatus(LoadStatus.error);
     }
   }
 
@@ -220,16 +220,16 @@ class StatusUpdateService {
 
         setClientsFromTopSources(statusResult);
 
-        if (!_statusProvider.isServerConnected) {
-          _statusProvider.setIsServerConnected(true);
+        if (_statusProvider.isServerLoading) {
+          _statusProvider.setServerStatus(LoadStatus.loaded);
         }
       } else {
         if (selectedUrlBefore == currentServer.address) {
-          if (_statusProvider.isServerConnected) {
+          if (_statusProvider.getServerStatus == LoadStatus.loaded) {
             logger.w(
               'Server disconnected: ${statusResult?.result.name}. ${currentServer.alias} (${currentServer.address})',
             );
-            _statusProvider.setIsServerConnected(false);
+            _statusProvider.setServerStatus(LoadStatus.error);
           }
           if (_statusProvider.getStatusLoading == LoadStatus.loading) {
             _statusProvider.setStatusLoading(LoadStatus.error);
@@ -270,16 +270,16 @@ class StatusUpdateService {
         _statusProvider.setOvertimeData(statusResult!.data!);
         _statusProvider.setOvertimeDataLoadingStatus(LoadStatus.loaded);
 
-        if (!_statusProvider.isServerConnected) {
-          _statusProvider.setIsServerConnected(true);
+        if (_statusProvider.isServerLoading) {
+          _statusProvider.setServerStatus(LoadStatus.loaded);
         }
       } else {
         if (statusUrlBefore == currentServer.address) {
-          if (_statusProvider.isServerConnected) {
+          if (_statusProvider.getServerStatus == LoadStatus.loaded) {
             logger.w(
               'Server disconnected: ${statusResult?.result.name}. ${currentServer.alias} (${currentServer.address})',
             );
-            _statusProvider.setIsServerConnected(false);
+            _statusProvider.setServerStatus(LoadStatus.error);
           }
           if (_statusProvider.getOvertimeDataLoadStatus == LoadStatus.loading) {
             _statusProvider.setOvertimeDataLoadingStatus(LoadStatus.error);

--- a/lib/services/status_update_service.dart
+++ b/lib/services/status_update_service.dart
@@ -90,6 +90,9 @@ class StatusUpdateService {
     if (_isAutoRefreshRunning) return;
     _isAutoRefreshRunning = true;
 
+    _statusProvider.setStatusLoading(LoadStatus.loading);
+    _statusProvider.setOvertimeDataLoadingStatus(LoadStatus.loading);
+
     _setupStatusDataTimer(runImmediately: runImmediately);
     _setupOverTimeDataTimer(runImmediately: runImmediately, isDelay: isDelay);
     _setupMetricsDataTimer(runImmediately: runImmediately, isDelay: isDelay);
@@ -97,6 +100,9 @@ class StatusUpdateService {
 
   /// Stop timer for auto refresh
   void _stopAutoRefresh() {
+    _statusProvider.setStatusLoading(LoadStatus.loading);
+    _statusProvider.setOvertimeDataLoadingStatus(LoadStatus.loading);
+
     _isAutoRefreshRunning = false;
     _statusDataTimer?.cancel();
     _overTimeDataTimer?.cancel();
@@ -220,7 +226,8 @@ class StatusUpdateService {
 
       if (_serversProvider.selectedServer?.address != selectedUrlBefore) {
         logger.d(
-          'Skipping stale status update: server was changed during fetch.',
+          'Skipping stale status update: server was changed during fetch. '
+          'Previous: $selectedUrlBefore, Selected: ${_serversProvider.selectedServer?.address}',
         );
         return;
       }
@@ -289,7 +296,8 @@ class StatusUpdateService {
 
       if (_serversProvider.selectedServer?.address != selectedUrlBefore) {
         logger.d(
-          'Skipping stale overtime data update: server was changed during fetch.',
+          'Skipping stale overtime data update: server was changed during fetch. '
+          'Previous: $selectedUrlBefore, Selected: ${_serversProvider.selectedServer?.address}',
         );
         return;
       }
@@ -360,7 +368,8 @@ class StatusUpdateService {
 
       if (_serversProvider.selectedServer?.address != selectedUrlBefore) {
         logger.d(
-          'Skipping stale metrics update: server was changed during fetch.',
+          'Skipping stale metrics update: server was changed during fetch. '
+          'Previous: $selectedUrlBefore, Selected: ${_serversProvider.selectedServer?.address}',
         );
         return;
       }

--- a/lib/services/status_update_service.dart
+++ b/lib/services/status_update_service.dart
@@ -216,6 +216,7 @@ class StatusUpdateService {
           statusResult!.data!.status == 'enabled',
         );
         _statusProvider.setRealtimeStatus(statusResult.data!);
+        _statusProvider.setStatusLoading(LoadStatus.loaded);
 
         setClientsFromTopSources(statusResult);
 
@@ -267,7 +268,6 @@ class StatusUpdateService {
 
       if (statusResult?.result == APiResponseType.success) {
         _statusProvider.setOvertimeData(statusResult!.data!);
-
         _statusProvider.setOvertimeDataLoadingStatus(LoadStatus.loaded);
 
         if (!_statusProvider.isServerConnected) {

--- a/test/full_coverage_test.dart
+++ b/test/full_coverage_test.dart
@@ -215,6 +215,7 @@ import 'package:pi_hole_client/services/logs_actions_service.dart';
 import 'package:pi_hole_client/services/logs_pagination_service.dart';
 import 'package:pi_hole_client/services/logs_screen_service.dart';
 import 'package:pi_hole_client/services/secret_manager.dart';
+import 'package:pi_hole_client/services/server_connection_service.dart';
 import 'package:pi_hole_client/services/status_update_service.dart';
 import 'package:pi_hole_client/widgets/adaptive_trailing_text.dart';
 import 'package:pi_hole_client/widgets/bottom_nav_bar.dart';

--- a/test/ut/providers/domains_list_provider_test.mocks.dart
+++ b/test/ut/providers/domains_list_provider_test.mocks.dart
@@ -480,6 +480,24 @@ class MockServersProvider extends _i1.Mock implements _i6.ServersProvider {
       );
 
   @override
+  void setConnectingServer(_i3.Server? server) => super.noSuchMethod(
+        Invocation.method(
+          #setConnectingServer,
+          [server],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void clearConnectingServer() => super.noSuchMethod(
+        Invocation.method(
+          #clearConnectingServer,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
   _i9.ApiGateway? loadApiGateway(_i3.Server? server) =>
       (super.noSuchMethod(Invocation.method(
         #loadApiGateway,

--- a/test/ut/providers/filters_provider_test.mocks.dart
+++ b/test/ut/providers/filters_provider_test.mocks.dart
@@ -90,6 +90,24 @@ class MockServersProvider extends _i1.Mock implements _i3.ServersProvider {
       );
 
   @override
+  void setConnectingServer(_i4.Server? server) => super.noSuchMethod(
+        Invocation.method(
+          #setConnectingServer,
+          [server],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void clearConnectingServer() => super.noSuchMethod(
+        Invocation.method(
+          #clearConnectingServer,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
   _i7.ApiGateway? loadApiGateway(_i4.Server? server) =>
       (super.noSuchMethod(Invocation.method(
         #loadApiGateway,

--- a/test/ut/providers/gravity_provider_test.mocks.dart
+++ b/test/ut/providers/gravity_provider_test.mocks.dart
@@ -513,6 +513,24 @@ class MockServersProvider extends _i1.Mock implements _i8.ServersProvider {
       );
 
   @override
+  void setConnectingServer(_i5.Server? server) => super.noSuchMethod(
+        Invocation.method(
+          #setConnectingServer,
+          [server],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void clearConnectingServer() => super.noSuchMethod(
+        Invocation.method(
+          #clearConnectingServer,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
   _i11.ApiGateway? loadApiGateway(_i5.Server? server) =>
       (super.noSuchMethod(Invocation.method(
         #loadApiGateway,

--- a/test/ut/providers/groups_provider_test.mocks.dart
+++ b/test/ut/providers/groups_provider_test.mocks.dart
@@ -480,6 +480,24 @@ class MockServersProvider extends _i1.Mock implements _i6.ServersProvider {
       );
 
   @override
+  void setConnectingServer(_i3.Server? server) => super.noSuchMethod(
+        Invocation.method(
+          #setConnectingServer,
+          [server],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void clearConnectingServer() => super.noSuchMethod(
+        Invocation.method(
+          #clearConnectingServer,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
   _i9.ApiGateway? loadApiGateway(_i3.Server? server) =>
       (super.noSuchMethod(Invocation.method(
         #loadApiGateway,

--- a/test/ut/providers/servers_provider_test.dart
+++ b/test/ut/providers/servers_provider_test.dart
@@ -106,6 +106,7 @@ void main() async {
       expect(serversProvider.selectedApiGateway, null);
       expect(serversProvider.numShown, 0);
       expect(serversProvider.queryStatuses, []);
+      expect(serversProvider.connectingServer, null);
       expect(listenerCalled, false);
     });
 
@@ -275,5 +276,23 @@ void main() async {
         expect(listenerCalled, true);
       },
     );
+
+    test(
+      'setConnectingServer sets the connecting server',
+      () async {
+        serversProvider.setConnectingServer(server);
+
+        expect(serversProvider.connectingServer, server);
+        expect(listenerCalled, false);
+      },
+    );
+
+    test('clearConnectingServer clears the connecting server', () {
+      serversProvider.setConnectingServer(server);
+      serversProvider.clearConnectingServer();
+
+      expect(serversProvider.connectingServer, null);
+      expect(listenerCalled, false);
+    });
   });
 }

--- a/test/ut/providers/status_provider_test.dart
+++ b/test/ut/providers/status_provider_test.dart
@@ -20,7 +20,7 @@ void main() {
     });
 
     test('Initial values are correct', () {
-      expect(statusProvider.isServerConnected, false);
+      expect(statusProvider.getServerStatus, LoadStatus.loading);
       expect(statusProvider.getRealtimeStatus, null);
       expect(statusProvider.getStatusLoading, LoadStatus.loading);
       expect(statusProvider.getOvertimeData, null);
@@ -32,8 +32,8 @@ void main() {
     });
 
     test('setIsServerConnected updates value and notifies listeners', () {
-      statusProvider.setIsServerConnected(true);
-      expect(statusProvider.isServerConnected, true);
+      statusProvider.setServerStatus(LoadStatus.loaded);
+      expect(statusProvider.getServerStatus, LoadStatus.loaded);
       expect(listenerCalled, true);
     });
 

--- a/test/ut/providers/status_provider_test.dart
+++ b/test/ut/providers/status_provider_test.dart
@@ -29,7 +29,7 @@ void main() {
       expect(statusProvider.getDnsCacheInfo, null);
       expect(statusProvider.getDnsRepliesInfo, null);
       expect(statusProvider.getOvertimeDataLoadStatus, LoadStatus.loading);
-      expect(statusProvider.isServerLoading, LoadStatus.loading);
+      expect(statusProvider.isServerLoading, true);
     });
 
     test('setServerStatus updates value and notifies listeners', () {

--- a/test/ut/providers/status_provider_test.dart
+++ b/test/ut/providers/status_provider_test.dart
@@ -29,9 +29,10 @@ void main() {
       expect(statusProvider.getDnsCacheInfo, null);
       expect(statusProvider.getDnsRepliesInfo, null);
       expect(statusProvider.getOvertimeDataLoadStatus, LoadStatus.loading);
+      expect(statusProvider.isServerLoading, LoadStatus.loading);
     });
 
-    test('setIsServerConnected updates value and notifies listeners', () {
+    test('setServerStatus updates value and notifies listeners', () {
       statusProvider.setServerStatus(LoadStatus.loaded);
       expect(statusProvider.getServerStatus, LoadStatus.loaded);
       expect(listenerCalled, true);

--- a/test/ut/providers/subscriptions_list_provider_test.mocks.dart
+++ b/test/ut/providers/subscriptions_list_provider_test.mocks.dart
@@ -480,6 +480,24 @@ class MockServersProvider extends _i1.Mock implements _i6.ServersProvider {
       );
 
   @override
+  void setConnectingServer(_i3.Server? server) => super.noSuchMethod(
+        Invocation.method(
+          #setConnectingServer,
+          [server],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void clearConnectingServer() => super.noSuchMethod(
+        Invocation.method(
+          #clearConnectingServer,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
   _i9.ApiGateway? loadApiGateway(_i3.Server? server) =>
       (super.noSuchMethod(Invocation.method(
         #loadApiGateway,

--- a/test/ut/services/status_update_service_test.dart
+++ b/test/ut/services/status_update_service_test.dart
@@ -61,6 +61,7 @@ void main() async {
       when(mockServersProvider.selectedApiGateway).thenReturn(mockApiGatewayV6);
       when(mockServersProvider.updateselectedServerStatus(any))
           .thenReturn(null);
+      when(mockServersProvider.connectingServer).thenReturn(null);
 
       when(mockStatusProvider.setServerStatus(any)).thenReturn(null);
       when(mockStatusProvider.setRealtimeStatus(any)).thenReturn(null);
@@ -135,6 +136,21 @@ void main() async {
       verify(mockStatusProvider.setRealtimeStatus(any)).called(1);
       verify(mockStatusProvider.setOvertimeData(any)).called(1);
       verify(mockStatusProvider.setMetricsInfo(any)).called(1);
+      expect(statusUpdateService.isAutoRefreshRunning, true);
+
+      statusUpdateService.stopAutoRefresh();
+    });
+
+    test('startAutoRefresh while switching servers', () async {
+      when(mockServersProvider.connectingServer).thenReturn(server);
+
+      statusUpdateService.startAutoRefresh();
+
+      await Future.delayed(const Duration(seconds: 1));
+      verify(mockAppConfigProvider.getAutoRefreshTime).called(4);
+      verifyNever(mockStatusProvider.setRealtimeStatus(any));
+      verifyNever(mockStatusProvider.setOvertimeData(any));
+      verifyNever(mockStatusProvider.setMetricsInfo(any));
       expect(statusUpdateService.isAutoRefreshRunning, true);
 
       statusUpdateService.stopAutoRefresh();

--- a/test/ut/services/status_update_service_test.dart
+++ b/test/ut/services/status_update_service_test.dart
@@ -62,14 +62,14 @@ void main() async {
       when(mockServersProvider.updateselectedServerStatus(any))
           .thenReturn(null);
 
-      when(mockStatusProvider.setIsServerConnected(any)).thenReturn(null);
+      when(mockStatusProvider.setServerStatus(any)).thenReturn(null);
       when(mockStatusProvider.setRealtimeStatus(any)).thenReturn(null);
       when(mockStatusProvider.setStatusLoading(any)).thenReturn(null);
       when(mockStatusProvider.setOvertimeData(any)).thenReturn(null);
       when(mockStatusProvider.setMetricsInfo(any)).thenReturn(null);
       when(mockStatusProvider.setOvertimeDataLoadingStatus(any))
           .thenReturn(null);
-      when(mockStatusProvider.isServerConnected).thenReturn(false);
+      when(mockStatusProvider.isServerLoading).thenReturn(true);
 
       when(mockFiltersProvider.setClients(any)).thenReturn(null);
 
@@ -165,7 +165,8 @@ void main() async {
         ),
       );
 
-      when(mockStatusProvider.isServerConnected).thenReturn(true);
+      when(mockStatusProvider.getServerStatus).thenReturn(LoadStatus.loaded);
+      when(mockStatusProvider.isServerLoading).thenReturn(false);
       when(mockStatusProvider.getStatusLoading).thenReturn(LoadStatus.loading);
       when(mockStatusProvider.getOvertimeDataLoadStatus)
           .thenReturn(LoadStatus.loading);
@@ -195,7 +196,8 @@ void main() async {
         );
       });
 
-      when(mockStatusProvider.isServerConnected).thenReturn(true);
+      when(mockStatusProvider.getServerStatus).thenReturn(LoadStatus.loaded);
+      when(mockStatusProvider.isServerLoading).thenReturn(false);
       when(mockStatusProvider.getStatusLoading).thenReturn(LoadStatus.loading);
       when(mockStatusProvider.getOvertimeDataLoadStatus)
           .thenReturn(LoadStatus.loading);
@@ -225,7 +227,8 @@ void main() async {
         );
       });
 
-      when(mockStatusProvider.isServerConnected).thenReturn(true);
+      when(mockStatusProvider.getServerStatus).thenReturn(LoadStatus.loaded);
+      when(mockStatusProvider.isServerLoading).thenReturn(false);
       when(mockStatusProvider.getStatusLoading).thenReturn(LoadStatus.loading);
       when(mockStatusProvider.getOvertimeDataLoadStatus)
           .thenReturn(LoadStatus.loading);

--- a/test/ut/services/status_update_service_test.mocks.dart
+++ b/test/ut/services/status_update_service_test.mocks.dart
@@ -902,6 +902,24 @@ class MockServersProvider extends _i1.Mock implements _i15.ServersProvider {
       );
 
   @override
+  void setConnectingServer(_i3.Server? server) => super.noSuchMethod(
+        Invocation.method(
+          #setConnectingServer,
+          [server],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void clearConnectingServer() => super.noSuchMethod(
+        Invocation.method(
+          #clearConnectingServer,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
   _i17.ApiGateway? loadApiGateway(_i3.Server? server) =>
       (super.noSuchMethod(Invocation.method(
         #loadApiGateway,

--- a/test/ut/services/status_update_service_test.mocks.dart
+++ b/test/ut/services/status_update_service_test.mocks.dart
@@ -1076,8 +1076,14 @@ class MockStatusProvider extends _i1.Mock implements _i18.StatusProvider {
   }
 
   @override
-  bool get isServerConnected => (super.noSuchMethod(
-        Invocation.getter(#isServerConnected),
+  _i19.LoadStatus get getServerStatus => (super.noSuchMethod(
+        Invocation.getter(#getServerStatus),
+        returnValue: _i19.LoadStatus.loading,
+      ) as _i19.LoadStatus);
+
+  @override
+  bool get isServerLoading => (super.noSuchMethod(
+        Invocation.getter(#isServerLoading),
         returnValue: false,
       ) as bool);
 
@@ -1100,10 +1106,10 @@ class MockStatusProvider extends _i1.Mock implements _i18.StatusProvider {
       ) as bool);
 
   @override
-  void setIsServerConnected(bool? value) => super.noSuchMethod(
+  void setServerStatus(_i19.LoadStatus? status) => super.noSuchMethod(
         Invocation.method(
-          #setIsServerConnected,
-          [value],
+          #setServerStatus,
+          [status],
         ),
         returnValueForMissingStub: null,
       );

--- a/test/widgets/helpers.dart
+++ b/test/widgets/helpers.dart
@@ -1745,7 +1745,7 @@ class TestSetupHelper {
     );
     when(mockServersProvider.removeServer(any)).thenAnswer((_) async => true);
     when(mockServersProvider.deleteDbData()).thenAnswer((_) async => true);
-    when(mockServersProvider.connectingServer).thenReturn(null);
+    when(mockServersProvider.connectingServer).thenReturn(serverV6);
   }
 
   void _initFiltersProviderMock(String useApiGatewayVersion) {

--- a/test/widgets/helpers.dart
+++ b/test/widgets/helpers.dart
@@ -1745,6 +1745,7 @@ class TestSetupHelper {
     );
     when(mockServersProvider.removeServer(any)).thenAnswer((_) async => true);
     when(mockServersProvider.deleteDbData()).thenAnswer((_) async => true);
+    when(mockServersProvider.connectingServer).thenReturn(null);
   }
 
   void _initFiltersProviderMock(String useApiGatewayVersion) {

--- a/test/widgets/helpers.dart
+++ b/test/widgets/helpers.dart
@@ -1778,7 +1778,8 @@ class TestSetupHelper {
 
   void _initStatusProviderMock(String useApiGatewayVersion) {
     when(mockStatusProvider.getStatusLoading).thenReturn(LoadStatus.loaded);
-    when(mockStatusProvider.isServerConnected).thenReturn(true);
+    when(mockStatusProvider.getServerStatus).thenReturn(LoadStatus.loaded);
+    when(mockStatusProvider.isServerLoading).thenReturn(false);
     when(mockStatusProvider.getOvertimeData).thenReturn(overtimeData);
     when(mockStatusProvider.getOvertimeDataLoadStatus)
         .thenReturn(LoadStatus.loaded);

--- a/test/widgets/helpers.mocks.dart
+++ b/test/widgets/helpers.mocks.dart
@@ -910,6 +910,24 @@ class MockServersProvider extends _i1.Mock implements _i15.ServersProvider {
       );
 
   @override
+  void setConnectingServer(_i3.Server? server) => super.noSuchMethod(
+        Invocation.method(
+          #setConnectingServer,
+          [server],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void clearConnectingServer() => super.noSuchMethod(
+        Invocation.method(
+          #clearConnectingServer,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
   _i17.ApiGateway? loadApiGateway(_i3.Server? server) =>
       (super.noSuchMethod(Invocation.method(
         #loadApiGateway,

--- a/test/widgets/helpers.mocks.dart
+++ b/test/widgets/helpers.mocks.dart
@@ -1288,8 +1288,14 @@ class MockStatusProvider extends _i1.Mock implements _i20.StatusProvider {
   }
 
   @override
-  bool get isServerConnected => (super.noSuchMethod(
-        Invocation.getter(#isServerConnected),
+  _i19.LoadStatus get getServerStatus => (super.noSuchMethod(
+        Invocation.getter(#getServerStatus),
+        returnValue: _i19.LoadStatus.loading,
+      ) as _i19.LoadStatus);
+
+  @override
+  bool get isServerLoading => (super.noSuchMethod(
+        Invocation.getter(#isServerLoading),
         returnValue: false,
       ) as bool);
 
@@ -1312,10 +1318,10 @@ class MockStatusProvider extends _i1.Mock implements _i20.StatusProvider {
       ) as bool);
 
   @override
-  void setIsServerConnected(bool? value) => super.noSuchMethod(
+  void setServerStatus(_i19.LoadStatus? status) => super.noSuchMethod(
         Invocation.method(
-          #setIsServerConnected,
-          [value],
+          #setServerStatus,
+          [status],
         ),
         returnValueForMissingStub: null,
       );

--- a/test/widgets/screens/home/home_test.dart
+++ b/test/widgets/screens/home/home_test.dart
@@ -50,7 +50,7 @@ void main() async {
 
           // Home App Bar
           expect(
-            find.byIcon(Icons.verified_user_rounded),
+            find.byIcon(Icons.gpp_good_rounded),
             findsOneWidget,
           );
           expect(find.byIcon(Icons.more_vert), findsOneWidget);

--- a/test/widgets/screens/home/home_test.dart
+++ b/test/widgets/screens/home/home_test.dart
@@ -284,8 +284,9 @@ void main() async {
           tester.view.physicalSize = const Size(1080, 2400);
           tester.view.devicePixelRatio = 2.0;
 
-          when(testSetup.mockStatusProvider.isServerConnected)
-              .thenReturn(false);
+          when(testSetup.mockStatusProvider.getServerStatus)
+              .thenReturn(LoadStatus.loading);
+          when(testSetup.mockStatusProvider.isServerLoading).thenReturn(true);
 
           addTearDown(() {
             tester.view.resetPhysicalSize();

--- a/test/widgets/screens/servers/servers_test.dart
+++ b/test/widgets/screens/servers/servers_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/mockito.dart';
+import 'package:pi_hole_client/models/gateways.dart';
 import 'package:pi_hole_client/screens/servers/add_server_fullscreen.dart';
 import 'package:pi_hole_client/screens/servers/delete_server_modal.dart';
 import 'package:pi_hole_client/screens/servers/servers.dart';
@@ -228,6 +229,39 @@ void main() async {
         await tester.pump(const Duration(milliseconds: 1000));
         await tester.pump(const Duration(milliseconds: 1000));
         expect(find.byType(AddServerFullscreen), findsOneWidget);
+      },
+    );
+
+    testWidgets(
+      'should show error when connecting to server',
+      (WidgetTester tester) async {
+        tester.view.physicalSize = const Size(1080, 2400);
+        tester.view.devicePixelRatio = 2.0;
+
+        when(testSetup.mockServersProvider.selectedServer).thenReturn(null);
+        when(testSetup.mockServersProvider.resetSelectedServer())
+            .thenAnswer((_) async => true);
+        when(testSetup.mockApiGatewayV6.loginQuery()).thenAnswer(
+            (_) async => LoginQueryResponse(result: APiResponseType.error));
+
+        addTearDown(() {
+          tester.view.resetPhysicalSize();
+          tester.view.resetDevicePixelRatio();
+        });
+
+        await tester.pumpWidget(
+          testSetup.buildTestWidget(
+            const ServersPage(),
+          ),
+        );
+
+        expect(find.byType(ServersPage), findsOneWidget);
+        expect(find.text('Servers'), findsOneWidget);
+        expect(find.text('Connect'), findsOneWidget);
+        await tester.tap(find.text('Connect'));
+        await tester.pumpAndSettle();
+        expect(find.byType(SnackBar), findsOneWidget);
+        expect(find.text('Cannot connect to server.'), findsOneWidget);
       },
     );
   });

--- a/test/widgets/screens/servers/servers_test.dart
+++ b/test/widgets/screens/servers/servers_test.dart
@@ -242,7 +242,8 @@ void main() async {
         when(testSetup.mockServersProvider.resetSelectedServer())
             .thenAnswer((_) async => true);
         when(testSetup.mockApiGatewayV6.loginQuery()).thenAnswer(
-            (_) async => LoginQueryResponse(result: APiResponseType.error));
+          (_) async => LoginQueryResponse(result: APiResponseType.error),
+        );
 
         addTearDown(() {
           tester.view.resetPhysicalSize();


### PR DESCRIPTION
## Overview

Fixes a bug where navigating away from the home screen during a server switch could result in an inconsistent state.  
Even if the new server successfully connects, the app may incorrectly fall back to the previously selected server and display it as active.  
This caused confusion across screens due to mismatched connection and UI state.

## Changes

- Retains the selected server during connection attempts, even when navigating away from the home screen
- Cancels outdated connection attempts if the selected server changes mid-process
- Prevents fallback unless a connection failure is explicitly detected (e.g. timeout)