### PR TITLE
fix(home): ensure FAB position resets after snackbar dismissal

### DIFF
--- a/lib/ui/home/home.dart
+++ b/lib/ui/home/home.dart
@@ -58,7 +58,9 @@ class _HomeState extends State<Home> {
   Widget build(BuildContext context) {
     final serversProvider = context.watch<ServersProvider>();
 
-    final appConfigProvider = context.read<AppConfigProvider>();
+    final showingSnackbar = context.select<AppConfigProvider, bool>(
+      (p) => p.showingSnackbar,
+    );
 
     final statusLoading = context.select<StatusProvider, LoadStatus>(
       (provider) => provider.getStatusLoading,
@@ -99,6 +101,15 @@ class _HomeState extends State<Home> {
           await enableServer(context);
         }
       }
+    }
+
+    double calcFabPosition() {
+      if (isVisible && statusLoading == LoadStatus.loaded) {
+        return showingSnackbar ? 70.0 : 20.0;
+      }
+
+      // If the FAB is not visible, it should be off-screen
+      return -70.0;
     }
 
     return serversProvider.selectedServer != null
@@ -160,11 +171,7 @@ class _HomeState extends State<Home> {
                     AnimatedPositioned(
                       duration: const Duration(milliseconds: 100),
                       curve: Curves.easeInOut,
-                      bottom: isVisible && statusLoading == LoadStatus.loaded
-                          ? appConfigProvider.showingSnackbar
-                                ? 70
-                                : 20
-                          : -70,
+                      bottom: calcFabPosition(),
                       right: 20,
                       child: FloatingActionButton(
                         onPressed: enableDisableServer,

--- a/lib/ui/home/home.dart
+++ b/lib/ui/home/home.dart
@@ -105,12 +105,13 @@ class _HomeState extends State<Home> {
 
     double calcFabPosition() {
       if (isVisible && statusLoading == LoadStatus.loaded) {
-        if (MediaQuery.of(context).size.width <= ResponsiveConstants.medium) {
-          return showingSnackbar ? 100.0 : 20.0;
+        if (showingSnackbar) {
+          final isSmallScreen =
+              MediaQuery.of(context).size.width <= ResponsiveConstants.medium;
+          return isSmallScreen ? 100.0 : 70.0;
         }
-        return showingSnackbar ? 70.0 : 20.0;
+        return 20.0;
       }
-
       // If the FAB is not visible, it should be off-screen
       return -70.0;
     }

--- a/lib/ui/home/home.dart
+++ b/lib/ui/home/home.dart
@@ -105,6 +105,9 @@ class _HomeState extends State<Home> {
 
     double calcFabPosition() {
       if (isVisible && statusLoading == LoadStatus.loaded) {
+        if (MediaQuery.of(context).size.width <= ResponsiveConstants.medium) {
+          return showingSnackbar ? 100.0 : 20.0;
+        }
         return showingSnackbar ? 70.0 : 20.0;
       }
 


### PR DESCRIPTION
## Overview
Fix FAB overlapping SnackBar on small screens and ensure it returns to its original position after dismissal.

## Changes

- Observe AppConfigProvider.showingSnackbar via context.select for reactive FAB updates.
- Centralize FAB bottom offset logic in calcFabPosition().
- Use dynamic offsets: 100.0 when Snackbar visible on narrow screens (width <= ResponsiveConstants.medium), else 70.0; default 20.0 when hidden.