### PR TITLE
fix(widget): sync blocking status to home widget after timed disable expires

### DIFF
--- a/android/app/src/main/kotlin/io/github/tsutsu3/pi_hole_client/MainActivity.kt
+++ b/android/app/src/main/kotlin/io/github/tsutsu3/pi_hole_client/MainActivity.kt
@@ -76,6 +76,15 @@ class MainActivity : FlutterFragmentActivity() {
                     result.success(null)
                 }
 
+                "scheduleBlockingRefresh" -> {
+                    val serverId = requireServerId(call, result) ?: return@setMethodCallHandler
+                    val delaySeconds = call.argument<Int>("delaySeconds") ?: 0
+                    if (delaySeconds > 0) {
+                        WidgetUpdateHelper.scheduleDelayedRefresh(this, serverId, delaySeconds.toLong())
+                    }
+                    result.success(null)
+                }
+
                 else -> result.notImplemented()
             }
         }

--- a/android/app/src/main/kotlin/io/github/tsutsu3/pi_hole_client/widget/WidgetUpdateHelper.kt
+++ b/android/app/src/main/kotlin/io/github/tsutsu3/pi_hole_client/widget/WidgetUpdateHelper.kt
@@ -224,4 +224,76 @@ object WidgetUpdateHelper {
     fun scheduleTogglePeriodicUpdate(context: Context) {
         schedulePeriodicUpdate<ToggleWidgetWorker>(context, "pihole_toggle_widget_periodic")
     }
+
+    /**
+     * Schedules a one-shot refresh for all widgets bound to [serverId] after
+     * [delaySeconds] seconds.
+     *
+     * Used when the app sets a timed disable on Pi-hole so the widget reflects
+     * the automatic re-enable once the timer expires, even if the app is closed.
+     */
+    fun scheduleDelayedRefresh(context: Context, serverId: String, delaySeconds: Long) {
+        val manager = AppWidgetManager.getInstance(context)
+        val prefs = WidgetPrefs.getInstance(context)
+
+        val statsIds = manager.getAppWidgetIds(
+            ComponentName(context, PiHoleWidgetProvider::class.java),
+        )
+        prefs.getWidgetIdsForServer(statsIds, serverId).forEach { widgetId ->
+            val request = OneTimeWorkRequestBuilder<PiHoleWidgetWorker>()
+                .setInputData(
+                    workDataOf(
+                        AppWidgetManager.EXTRA_APPWIDGET_ID to widgetId,
+                        WidgetConstants.EXTRA_ACTION to WidgetConstants.ACTION_REFRESH,
+                    ),
+                )
+                .setInitialDelay(delaySeconds, TimeUnit.SECONDS)
+                .build()
+            WorkManager.getInstance(context).enqueueUniqueWork(
+                "pihole_widget_delayed_$widgetId",
+                ExistingWorkPolicy.REPLACE,
+                request,
+            )
+        }
+
+        val toggleIds = manager.getAppWidgetIds(
+            ComponentName(context, ToggleWidgetProvider::class.java),
+        )
+        prefs.getWidgetIdsForServer(toggleIds, serverId).forEach { widgetId ->
+            val request = OneTimeWorkRequestBuilder<ToggleWidgetWorker>()
+                .setInputData(
+                    workDataOf(
+                        AppWidgetManager.EXTRA_APPWIDGET_ID to widgetId,
+                        WidgetConstants.EXTRA_ACTION to WidgetConstants.ACTION_REFRESH,
+                    ),
+                )
+                .setInitialDelay(delaySeconds, TimeUnit.SECONDS)
+                .build()
+            WorkManager.getInstance(context).enqueueUniqueWork(
+                "pihole_toggle_delayed_$widgetId",
+                ExistingWorkPolicy.REPLACE,
+                request,
+            )
+        }
+
+        val compactIds = manager.getAppWidgetIds(
+            ComponentName(context, CompactWidgetProvider::class.java),
+        )
+        prefs.getWidgetIdsForServer(compactIds, serverId).forEach { widgetId ->
+            val request = OneTimeWorkRequestBuilder<PiHoleWidgetWorker>()
+                .setInputData(
+                    workDataOf(
+                        AppWidgetManager.EXTRA_APPWIDGET_ID to widgetId,
+                        WidgetConstants.EXTRA_ACTION to WidgetConstants.ACTION_REFRESH,
+                    ),
+                )
+                .setInitialDelay(delaySeconds, TimeUnit.SECONDS)
+                .build()
+            WorkManager.getInstance(context).enqueueUniqueWork(
+                "pihole_compact_delayed_$widgetId",
+                ExistingWorkPolicy.REPLACE,
+                request,
+            )
+        }
+    }
 }

--- a/lib/ui/core/actions/server_management.dart
+++ b/lib/ui/core/actions/server_management.dart
@@ -6,6 +6,7 @@ import 'package:pi_hole_client/ui/core/ui/helpers/snackbar.dart';
 import 'package:pi_hole_client/ui/core/ui/modals/process_modal.dart';
 import 'package:pi_hole_client/ui/core/view_models/app_config_viewmodel.dart';
 import 'package:pi_hole_client/ui/core/view_models/servers_viewmodel.dart';
