### PR TITLE
refactor(ui): extract color helpers from utils to UI layer

### DIFF
--- a/lib/ui/core/ui/helpers/color_helpers.dart
+++ b/lib/ui/core/ui/helpers/color_helpers.dart
@@ -1,0 +1,74 @@
+import 'package:flutter/material.dart';
+import 'package:pi_hole_client/config/enums.dart';
+import 'package:pi_hole_client/ui/core/themes/theme.dart';
+
+/// Converts a given [color] to the corresponding theme-based color defined in
+/// [AppColors].
+///
+/// This function is used to adapt predefined colors (such as [Colors.red],
+/// [Colors.green], etc.) to theme-specific variants from [AppColors]. If the
+/// provided color matches a predefined color, the corresponding color from
+/// [AppColors] is returned. If no match is found, the original color is
+/// returned unchanged.
+///
+/// ### Parameters:
+/// - [colors]: An instance of [AppColors] that contains the theme-based color
+/// definitions.
+/// - [color]: The original color to be converted.
+///
+/// ### Returns:
+/// A theme-adjusted [Color] if a match is found in [AppColors], otherwise
+/// returns the original [color].
+Color convertColor(AppColors colors, Color color) {
+  switch (color) {
+    case Colors.red:
+      return colors.queryRed ?? Colors.red;
+    case Colors.green:
+      return colors.queryGreen ?? Colors.green;
+    case Colors.blue:
+      return colors.queryBlue ?? Colors.blue;
+    case Colors.orange:
+      return colors.queryOrange ?? Colors.orange;
+    case Colors.grey:
+      return colors.queryGrey ?? Colors.grey;
+    default:
+      return color;
+  }
+}
+
+/// Converts a given [number] to the corresponding theme-based color defined in
+/// [AppColors].
+///
+/// This function is used to adapt predefined color numbers (0-3) to theme-
+/// specific variants from [AppColors]. If the provided number matches a
+/// predefined color, the corresponding color from [AppColors] is returned. If
+/// no match is found, the default color is returned.
+///
+/// ### Parameters:
+/// - [colors]: An instance of [AppColors] that contains the theme-based color
+/// definitions.
+/// - [number]: The number representing the color to be converted.
+Color convertColorFromNumber(AppColors colors, int number) {
+  switch (number) {
+    case 0:
+      return colors.queryGreen ?? Colors.green;
+    case 1:
+      return colors.queryRed ?? Colors.red;
+    case 2:
+      return colors.queryBlue ?? Colors.blue;
+    case 3:
+      return colors.queryOrange ?? Colors.orange;
+    default:
+      return colors.queryGrey ?? Colors.grey;
+  }
+}
+
+Color domainTypeColor(AppColors colors, DomainType type, DomainKind kind) {
+  return switch ((type, kind)) {
+    (DomainType.allow, DomainKind.exact) => colors.queryGreen ?? Colors.green,
+    (DomainType.deny, DomainKind.exact) => colors.queryRed ?? Colors.red,
+    (DomainType.allow, DomainKind.regex) => colors.queryBlue ?? Colors.blue,
+    (DomainType.deny, DomainKind.regex) =>
+      colors.queryOrange ?? Colors.orange,
+  };
+}

--- a/lib/ui/domains/widgets/domain_details_screen.dart
+++ b/lib/ui/domains/widgets/domain_details_screen.dart
@@ -8,6 +8,7 @@ import 'package:pi_hole_client/domain/models_old/gateways.dart';
 import 'package:pi_hole_client/ui/core/l10n/generated/app_localizations.dart';
 import 'package:pi_hole_client/ui/core/themes/theme.dart';
 import 'package:pi_hole_client/ui/core/ui/components/custom_list_tile.dart';
+import 'package:pi_hole_client/ui/core/ui/helpers/color_helpers.dart';
 import 'package:pi_hole_client/ui/core/ui/helpers/snackbar.dart';
 import 'package:pi_hole_client/ui/core/ui/modals/delete_modal.dart';
 import 'package:pi_hole_client/ui/core/ui/modals/process_modal.dart';

