### PR TITLE
fix(db): make v10 migration compatible with SQLite < 3.25

### DIFF
--- a/lib/data/services/local/database_service.dart
+++ b/lib/data/services/local/database_service.dart
@@ -786,9 +786,39 @@ class DatabaseService {
   /// to reflect that the option covers not only self-signed certificates
   /// but also those with incomplete chains.
   Future<void> _upgradeToV10(Database db) async {
-    await db.execute(
-      'ALTER TABLE servers RENAME COLUMN allowSelfSignedCert TO allowUntrustedCert',
-    );
+    await db.execute('''
+      CREATE TABLE servers_new (
+        address TEXT PRIMARY KEY NOT NULL,
+        alias TEXT NOT NULL,
+        isDefaultServer NUMERIC NOT NULL,
+        apiVersion TEXT NOT NULL,
+        allowUntrustedCert NUMERIC NOT NULL,
+        ignoreCertificateErrors NUMERIC NOT NULL,
+        pinnedCertificateSha256 TEXT
+      )
+    ''');
+    await db.execute('''
+      INSERT INTO servers_new (
+        address,
+        alias,
+        isDefaultServer,
+        apiVersion,
+        allowUntrustedCert,
+        ignoreCertificateErrors,
+        pinnedCertificateSha256
+      )
+      SELECT
+        address,
+        alias,
+        isDefaultServer,
+        apiVersion,
+        allowSelfSignedCert,
+        ignoreCertificateErrors,
+        pinnedCertificateSha256
+      FROM servers
+    ''');
+    await db.execute('DROP TABLE servers');
+    await db.execute('ALTER TABLE servers_new RENAME TO servers');
     logger.d('Database upgraded to version 10');
   }
 }


### PR DESCRIPTION
## Overview
The v9→v10 migration used `ALTER TABLE ... RENAME COLUMN`, which requires SQLite 3.25+ and fails on Android 8/9 (system SQLite 3.18/3.22). On affected devices the migration threw `near "COLUMN": syntax error`, the failure propagated up from `main()`, `runApp()` was never called, and the app hung on the splash screen after upgrading from v1.8.0 to v1.9.0.

## Changes
- Rewrote `_upgradeToV10` to use the create-new → copy → drop → rename pattern (matching `_upgradeToV5` / `_upgradeToV8` / `_upgradeToV9`) so the rename of `allowSelfSignedCert` → `allowUntrustedCert` works on all supported Android versions.
- Since `onUpgrade` runs in a transaction, devices that previously failed the migration remain at schema v9 and will pick up the new v10 migration cleanly on next launch — no manual recovery needed.
