### PR TITLE
feat(adlist): simplify Adlist layout from 3-column to 2-column on tablets

### DIFF
--- a/lib/screens/settings/server_settings/subscriptions.dart
+++ b/lib/screens/settings/server_settings/subscriptions.dart
@@ -269,47 +269,7 @@ class _SubscriptionListsWidgetState extends State<SubscriptionListsWidget>
       );
     }
 
-    if (MediaQuery.of(context).size.width > ResponsiveConstants.xxLarge) {
-      // 3 columns layout
-      return Row(
-        children: [
-          Expanded(
-            child: scaffold(),
-          ),
-          Expanded(
-            child: selectedSubscription != null
-                ? SubscriptionDetailsScreen(
-                    subscription: selectedSubscription!,
-                    remove: (subscription) {
-                      setState(() => selectedSubscription = null);
-                      removeSubscription(subscription);
-                    },
-                    groups: groups,
-                    colors: serversProvider.colors,
-                  )
-                : ColoredBox(
-                    color: Theme.of(context).scaffoldBackgroundColor,
-                    child: SafeArea(
-                      child: Center(
-                        child: Text(
-                          AppLocalizations.of(context)!.selectAdlistsLeftColumn,
-                          textAlign: TextAlign.center,
-                          style: TextStyle(
-                            fontSize: 24,
-                            fontWeight: FontWeight.normal,
-                            decoration: TextDecoration.none,
-                            color:
-                                Theme.of(context).colorScheme.onSurfaceVariant,
-                          ),
-                        ),
-                      ),
-                    ),
-                  ),
-          ),
-        ],
-      );
-    } else if (MediaQuery.of(context).size.width > ResponsiveConstants.large) {
-      // 2 columns layout
+    if (MediaQuery.of(context).size.width > ResponsiveConstants.large) {
       return scaffold(
         onTap: (subscription) {
           Navigator.push(

--- a/test/widgets/screens/settings/server_settings/subscriptions_test.dart
+++ b/test/widgets/screens/settings/server_settings/subscriptions_test.dart
@@ -55,10 +55,6 @@ void main() async {
             find.text('There are no adlists to show here.'),
             findsOneWidget,
           );
-          expect(
-            find.text('Choose an adlist to see its details'),
-            findsOneWidget,
-          );
         },
       );
 
@@ -531,10 +527,6 @@ void main() async {
 
           expect(find.byType(SnackBar), findsOneWidget);
           expect(find.text('Adlist removed successfully'), findsWidgets);
-          expect(
-            find.text('Choose an adlist to see its details'),
-            findsWidgets,
-          );
         },
       );
 


### PR DESCRIPTION
## Overview

This PR updates the Adlist screen layout for tablet-sized devices by reducing the 3-column interface to a more focused 2-column layout.

## Screenshot

|before|after|
|---|---|
|![](https://github.com/user-attachments/assets/f21dbb43-f2a4-46e5-837b-d13d1a103be3)|![](https://github.com/user-attachments/assets/d7558cef-ffd5-400a-a4cb-bc5d450afa4f)|