--- a/lib/ui/domains/widgets/domain_tile.dart
+++ b/lib/ui/domains/widgets/domain_tile.dart
@@ -3,6 +3,7 @@ import 'package:pi_hole_client/config/formats.dart';
 import 'package:pi_hole_client/config/responsive.dart';
 import 'package:pi_hole_client/domain/models_old/domain.dart';
 import 'package:pi_hole_client/ui/core/themes/theme.dart';
+import 'package:pi_hole_client/ui/core/ui/helpers/color_helpers.dart';
 import 'package:pi_hole_client/utils/conversions.dart';
 import 'package:pi_hole_client/utils/format.dart';
 

--- a/lib/ui/home/widgets/home_appbar/adblock_status_icon.dart
+++ b/lib/ui/home/widgets/home_appbar/adblock_status_icon.dart
@@ -1,9 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:pi_hole_client/config/enums.dart';
 import 'package:pi_hole_client/ui/core/themes/theme.dart';
+import 'package:pi_hole_client/ui/core/ui/helpers/color_helpers.dart';
 import 'package:pi_hole_client/ui/core/viewmodel/servers_provider.dart';
 import 'package:pi_hole_client/ui/core/viewmodel/status_provider.dart';
-import 'package:pi_hole_client/utils/conversions.dart';
 import 'package:provider/provider.dart';
 
 /// A widget that displays an icon representing the current ad-block server status.

--- a/lib/ui/logs/widgets/log_status.dart
+++ b/lib/ui/logs/widgets/log_status.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:pi_hole_client/ui/core/themes/theme.dart';
+import 'package:pi_hole_client/ui/core/ui/helpers/color_helpers.dart';
 import 'package:pi_hole_client/ui/core/viewmodel/servers_provider.dart';
