### PR TITLE
fix(logs): prevent duplicate entries by clearing list before reload

### DIFF
--- a/lib/ui/logs/logs.dart
+++ b/lib/ui/logs/logs.dart
@@ -100,9 +100,9 @@ class _LogsState extends State<Logs> {
 
   Future<void> initializeLoad() async {
     if (!mounted) return;
+    logsList.clear();
     setState(() {
       loadStatus = LoadStatus.loading;
-      logsList.clear();
     });
 
     final now = DateTime.now();


### PR DESCRIPTION
## Overview
Fixes an issue where log entries kept increasing indefinitely after multiple updates.
Previously, the log list was not cleared before fetching new data, causing duplicates to accumulate.

## Changes

* Clear `logsList` at the start of `initializeLoad()` to reset the list before loading new logs