### PR TITLE
fix(api):  handle invalid UTF-8 in network devices response

### DIFF
--- a/lib/data/gateway/api_gateway_v6.dart
+++ b/lib/data/gateway/api_gateway_v6.dart
@@ -1729,7 +1729,10 @@ class ApiGatewayV6 implements ApiGateway {
       final results = await httpClient(method: 'get', url: uri.toString());
 
       if (results.statusCode == 200) {
-        final devices = Devices.fromJson(jsonDecode(results.body));
+        // Use allowMalformed to handle invalid UTF-8 characters in device
+        // names or MAC vendor names
+        final body = utf8.decode(results.bodyBytes, allowMalformed: true);
+        final devices = Devices.fromJson(jsonDecode(body));
 
         return DevicesResponse(
           result: APiResponseType.success,
@@ -1741,7 +1744,8 @@ class ApiGatewayV6 implements ApiGateway {
           message: fetchError,
         );
       }
-    } catch (e) {
+    } catch (e, stackTrace) {
+      logger.e('getDevices failed', error: e, stackTrace: stackTrace);
       return DevicesResponse(
         result: APiResponseType.error,
         message: unexpectedError,

--- a/lib/ui/core/viewmodel/local_dns_provider.dart
+++ b/lib/ui/core/viewmodel/local_dns_provider.dart
@@ -7,6 +7,7 @@ import 'package:pi_hole_client/domain/model/network/network.dart';
 import 'package:pi_hole_client/domain/models_old/devices.dart';
 import 'package:pi_hole_client/domain/models_old/gateways.dart';
 import 'package:pi_hole_client/ui/core/viewmodel/servers_provider.dart';
+import 'package:pi_hole_client/utils/logger.dart';
 
 class LocalDnsProvider with ChangeNotifier {
   LocalDnsProvider({required this.serversProvider});
@@ -80,9 +81,15 @@ class LocalDnsProvider with ChangeNotifier {
         _buildDeviceMaps(devicesInfo.devices);
         _loadingStatus = LoadStatus.loaded;
       } else {
+        logger.e(
+          'Failed to load LocalDns data. '
+          'getLocalDns: ${result[0].result} (${result[0].message ?? 'no message'}), '
+          'getDevices: ${result[1].result} (${result[1].message ?? 'no message'})',
+        );
         _loadingStatus = LoadStatus.error;
       }
     } catch (e) {
+      logger.e('Failed to load LocalDns data', error: e);
       _loadingStatus = LoadStatus.error;
     } finally {
       notifyListeners();

--- a/lib/ui/settings/server_settings/advanced_settings/network_screen.dart
+++ b/lib/ui/settings/server_settings/advanced_settings/network_screen.dart
@@ -219,7 +219,11 @@ class _NetworkState extends State<NetworkScreen> {
           currentClientIp = result[1].data?.addr;
         } else {
           isFetchError = true;
-          logger.e('Failed to load network devices or client info');
+          logger.e(
+            'Failed to load network data. '
+            'getDevices: ${result[0].result} (${result[0].message ?? 'no message'}), '
+            'getClient: ${result[1].result} (${result[1].message ?? 'no message'})',
+          );
         }
       });
     } catch (e) {


### PR DESCRIPTION
## Overview

Fix UTF-8 decoding error in getDevices() API caused by invalid UTF-8 bytes in device names or MAC vendor names, which prevented Network screen, Local DNS screen, and client address selection from loading data.

## Changes

- Fix UTF-8 decoding error in getDevices() API that caused data loading failures
- Add improved error logging for easier debugging


