### PR TITLE
feat(device): add localized "hours ago" to lastQuery timestamp display

### DIFF
--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -522,6 +522,7 @@
   "systemTheme": "System Standard",
   "theme": "Design",
   "time": "Zeit",
+  "timeHoursAgo": "vor {hours} Stunden",
   "timestamps": "Zeitstempel",
   "tlsStatus": "TLS-Status",
   "toTime": "Bis",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -522,6 +522,7 @@
   "systemTheme": "System theme",
   "theme": "Theme",
   "time": "Time",
+  "timeHoursAgo": "{hours} hours ago",
   "timestamps": "Timestamps",
   "tlsStatus": "TLS Status",
   "toTime": "To time",

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -523,6 +523,7 @@
   "systemTheme": "Tema del sistema",
   "theme": "Tema",
   "time": "Hora",
+  "timeHoursAgo": "hace {hours} horas",
   "timestamps": "Marcas de tiempo",
   "tlsStatus": "Estado de TLS",
   "toTime": "Hasta",

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -524,6 +524,7 @@
   "systemTheme": "システムテーマ",
   "theme": "テーマ",
   "time": "時間",
+  "timeHoursAgo": "{hours}時間前",
   "timestamps": "タイムスタンプ",
   "tlsStatus": "TLSステータス",
   "toTime": "終了時刻",

--- a/lib/l10n/app_pl.arb
+++ b/lib/l10n/app_pl.arb
@@ -522,6 +522,7 @@
   "systemTheme": "Motyw systemowy",
   "theme": "Motyw",
   "time": "Czas",
+  "timeHoursAgo": "{hours} godzin temu",
   "timestamps": "Sygnatury czasowe",
   "tlsStatus": "Status TLS",
   "toTime": "Do kiedy",

--- a/lib/l10n/generated/app_localizations.dart
+++ b/lib/l10n/generated/app_localizations.dart
@@ -3242,6 +3242,12 @@ abstract class AppLocalizations {
   /// **'Time'**
   String get time;
 
+  /// No description provided for @timeHoursAgo.
+  ///
+  /// In en, this message translates to:
+  /// **'{hours} hours ago'**
+  String timeHoursAgo(Object hours);
+
   /// No description provided for @timestamps.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/generated/app_localizations_de.dart
+++ b/lib/l10n/generated/app_localizations_de.dart
@@ -1669,6 +1669,11 @@ class AppLocalizationsDe extends AppLocalizations {
   String get time => 'Zeit';
 
   @override
+  String timeHoursAgo(Object hours) {
+    return 'vor $hours Stunden';
+  }
+
+  @override
   String get timestamps => 'Zeitstempel';
 
   @override

--- a/lib/l10n/generated/app_localizations_en.dart
+++ b/lib/l10n/generated/app_localizations_en.dart
@@ -1638,6 +1638,11 @@ class AppLocalizationsEn extends AppLocalizations {
   String get time => 'Time';
 
   @override
+  String timeHoursAgo(Object hours) {
+    return '$hours hours ago';
+  }
+
+  @override
   String get timestamps => 'Timestamps';
 
   @override

--- a/lib/l10n/generated/app_localizations_es.dart
+++ b/lib/l10n/generated/app_localizations_es.dart
@@ -1666,6 +1666,11 @@ class AppLocalizationsEs extends AppLocalizations {
   String get time => 'Hora';
 
   @override
+  String timeHoursAgo(Object hours) {
+    return 'hace $hours horas';
+  }
+
+  @override
   String get timestamps => 'Marcas de tiempo';
 
   @override

--- a/lib/l10n/generated/app_localizations_ja.dart
+++ b/lib/l10n/generated/app_localizations_ja.dart
@@ -1595,6 +1595,11 @@ class AppLocalizationsJa extends AppLocalizations {
   String get time => '時間';
 
   @override
+  String timeHoursAgo(Object hours) {
+    return '$hours時間前';
+  }
+
+  @override
   String get timestamps => 'タイムスタンプ';
 
   @override

--- a/lib/l10n/generated/app_localizations_pl.dart
+++ b/lib/l10n/generated/app_localizations_pl.dart
@@ -1651,6 +1651,11 @@ class AppLocalizationsPl extends AppLocalizations {
   String get time => 'Czas';
 
   @override
+  String timeHoursAgo(Object hours) {
+    return '$hours godzin temu';
+  }
+
+  @override
   String get timestamps => 'Sygnatury czasowe';
 
   @override

--- a/lib/screens/settings/server_settings/advanced_settings/network_screen/network_detail_screen.dart
+++ b/lib/screens/settings/server_settings/advanced_settings/network_screen/network_detail_screen.dart
@@ -20,6 +20,8 @@ class NetworkDetailScreen extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final locale = AppLocalizations.of(context)!;
+    final isUnknown =
+        device.lastQuery == DateTime.fromMillisecondsSinceEpoch(0);
 
     return Scaffold(
       appBar: AppBar(
@@ -78,10 +80,10 @@ class NetworkDetailScreen extends StatelessWidget {
               CustomListTile(
                 leadingIcon: Icons.query_stats_rounded,
                 label: locale.lastQuery,
-                description: formatTimestamp(
-                  device.lastQuery,
-                  kUnifiedDateTimeLogFormat,
-                ),
+                description: isUnknown
+                    ? locale.unknown
+                    : '${formatTimestamp(device.lastQuery, kUnifiedDateTimeLogFormat)} '
+                        '(${locale.timeHoursAgo(DateTime.now().difference(device.lastQuery).inHours)})',
               ),
               CustomListTile(
                 leadingIcon: Icons.bar_chart_rounded,


### PR DESCRIPTION
## Overview

Displayed elapsed time ("X hours ago") next to lastQuery timestamp with i18n support.

## Screenshots

|before|after|
|---|---|
|![](https://github.com/user-attachments/assets/962c1e6a-58e1-46fa-bc71-265e8cbc0f8a)|![](https://github.com/user-attachments/assets/688eb6f9-b7c2-471f-a495-7afa655f1bd9)|

