### PR TITLE
refactor(dns-blocking): migrate server enable/disable from Gateway to DnsRepository

### DIFF
--- a/lib/data/repositories/api/repository_bundle.dart
+++ b/lib/data/repositories/api/repository_bundle.dart
@@ -1,5 +1,6 @@
 import 'package:pi_hole_client/data/repositories/api/interfaces/auth_repository.dart';
 import 'package:pi_hole_client/data/repositories/api/interfaces/dhcp_repository.dart';
+import 'package:pi_hole_client/data/repositories/api/interfaces/dns_repository.dart';
 import 'package:pi_hole_client/data/repositories/api/interfaces/ftl_repository.dart';
 import 'package:pi_hole_client/data/repositories/api/interfaces/local_dns_repository.dart';
 import 'package:pi_hole_client/data/repositories/api/interfaces/network_repository.dart';
@@ -8,6 +9,7 @@ class RepositoryBundle {
   const RepositoryBundle({
     required this.auth,
     required this.dhcp,
+    required this.dns,
     required this.ftl,
     required this.localDns,
     required this.network,
@@ -16,6 +18,7 @@ class RepositoryBundle {
 
   final AuthRepository auth;
   final DhcpRepository dhcp;
+  final DnsRepository dns;
   final FtlRepository ftl;
   final LocalDnsRepository localDns;
   final NetworkRepository network;

--- a/lib/data/repositories/api/repository_factory.dart
+++ b/lib/data/repositories/api/repository_factory.dart
@@ -1,11 +1,13 @@
 import 'package:pi_hole_client/data/repositories/api/repository_bundle.dart';
 import 'package:pi_hole_client/data/repositories/api/v5/auth_repository.dart';
 import 'package:pi_hole_client/data/repositories/api/v5/dhcp_repository.dart';
+import 'package:pi_hole_client/data/repositories/api/v5/dns_repository.dart';
 import 'package:pi_hole_client/data/repositories/api/v5/ftl_repository.dart';
 import 'package:pi_hole_client/data/repositories/api/v5/local_dns_repository.dart';
 import 'package:pi_hole_client/data/repositories/api/v5/network_repository.dart';
 import 'package:pi_hole_client/data/repositories/api/v6/auth_repository.dart';
 import 'package:pi_hole_client/data/repositories/api/v6/dhcp_repository.dart';
+import 'package:pi_hole_client/data/repositories/api/v6/dns_repository.dart';
 import 'package:pi_hole_client/data/repositories/api/v6/ftl_repository.dart';
 import 'package:pi_hole_client/data/repositories/api/v6/local_dns_repository.dart';
 import 'package:pi_hole_client/data/repositories/api/v6/network_repository.dart';
@@ -28,6 +30,7 @@ class RepositoryBundleFactory {
         return RepositoryBundle(
           auth: AuthRepositoryV6(client: client, creds: creds),
           dhcp: DhcpRepositoryV6(client: client, creds: creds),
+          dns: DnsRepositoryV6(client: client, creds: creds),
           ftl: FtlRepositoryV6(client: client, creds: creds),
           localDns: LocalDnsRepositoryV6(client: client, creds: creds),
           network: NetworkRepositoryV6(client: client, creds: creds),
@@ -38,6 +41,7 @@ class RepositoryBundleFactory {
         return RepositoryBundle(
           auth: AuthRepositoryV5(client: client, creds: creds),
           dhcp: DhcpRepositoryV5(client: client, creds: creds),
+          dns: DnsRepositoryV5(client: client, creds: creds),
           ftl: FtlRepositoryV5(client: client, creds: creds),
           localDns: LocalDnsRepositoryV5(client: client, creds: creds),
           network: NetworkRepositoryV5(client: client, creds: creds),

--- a/lib/ui/core/logic/server_management.dart
+++ b/lib/ui/core/logic/server_management.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
-import 'package:pi_hole_client/domain/models_old/gateways.dart';
+import 'package:pi_hole_client/config/enums.dart';
+import 'package:pi_hole_client/data/repositories/api/repository_bundle.dart';
 import 'package:pi_hole_client/ui/core/l10n/generated/app_localizations.dart';
 import 'package:pi_hole_client/ui/core/ui/helpers/snackbar.dart';
 import 'package:pi_hole_client/ui/core/ui/modals/process_modal.dart';
@@ -13,29 +14,35 @@ Future<void> enableServer(BuildContext context) async {
     context,
     listen: false,
   );
-  final apiGateway = serversProvider.selectedApiGateway;
+  final bundle = Provider.of<RepositoryBundle?>(context, listen: false);
+  if (bundle == null) return;
 
   final process = ProcessModal(context: context);
   process.open(AppLocalizations.of(context)!.enablingServer);
-  final result = await apiGateway?.enableServerRequest();
+  final result = await bundle.dns.enableBlocking();
   process.close();
 
   if (!context.mounted) return;
 
-  if (result?.result == APiResponseType.success) {
-    serversProvider.updateselectedServerStatus(true);
-    showSuccessSnackBar(
-      context: context,
-      appConfigProvider: appConfigProvider,
-      label: AppLocalizations.of(context)!.serverEnabled,
-    );
-  } else {
-    showErrorSnackBar(
-      context: context,
-      appConfigProvider: appConfigProvider,
-      label: AppLocalizations.of(context)!.couldntEnableServer,
-    );
-  }
+  result.fold(
+    (blocking) {
+      serversProvider.updateselectedServerStatus(
+        blocking.status == DnsBlockingStatus.enabled,
+      );
+      showSuccessSnackBar(
+        context: context,
+        appConfigProvider: appConfigProvider,
+        label: AppLocalizations.of(context)!.serverEnabled,
+      );
+    },
+    (error) {
+      showErrorSnackBar(
+        context: context,
+        appConfigProvider: appConfigProvider,
+        label: AppLocalizations.of(context)!.couldntEnableServer,
+      );
+    },
+  );
 }
 
 Future<void> disableServer(int time, BuildContext context) async {
@@ -44,25 +51,31 @@ Future<void> disableServer(int time, BuildContext context) async {
     context,
     listen: false,
   );
-  final apiGateway = serversProvider.selectedApiGateway;
+  final bundle = Provider.of<RepositoryBundle?>(context, listen: false);
+  if (bundle == null) return;
 
   final process = ProcessModal(context: context);
   process.open(AppLocalizations.of(context)!.disablingServer);
-  final result = await apiGateway?.disableServerRequest(time);
+  final result = await bundle.dns.disableBlocking(time);
   process.close();
+
   if (!context.mounted) return;
-  if (result?.result == APiResponseType.success) {
-    serversProvider.updateselectedServerStatus(false);
-    showSuccessSnackBar(
-      context: context,
-      appConfigProvider: appConfigProvider,
-      label: AppLocalizations.of(context)!.serverDisabled,
-    );
-  } else {
-    showErrorSnackBar(
-      context: context,
-      appConfigProvider: appConfigProvider,
-      label: AppLocalizations.of(context)!.couldntDisableServer,
-    );
-  }
+
+  result.fold(
+    (blocking) {
+      serversProvider.updateselectedServerStatus(false);
+      showSuccessSnackBar(
+        context: context,
+        appConfigProvider: appConfigProvider,
+        label: AppLocalizations.of(context)!.serverDisabled,
+      );
+    },
+    (error) {
+      showErrorSnackBar(
+        context: context,
+        appConfigProvider: appConfigProvider,
+        label: AppLocalizations.of(context)!.couldntDisableServer,
+      );
+    },
+  );
 }

--- a/test/widgets/helpers.dart
+++ b/test/widgets/helpers.dart
@@ -30,6 +30,7 @@ import 'package:pi_hole_client/data/model/v6/lists/lists.dart' show Lists;
 import 'package:pi_hole_client/data/model/v6/metrics/query.dart';
 import 'package:pi_hole_client/data/model/v6/network/devices.dart';
 import 'package:pi_hole_client/data/model/v6/network/gateway.dart';
+import 'package:pi_hole_client/data/repositories/api/repository_bundle.dart';
 import 'package:pi_hole_client/domain/model/local_dns/local_dns.dart';
 import 'package:pi_hole_client/domain/model/network/network.dart'
     show DeviceOption;
@@ -69,6 +70,12 @@ import 'package:pi_hole_client/ui/core/viewmodel/status_provider.dart';
 import 'package:pi_hole_client/ui/core/viewmodel/subscriptions_list_provider.dart';
 import 'package:provider/provider.dart';
 
+import '../../testing/fakes/repositories/api/fake_auth_repository.dart';
+import '../../testing/fakes/repositories/api/fake_dhcp_repository.dart';
+import '../../testing/fakes/repositories/api/fake_dns_repository.dart';
+import '../../testing/fakes/repositories/api/fake_ftl_repository.dart';
+import '../../testing/fakes/repositories/api/fake_local_dns_repository.dart';
+import '../../testing/fakes/repositories/api/fake_network_repository.dart';
 import './helpers.mocks.dart';
 
 final serverV5 = Server(
@@ -1579,6 +1586,17 @@ class TestSetupHelper {
               create: (_) => mockStatusUpdateService,
               dispose: (_, service) => service.stopAutoRefresh(),
             ),
+            Provider<RepositoryBundle?>(
+              create: (_) => RepositoryBundle(
+                auth: FakeAuthRepository(),
+                dhcp: FakeDhcpRepository(),
+                dns: FakeDnsRepository(),
+                ftl: FakeFtlRepository(),
+                localDns: FakeLocalDnsRepository(),
+                network: FakeNetworkRepository(),
+                serverAddress: 'http://localhost:8081',
+              ),
+            ),
           ],
           child: Phoenix(
             child: MaterialApp(
@@ -1662,6 +1680,17 @@ class TestSetupHelper {
         Provider<StatusUpdateService>(
           create: (_) => mockStatusUpdateService,
           dispose: (_, service) => service.stopAutoRefresh(),
+        ),
+        Provider<RepositoryBundle?>(
+          create: (_) => RepositoryBundle(
+            auth: FakeAuthRepository(),
+            dhcp: FakeDhcpRepository(),
+            dns: FakeDnsRepository(),
+            ftl: FakeFtlRepository(),
+            localDns: FakeLocalDnsRepository(),
+            network: FakeNetworkRepository(),
+            serverAddress: 'http://localhost:8081',
+          ),
         ),
       ],
       child: child,


### PR DESCRIPTION
## Overview
Migrate the DNS blocking enable/disable functionality in `server_management.dart` from the legacy ApiGateway pattern to the Repository pattern. 

Part of #367

## Changes
- Add `DnsRepository` field to `RepositoryBundle` and wire up v5/v6 implementations in `RepositoryBundleFactory`
- Rewrite `enableServer()` and `disableServer()` in `server_management.dart` to use `DnsRepository` with `Result.fold()` instead of the legacy gateway pattern

