### PR TITLE
chore(settings): remove deprecated security option from advanced settings

### DIFF
--- a/lib/ui/settings/app_settings/advanced_options.dart
+++ b/lib/ui/settings/app_settings/advanced_options.dart
@@ -199,20 +199,6 @@ class AdvancedOptions extends StatelessWidget {
         child: ListView(
           children: [
             SectionLabel(label: AppLocalizations.of(context)!.security),
-            // TODO: Delete this option
-            CustomListTile(
-              leadingIcon: Icons.lock,
-              label: AppLocalizations.of(context)!.dontCheckCertificate,
-              description: AppLocalizations.of(
-                context,
-              )!.dontCheckCertificateDescription,
-              padding: const EdgeInsets.only(
-                top: 10,
-                bottom: 10,
-                left: 20,
-                right: 10,
-              ),
-            ),
             CustomListTile(
               leadingIcon: Icons.fingerprint_rounded,
               label: AppLocalizations.of(context)!.appUnlock,

--- a/test/widgets/screens/settings/app_settings/advanced_settings/advanced_options_test.dart
+++ b/test/widgets/screens/settings/app_settings/advanced_settings/advanced_options_test.dart
@@ -36,9 +36,6 @@ void main() async {
 
       expect(find.byType(AdvancedOptions), findsOneWidget);
       expect(find.text('Advanced settings'), findsOneWidget);
-
-      expect(find.text('Security'), findsOneWidget);
-      expect(find.text("Don't check SSL certificate"), findsOneWidget);
       expect(find.text('App unlock'), findsOneWidget);
 
       expect(find.text('Charts'), findsOneWidget);
@@ -52,25 +49,6 @@ void main() async {
       expect(find.text('Others'), findsOneWidget);
       expect(find.text('App logs'), findsOneWidget);
       expect(find.text('Reset application'), findsOneWidget);
-    });
-
-    testWidgets('should show ssl certificate check setting', (
-      WidgetTester tester,
-    ) async {
-      tester.view.physicalSize = const Size(1080, 2400);
-      tester.view.devicePixelRatio = 2.0;
-
-      addTearDown(() {
-        tester.view.resetPhysicalSize();
-        tester.view.resetDevicePixelRatio();
-      });
-
-      await tester.pumpWidget(
-        testSetup.buildTestWidget(const AdvancedOptions()),
-      );
-
-      expect(find.byType(AdvancedOptions), findsOneWidget);
-      expect(find.text("Don't check SSL certificate"), findsOneWidget);
     });
 
     testWidgets('should show App Unlock screen', (WidgetTester tester) async {


### PR DESCRIPTION
<img width="623" height="393" alt="タイトルなし" src="https://github.com/user-attachments/assets/e371514f-820a-43a7-9fe7-b4bf943ac9cc" />
