### PR TITLE
fix(auto_refresh): avoid 'Connection closed before full header was received' on specific devices

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -7,7 +7,6 @@
         android:name="${applicationName}"
         android:icon="@mipmap/ic_launcher"
         android:allowBackup="false"
-        android:usesCleartextTraffic="true"
         android:fullBackupContent="@xml/backup_rules">
         <activity
             android:name=".MainActivity"

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -7,6 +7,7 @@
         android:name="${applicationName}"
         android:icon="@mipmap/ic_launcher"
         android:allowBackup="false"
+        android:usesCleartextTraffic="true"
         android:fullBackupContent="@xml/backup_rules">
         <activity
             android:name=".MainActivity"

--- a/lib/services/status_update_service.dart
+++ b/lib/services/status_update_service.dart
@@ -241,7 +241,7 @@ class StatusUpdateService {
 
         setClientsFromTopSources(statusResult);
 
-        if (_statusProvider.isServerLoading) {
+        if (_statusProvider.getServerStatus != LoadStatus.loaded) {
           _statusProvider.setServerStatus(LoadStatus.loaded);
         }
       } else {
@@ -306,7 +306,7 @@ class StatusUpdateService {
         _statusProvider.setOvertimeData(statusResult!.data!);
         _statusProvider.setOvertimeDataLoadingStatus(LoadStatus.loaded);
 
-        if (_statusProvider.isServerLoading) {
+        if (_statusProvider.getServerStatus != LoadStatus.loaded) {
           _statusProvider.setServerStatus(LoadStatus.loaded);
         }
       } else {

--- a/lib/services/status_update_service.dart
+++ b/lib/services/status_update_service.dart
@@ -264,10 +264,13 @@ class StatusUpdateService {
     }
 
     _statusDataTimer = Timer.periodic(
-      // Add a small buffer to avoid 'ClientException: Connection closed before full header was received'
+      // Add a slight negative offset to avoid 'ClientException: Connection closed before full header was received'.
       // This error occurs frequently on certain devices (e.g. Pixel 6a) when using exact intervals (e.g. 5000ms).
+      // Using a slightly shorter interval (e.g. 4700ms) prevents hitting the edge of server-side timeout.
+      // Adding instead (+300ms) causes the socket to expire just before reuse,
+      // resulting in every request creating a new TCP handshake and closing the socket immediately.
       Duration(
-        milliseconds: _appConfigProvider.getAutoRefreshTime! * 1000 + 300,
+        milliseconds: _appConfigProvider.getAutoRefreshTime! * 1000 - 300,
       ),
       (timer) => timerFn(timer: timer),
     );

--- a/lib/services/status_update_service.dart
+++ b/lib/services/status_update_service.dart
@@ -57,7 +57,7 @@ class StatusUpdateService {
   /// - [isDelay]: If true, the refresh will be delayed by a short duration.
   void startAutoRefresh({
     bool runImmediately = true,
-    bool isDelay = false,
+    bool isDelay = true,
   }) {
     if (!_isAutoRefreshRunning) {
       logger.d(
@@ -264,7 +264,11 @@ class StatusUpdateService {
     }
 
     _statusDataTimer = Timer.periodic(
-      Duration(seconds: _appConfigProvider.getAutoRefreshTime!),
+      // Add a small buffer to avoid 'ClientException: Connection closed before full header was received'
+      // This error occurs frequently on certain devices (e.g. Pixel 6a) when using exact intervals (e.g. 5000ms).
+      Duration(
+        milliseconds: _appConfigProvider.getAutoRefreshTime! * 1000 + 300,
+      ),
       (timer) => timerFn(timer: timer),
     );
   }

--- a/lib/services/status_update_service.dart
+++ b/lib/services/status_update_service.dart
@@ -57,7 +57,7 @@ class StatusUpdateService {
   /// - [isDelay]: If true, the refresh will be delayed by a short duration.
   void startAutoRefresh({
     bool runImmediately = true,
-    bool isDelay = true,
+    bool isDelay = false,
   }) {
     if (!_isAutoRefreshRunning) {
       logger.d(

--- a/test/ut/services/status_update_service_test.dart
+++ b/test/ut/services/status_update_service_test.dart
@@ -71,6 +71,7 @@ void main() async {
       when(mockStatusProvider.setOvertimeDataLoadingStatus(any))
           .thenReturn(null);
       when(mockStatusProvider.isServerLoading).thenReturn(true);
+      when(mockStatusProvider.getServerStatus).thenReturn(LoadStatus.loading);
 
       when(mockFiltersProvider.setClients(any)).thenReturn(null);
 


### PR DESCRIPTION
## Overview
This pull request fixes a network-related error and a UI bug in the server status indicator. The changes improve connection reliability during auto-refresh and ensure the status icon correctly updates after recovery from an error state.

## Changes
- Reduced the auto-refresh interval by 300ms to prevent ClientException: Connection closed before full header was received, which occurred on specific devices like Pixel 6a.

- Fixed an issue where the server status icon did not reset correctly after recovering from an error.