-import 'package:pi_hole_client/utils/conversions.dart';
 import 'package:provider/provider.dart';
 
 class LogStatus extends StatelessWidget {

--- a/lib/ui/settings/app_settings/advanced_options.dart
+++ b/lib/ui/settings/app_settings/advanced_options.dart
@@ -5,6 +5,7 @@ import 'package:pi_hole_client/ui/app_logs/app_logs.dart';
 import 'package:pi_hole_client/ui/core/l10n/generated/app_localizations.dart';
 import 'package:pi_hole_client/ui/core/ui/components/custom_list_tile.dart';
 import 'package:pi_hole_client/ui/core/ui/components/section_label.dart';
+import 'package:pi_hole_client/ui/core/ui/helpers/color_helpers.dart';
 import 'package:pi_hole_client/ui/core/ui/helpers/snackbar.dart';
 import 'package:pi_hole_client/ui/core/ui/modals/process_modal.dart';
 import 'package:pi_hole_client/ui/core/viewmodel/app_config_provider.dart';
@@ -16,7 +17,6 @@ import 'package:pi_hole_client/ui/settings/app_settings/advanced_settings/enter_
 import 'package:pi_hole_client/ui/settings/app_settings/advanced_settings/log_refresh_interval_screen.dart';
 import 'package:pi_hole_client/ui/settings/app_settings/advanced_settings/logs_quantity_load_screen.dart';
 import 'package:pi_hole_client/ui/settings/app_settings/advanced_settings/reset_screen.dart';
-import 'package:pi_hole_client/utils/conversions.dart';
 import 'package:provider/provider.dart';
 
 class AdvancedOptions extends StatelessWidget {

--- a/lib/ui/settings/app_settings/advanced_settings/app_unlock_setup_modal.dart
+++ b/lib/ui/settings/app_settings/advanced_settings/app_unlock_setup_modal.dart
@@ -1,11 +1,11 @@
 import 'package:flutter/material.dart';
 import 'package:local_auth/local_auth.dart';
 import 'package:pi_hole_client/ui/core/l10n/generated/app_localizations.dart';
+import 'package:pi_hole_client/ui/core/ui/helpers/color_helpers.dart';
 import 'package:pi_hole_client/ui/core/ui/helpers/snackbar.dart';
 import 'package:pi_hole_client/ui/core/viewmodel/app_config_provider.dart';
 import 'package:pi_hole_client/ui/settings/app_settings/advanced_settings/app_lock/create_pass_code_modal.dart';
 import 'package:pi_hole_client/ui/settings/app_settings/advanced_settings/app_lock/remove_passcode_modal.dart';
-import 'package:pi_hole_client/utils/conversions.dart';
 import 'package:provider/provider.dart';
 
 class AppUnlockSetupModal extends StatefulWidget {

--- a/lib/utils/conversions.dart
+++ b/lib/utils/conversions.dart
@@ -1,68 +1,6 @@
-import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
+import 'package:pi_hole_client/config/enums.dart';
 import 'package:pi_hole_client/domain/models_old/domain.dart';
-import 'package:pi_hole_client/ui/core/themes/theme.dart';
-
-/// Converts a given [color] to the corresponding theme-based color defined in
-/// [AppColors].
-///
-/// This function is used to adapt predefined colors (such as [Colors.red],
-/// [Colors.green], etc.) to theme-specific variants from [AppColors]. If the
-/// provided color matches a predefined color, the corresponding color from
-/// [AppColors] is returned. If no match is found, the original color is
-/// returned unchanged.
-///
-/// ### Parameters:
-/// - [colors]: An instance of [AppColors] that contains the theme-based color
-/// definitions.
-/// - [color]: The original color to be converted.
-///
-/// ### Returns:
-/// A theme-adjusted [Color] if a match is found in [AppColors], otherwise
-/// returns the original [color].
-Color convertColor(AppColors colors, Color color) {
-  switch (color) {
-    case Colors.red:
-      return colors.queryRed ?? Colors.red;
-    case Colors.green:
-      return colors.queryGreen ?? Colors.green;
-    case Colors.blue:
-      return colors.queryBlue ?? Colors.blue;
-    case Colors.orange:
-      return colors.queryOrange ?? Colors.orange;
-    case Colors.grey:
-      return colors.queryGrey ?? Colors.grey;
-    default:
-      return color;
-  }
-}
-
-/// Converts a given [number] to the corresponding theme-based color defined in
-/// [AppColors].
-///
-/// This function is used to adapt predefined color numbers (0-3) to theme-
-/// specific variants from [AppColors]. If the provided number matches a
-/// predefined color, the corresponding color from [AppColors] is returned. If
-/// no match is found, the default color is returned.
-///
-/// ### Parameters:
-/// - [colors]: An instance of [AppColors] that contains the theme-based color
-/// definitions.
-/// - [number]: The number representing the color to be converted.
-Color convertColorFromNumber(AppColors colors, int number) {
-  switch (number) {
-    case 0:
-      return colors.queryGreen ?? Colors.green;
-    case 1:
-      return colors.queryRed ?? Colors.red;
-    case 2:
-      return colors.queryBlue ?? Colors.blue;
-    case 3:
-      return colors.queryOrange ?? Colors.orange;
-    default:
-      return colors.queryGrey ?? Colors.grey;
-  }
-}
 
 String getDomainType(int type) {
   switch (type) {
@@ -145,4 +83,13 @@ List<Map<String, dynamic>> convertFromMapToList(Map<String, int> values) {
     items.add({'label': key, 'value': value});
   });
   return items;
+}
+
+String getDomainTypeLabel(DomainType type, DomainKind kind) {
+  return switch ((type, kind)) {
+    (DomainType.allow, DomainKind.exact) => 'Whitelist',
+    (DomainType.deny, DomainKind.exact) => 'Blacklist',
+    (DomainType.allow, DomainKind.regex) => 'Whitelist Regex',
+    (DomainType.deny, DomainKind.regex) => 'Blacklist Regex',
+  };
 }


### PR DESCRIPTION
## Overview

`lib/utils/conversions.dart` imported `AppColors` from the UI layer (`lib/ui/core/themes/theme.dart`),
creating a reverse dependency from utils → ui. 
This extracts the color-related helper functions into the UI layer where they belong.