+import 'package:pi_hole_client/utils/widget_channel.dart';
 import 'package:provider/provider.dart';
 
 Future<void> enableServer(BuildContext context) async {
@@ -16,6 +17,8 @@ Future<void> enableServer(BuildContext context) async {
   );
   final bundle = Provider.of<RepositoryBundle?>(context, listen: false);
   if (bundle == null) return;
+
+  final serverAddress = serversViewModel.selectedServer?.address;
 
   final process = ProcessModal(context: context);
   process.open(AppLocalizations.of(context)!.enablingServer);
@@ -43,6 +46,10 @@ Future<void> enableServer(BuildContext context) async {
       );
     },
   );
+
+  if (result.isSuccess() && serverAddress != null) {
+    await WidgetChannel.sendBlockingUpdated(serverAddress: serverAddress);
+  }
 }
 
 Future<void> disableServer(int time, BuildContext context) async {
@@ -53,6 +60,8 @@ Future<void> disableServer(int time, BuildContext context) async {
   );
   final bundle = Provider.of<RepositoryBundle?>(context, listen: false);
   if (bundle == null) return;
+
+  final serverAddress = serversViewModel.selectedServer?.address;
 
   final process = ProcessModal(context: context);
   process.open(AppLocalizations.of(context)!.disablingServer);
@@ -78,4 +87,14 @@ Future<void> disableServer(int time, BuildContext context) async {
       );
     },
   );
+
+  if (result.isSuccess() && serverAddress != null) {
+    await WidgetChannel.sendBlockingUpdated(serverAddress: serverAddress);
+    if (time > 0) {
+      await WidgetChannel.scheduleBlockingRefresh(
+        serverAddress: serverAddress,
+        delaySeconds: time,
+      );
+    }
+  }
 }

--- a/lib/ui/core/view_models/status_viewmodel.dart
+++ b/lib/ui/core/view_models/status_viewmodel.dart
@@ -14,6 +14,7 @@ import 'package:pi_hole_client/domain/use_cases/realtime_status/realtime_status_
 import 'package:pi_hole_client/domain/use_cases/realtime_status/realtime_status_usecase_v6.dart';
 import 'package:pi_hole_client/utils/exceptions.dart';
 import 'package:pi_hole_client/utils/logger.dart';
+import 'package:pi_hole_client/utils/widget_channel.dart';
 
 /// ViewModel for the Home and Statistics screens.
 ///
@@ -419,6 +420,8 @@ class StatusViewModel with ChangeNotifier {
       final useCase = _createRealtimeStatusUseCase();
       if (useCase == null) return;
 
+      // Capture blocking status before fetch to detect changes.
+      final prevBlockingStatus = _realtimeStatus?.status;
       final result = await useCase.fetchRealtimeStatus();
 
       if (_selectedServerAddress != selectedUrlBefore) {
@@ -442,6 +445,16 @@ class StatusViewModel with ChangeNotifier {
           if (_serverStatus != LoadStatus.loaded) {
             _serverStatus = LoadStatus.loaded;
             notifyListeners();
+          }
+
+          // When blocking status changes during auto-refresh (e.g. a timed
+          // disable expired while the app was in the foreground), notify the
+          // home widget so it reflects the new state immediately.
+          if (status.status != prevBlockingStatus &&
+              _selectedServerAddress != null) {
+            WidgetChannel.sendBlockingUpdated(
+              serverAddress: _selectedServerAddress!,
+            );
           }
         },
         (error) {

--- a/lib/utils/widget_channel.dart
+++ b/lib/utils/widget_channel.dart
@@ -82,4 +82,23 @@ class WidgetChannel {
       logger.w('Widget blockingUpdated failed: $e');
     }
   }
+
+  /// Schedules a widget refresh after [delaySeconds] seconds.
+  ///
+  /// Used after a timed disable so the widget reflects the server auto
+  /// re-enabling blocking once the timer expires, even if the app is closed.
+  static Future<void> scheduleBlockingRefresh({
+    required String serverAddress,
+    required int delaySeconds,
+  }) async {
+    if (!_isSupported()) return;
+    try {
+      await _channel.invokeMethod('scheduleBlockingRefresh', {
+        'serverId': serverAddress,
+        'delaySeconds': delaySeconds,
+      });
+    } catch (e) {
+      logger.w('Widget scheduleBlockingRefresh failed: $e');
+    }
+  }
 }


### PR DESCRIPTION
## Overview
Home widget blocking status was not updated when a timed disable expired. This fix covers two scenarios: the timer expiring while the app is closed (widget relied on the 30-minute periodic refresh), and the timer expiring while the app is open in the foreground (auto-refresh updated the app UI but never notified the widget).

## Changes
- Notify the home widget immediately when `enableServer()`/`disableServer()` succeeds in the app
- Schedule a delayed WorkManager task (`setInitialDelay`) after a timed disable so the widget refreshes once the timer expires, even when the app is closed
- Notify the home widget during the auto-refresh polling cycle when the blocking status changes (e.g., a timed disable expires while the app is in the foreground)
- Add `WidgetChannel.scheduleBlockingRefresh()` Flutter→Kotlin bridge and `WidgetUpdateHelper.scheduleDelayedRefresh()` Kotlin implementation to support the delayed refresh
