### PR TITLE
refactor(routing): unify server-scoped route guards into ServerScopedRoute

### DIFF
--- a/lib/routing/app_router.dart
+++ b/lib/routing/app_router.dart
@@ -4,9 +4,9 @@ import 'package:pi_hole_client/data/repositories/api/interfaces/repository_bundl
 import 'package:pi_hole_client/domain/model/network/network.dart';
 import 'package:pi_hole_client/routing/route_extra.dart';
 import 'package:pi_hole_client/routing/routes.dart';
+import 'package:pi_hole_client/routing/server_scoped_route.dart';
 import 'package:pi_hole_client/ui/app_logs/widgets/app_logs_screen.dart';
 import 'package:pi_hole_client/ui/core/l10n/generated/app_localizations.dart';
-import 'package:pi_hole_client/ui/core/ui/components/empty_data_screen.dart';
 import 'package:pi_hole_client/ui/core/view_models/app_config_viewmodel.dart';
 import 'package:pi_hole_client/ui/core/view_models/servers_viewmodel.dart';
 import 'package:pi_hole_client/ui/core/view_models/status_viewmodel.dart';
@@ -157,14 +157,10 @@ GoRouter createAppRouter({
                   GoRoute(
                     path: '/domains',
                     name: Routes.domains,
-                    builder: (context, state) {
-                      final bundle = context.watch<RepositoryBundle?>();
-                      if (bundle == null) return const SizedBox.shrink();
-                      return KeyedSubtree(
-                        key: ObjectKey(bundle),
-                        child: createDomainsScreen(bundle),
-                      );
-                    },
+                    builder: (context, state) => ServerScopedRoute(
+                      title: AppLocalizations.of(context)!.domains,
+                      builder: (bundle, _) => createDomainsScreen(bundle),
+                    ),
                     routes: [
                       GoRoute(
                         path: 'details',
@@ -275,37 +271,23 @@ GoRouter createAppRouter({
                       GoRoute(
                         path: '/settings/server/info',
                         name: Routes.settingsServerInfo,
-                        builder: (context, state) {
-                          final bundle = context.read<RepositoryBundle?>();
-                          final server = context
-                              .read<ServersViewModel>()
-                              .selectedServer;
-                          if (bundle == null || server == null) {
-                            return _serverUnselectedScreen(
-                              context,
-                              AppLocalizations.of(context)!.serverInfo,
-                            );
-                          }
-                          return createServerInfoScreen(
+                        builder: (context, state) => ServerScopedRoute(
+                          title: AppLocalizations.of(context)!.serverInfo,
+                          builder: (bundle, server) => createServerInfoScreen(
                             bundle: bundle,
                             serverAlias: server.alias,
                             serverAddress: server.address,
-                          );
-                        },
+                          ),
+                        ),
                       ),
                       GoRoute(
                         path: '/settings/server/adlists',
                         name: Routes.settingsServerAdlists,
-                        builder: (context, state) {
-                          final bundle = context.read<RepositoryBundle?>();
-                          if (bundle == null) {
-                            return _serverUnselectedScreen(
-                              context,
-                              AppLocalizations.of(context)!.adlists,
-                            );
-                          }
-                          return createAdlistScreen(bundle);
-                        },
+                        builder: (context, state) => ServerScopedRoute(
+                          title: AppLocalizations.of(context)!.adlists,
+                          required: RequiredApiVersion.v6Only,
+                          builder: (bundle, _) => createAdlistScreen(bundle),
+                        ),
                         routes: [
                           GoRoute(
                             path: 'details',
@@ -328,16 +310,12 @@ GoRouter createAppRouter({
                       GoRoute(
                         path: '/settings/server/group-client',
                         name: Routes.settingsServerGroupClient,
-                        builder: (context, state) {
-                          final bundle = context.read<RepositoryBundle?>();
-                          if (bundle == null) {
-                            return _serverUnselectedScreen(
-                              context,
-                              AppLocalizations.of(context)!.groupsAndClients,
-                            );
-                          }
-                          return createGroupClientScreen(bundle);
-                        },
+                        builder: (context, state) => ServerScopedRoute(
+                          title: AppLocalizations.of(context)!.groupsAndClients,
+                          required: RequiredApiVersion.v6Only,
+                          builder: (bundle, _) =>
+                              createGroupClientScreen(bundle),
+                        ),
                         routes: [
                           GoRoute(
                             path: 'group-details',
@@ -390,16 +368,21 @@ GoRouter createAppRouter({
                       GoRoute(
                         path: '/settings/server/advanced',
                         name: Routes.settingsServerAdvanced,
-                        builder: (context, state) =>
-                            const AdvancedServerOptionsScreen(),
+                        builder: (context, state) => ServerScopedRoute(
+                          title: AppLocalizations.of(context)!.advancedSetup,
+                          required: RequiredApiVersion.v6Only,
+                          builder: (_, _) => const AdvancedServerOptionsScreen(),
+                        ),
                       ),
 
                       // ── Settings > Server > Advanced ──
                       GoRoute(
                         path: '/settings/server/advanced/sessions',
                         name: Routes.settingsServerAdvancedSessions,
-                        builder: (context, state) => createSessionsScreen(
-                          context.read<RepositoryBundle?>()!,
+                        builder: (context, state) => ServerScopedRoute(
+                          title: AppLocalizations.of(context)!.sessions,
+                          required: RequiredApiVersion.v6Only,
+                          builder: (bundle, _) => createSessionsScreen(bundle),
                         ),
                         routes: [
                           GoRoute(
@@ -418,8 +401,10 @@ GoRouter createAppRouter({
                       GoRoute(
                         path: '/settings/server/advanced/dhcp',
                         name: Routes.settingsServerAdvancedDhcp,
-                        builder: (context, state) => createDhcpScreen(
-                          context.read<RepositoryBundle?>()!,
+                        builder: (context, state) => ServerScopedRoute(
+                          title: AppLocalizations.of(context)!.dhcp,
+                          required: RequiredApiVersion.v6Only,
+                          builder: (bundle, _) => createDhcpScreen(bundle),
                         ),
                         routes: [
                           GoRoute(
@@ -438,8 +423,10 @@ GoRouter createAppRouter({
                       GoRoute(
                         path: '/settings/server/advanced/local-dns',
                         name: Routes.settingsServerAdvancedLocalDns,
-                        builder: (context, state) => createLocalDnsScreen(
-                          context.read<RepositoryBundle?>()!,
+                        builder: (context, state) => ServerScopedRoute(
+                          title: AppLocalizations.of(context)!.localDns,
+                          required: RequiredApiVersion.v6Only,
+                          builder: (bundle, _) => createLocalDnsScreen(bundle),
                         ),
                         routes: [
                           GoRoute(
@@ -461,10 +448,13 @@ GoRouter createAppRouter({
                       GoRoute(
                         path: '/settings/server/advanced/find-domains-in-lists',
                         name: Routes.settingsServerAdvancedFindDomainsInLists,
-                        builder: (context, state) =>
-                            createFindDomainsInListsScreen(
-                              context.read<RepositoryBundle?>()!,
-                            ),
+                        builder: (context, state) => ServerScopedRoute(
+                          title:
+                              AppLocalizations.of(context)!.findDomainsInLists,
+                          required: RequiredApiVersion.v6Only,
+                          builder: (bundle, _) =>
+                              createFindDomainsInListsScreen(bundle),
+                        ),
                         routes: [
                           GoRoute(
                             path: 'domain-details',
@@ -515,8 +505,10 @@ GoRouter createAppRouter({
                       GoRoute(
                         path: '/settings/server/advanced/interface',
                         name: Routes.settingsServerAdvancedInterface,
-                        builder: (context, state) => createInterfaceScreen(
-                          context.read<RepositoryBundle?>()!,
+                        builder: (context, state) => ServerScopedRoute(
+                          title: AppLocalizations.of(context)!.interface,
+                          required: RequiredApiVersion.v6Only,
+                          builder: (bundle, _) => createInterfaceScreen(bundle),
                         ),
                         routes: [
                           GoRoute(
@@ -555,8 +547,10 @@ GoRouter createAppRouter({
                       GoRoute(
                         path: '/settings/server/advanced/network',
                         name: Routes.settingsServerAdvancedNetwork,
-                        builder: (context, state) => createNetworkScreen(
-                          context.read<RepositoryBundle?>()!,
+                        builder: (context, state) => ServerScopedRoute(
+                          title: AppLocalizations.of(context)!.network,
+                          required: RequiredApiVersion.v6Only,
+                          builder: (bundle, _) => createNetworkScreen(bundle),
                         ),
                         routes: [
                           GoRoute(
@@ -615,16 +609,6 @@ GoRouter createAppRouter({
         builder: (context, state) => const ServersScreen(),
       ),
     ],
-  );
-}
-
-/// Fallback shown by server-scoped settings routes when no server is selected
-/// (i.e. [RepositoryBundle] is null). Matches the v1.8.0 behavior of showing
-/// a titled empty screen instead of throwing.
-Widget _serverUnselectedScreen(BuildContext context, String title) {
-  return Scaffold(
-    appBar: AppBar(title: Text(title)),
-    body: const SafeArea(child: EmptyDataScreen()),
   );
 }
 

--- a/lib/routing/server_scoped_route.dart
+++ b/lib/routing/server_scoped_route.dart
@@ -1,0 +1,71 @@
+import 'package:flutter/material.dart';
+import 'package:pi_hole_client/data/repositories/api/interfaces/repository_bundle.dart';
+import 'package:pi_hole_client/domain/model/api_versions.dart';
+import 'package:pi_hole_client/domain/model/server/server.dart';
+import 'package:pi_hole_client/ui/core/ui/components/empty_data_screen.dart';
+import 'package:pi_hole_client/ui/core/ui/components/pi_hole_v5_not_supported_screen.dart';
+import 'package:pi_hole_client/ui/core/view_models/servers_viewmodel.dart';
+import 'package:provider/provider.dart';
+
+/// Minimum API version required by a server-scoped route.
+enum RequiredApiVersion {
+  /// Works on any supported Pi-hole version.
+  any,
+
+  /// Requires Pi-hole v6.
+  v6Only,
+}
+
+/// Guard wrapper for every `/settings/server/*` and `/domains` route.
+///
+/// Centralizes three concerns that used to be handled ad-hoc across the
+/// router and individual screens:
+///
+/// 1. **No server selected** — renders a titled empty screen.
+/// 2. **v6-only feature on v5 server** — renders a titled
+///    [PiHoleV5NotSupportedScreen].
+/// 3. **Happy path** — invokes [builder] with the non-null bundle and server,
+///    wrapped in a [KeyedSubtree] keyed on bundle identity so switching
+///    servers tears down stale ViewModels instead of leaking state.
+class ServerScopedRoute extends StatelessWidget {
+  const ServerScopedRoute({
+    required this.title,
+    required this.builder,
+    this.required = RequiredApiVersion.any,
+    super.key,
+  });
+
+  /// AppBar title used by the fallback scaffolds (unselected / v5-not-supported).
+  final String title;
+
+  /// Minimum API version required by the wrapped screen.
+  final RequiredApiVersion required;
+
+  /// Builds the actual screen. `bundle` and `server` are guaranteed non-null.
+  final Widget Function(RepositoryBundle bundle, Server server) builder;
+
+  @override
+  Widget build(BuildContext context) {
+    final bundle = context.watch<RepositoryBundle?>();
+    final server = context.select<ServersViewModel, Server?>(
+      (vm) => vm.selectedServer,
+    );
+
+    if (bundle == null || server == null) {
+      return Scaffold(
+        appBar: AppBar(title: Text(title)),
+        body: const SafeArea(child: EmptyDataScreen()),
+      );
+    }
+
+    if (required == RequiredApiVersion.v6Only &&
+        server.apiVersion == SupportedApiVersions.v5) {
+      return Scaffold(
+        appBar: AppBar(title: Text(title)),
+        body: const SafeArea(child: PiHoleV5NotSupportedScreen()),
+      );
+    }
+
+    return KeyedSubtree(key: ObjectKey(bundle), child: builder(bundle, server));
+  }
+}

--- a/lib/ui/core/ui/components/pi_hole_v5_not_supported_screen.dart
+++ b/lib/ui/core/ui/components/pi_hole_v5_not_supported_screen.dart
@@ -6,31 +6,29 @@ class PiHoleV5NotSupportedScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      body: Center(
-        child: Padding(
-          padding: const EdgeInsets.symmetric(horizontal: 24.0),
-          child: Column(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              const Icon(Icons.not_interested_rounded, size: 60),
-              const SizedBox(height: 16),
-              Text(
-                AppLocalizations.of(context)!.unsupportedFeatureTitle,
-                textAlign: TextAlign.center,
-                style: const TextStyle(
-                  fontSize: 24,
-                  fontWeight: FontWeight.bold,
-                ),
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 24.0),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            const Icon(Icons.not_interested_rounded, size: 60),
+            const SizedBox(height: 16),
+            Text(
+              AppLocalizations.of(context)!.unsupportedFeatureTitle,
+              textAlign: TextAlign.center,
+              style: const TextStyle(
+                fontSize: 24,
+                fontWeight: FontWeight.bold,
               ),
-              const SizedBox(height: 32),
-              Text(
-                AppLocalizations.of(context)!.featureNotSupportedMessage,
-                textAlign: TextAlign.center,
-                style: const TextStyle(fontSize: 16, height: 1.5),
-              ),
-            ],
-          ),
+            ),
+            const SizedBox(height: 32),
+            Text(
+              AppLocalizations.of(context)!.featureNotSupportedMessage,
+              textAlign: TextAlign.center,
+              style: const TextStyle(fontSize: 16, height: 1.5),
+            ),
+          ],
         ),
       ),
     );

--- a/lib/ui/settings/server_settings/adlists/widgets/adlist_screen.dart
+++ b/lib/ui/settings/server_settings/adlists/widgets/adlist_screen.dart
@@ -4,12 +4,9 @@ import 'package:pi_hole_client/domain/model/list/adlist.dart';
 import 'package:pi_hole_client/routing/route_extra.dart';
 import 'package:pi_hole_client/routing/routes.dart';
 import 'package:pi_hole_client/ui/core/l10n/generated/app_localizations.dart';
-import 'package:pi_hole_client/ui/core/ui/components/empty_data_screen.dart';
-import 'package:pi_hole_client/ui/core/ui/components/pi_hole_v5_not_supported_screen.dart';
 import 'package:pi_hole_client/ui/core/ui/helpers/responsive.dart';
 import 'package:pi_hole_client/ui/core/ui/modals/group_filter_modal.dart';
 import 'package:pi_hole_client/ui/core/view_models/app_config_viewmodel.dart';
-import 'package:pi_hole_client/ui/core/view_models/servers_viewmodel.dart';
 import 'package:pi_hole_client/ui/settings/server_settings/adlists/view_models/adlists_viewmodel.dart';
 import 'package:pi_hole_client/ui/settings/server_settings/adlists/view_models/gravity_update_viewmodel.dart';
 import 'package:pi_hole_client/ui/settings/server_settings/adlists/widgets/adlist_actions.dart';
@@ -25,26 +22,7 @@ class AdlistScreen extends StatelessWidget {
   const AdlistScreen({super.key});
 
   @override
-  Widget build(BuildContext context) {
-    final serversViewModel = Provider.of<ServersViewModel>(context);
-    final selectedServer = serversViewModel.selectedServer;
-
-    if (selectedServer == null) {
-      return Scaffold(
-        appBar: AppBar(title: Text(AppLocalizations.of(context)!.adlists)),
-        body: const SafeArea(child: EmptyDataScreen()),
-      );
-    }
-
-    if (selectedServer.apiVersion == 'v5') {
-      return Scaffold(
-        appBar: AppBar(title: Text(AppLocalizations.of(context)!.adlists)),
-        body: const SafeArea(child: PiHoleV5NotSupportedScreen()),
-      );
-    }
-
-    return const AdlistScreenWidget();
-  }
+  Widget build(BuildContext context) => const AdlistScreenWidget();
 }
 
 class AdlistScreenWidget extends StatefulWidget {

--- a/lib/ui/settings/server_settings/advanced_settings/find_domains_in_lists/widgets/find_domains_in_lists_screen.dart
+++ b/lib/ui/settings/server_settings/advanced_settings/find_domains_in_lists/widgets/find_domains_in_lists_screen.dart
@@ -7,12 +7,9 @@ import 'package:pi_hole_client/routing/route_extra.dart';
 import 'package:pi_hole_client/routing/routes.dart';
 import 'package:pi_hole_client/ui/core/l10n/generated/app_localizations.dart';
 import 'package:pi_hole_client/ui/core/themes/theme.dart';
-import 'package:pi_hole_client/ui/core/ui/components/empty_data_screen.dart';
-import 'package:pi_hole_client/ui/core/ui/components/pi_hole_v5_not_supported_screen.dart';
 import 'package:pi_hole_client/ui/core/ui/helpers/snackbar.dart';
 import 'package:pi_hole_client/ui/core/ui/modals/process_modal.dart';
 import 'package:pi_hole_client/ui/core/view_models/app_config_viewmodel.dart';
-import 'package:pi_hole_client/ui/core/view_models/servers_viewmodel.dart';
 import 'package:pi_hole_client/ui/settings/server_settings/advanced_settings/find_domains_in_lists/view_models/find_domains_in_lists_viewmodel.dart';
 import 'package:pi_hole_client/ui/settings/server_settings/advanced_settings/find_domains_in_lists/widgets/models.dart';
 import 'package:pi_hole_client/ui/settings/server_settings/advanced_settings/find_domains_in_lists/widgets/results_section.dart';
@@ -21,9 +18,7 @@ import 'package:pi_hole_client/ui/settings/server_settings/group_client/view_mod
 import 'package:provider/provider.dart';
 
 class FindDomainsInListsScreen extends StatefulWidget {
-  const FindDomainsInListsScreen({this.showAppBar = true, super.key});
-
-  final bool showAppBar;
+  const FindDomainsInListsScreen({super.key});
 
   @override
   State<FindDomainsInListsScreen> createState() =>
@@ -58,35 +53,9 @@ class _FindDomainsInListsScreenState extends State<FindDomainsInListsScreen> {
   @override
   Widget build(BuildContext context) {
     final viewModel = context.watch<FindDomainsInListsViewModel>();
-    final serversViewModel = context.watch<ServersViewModel>();
     final appConfigViewModel = context.read<AppConfigViewModel>();
     final groups = context.watch<GroupsViewModel>().groupItems;
     final colors = appConfigViewModel.colors;
-    final apiVersion = serversViewModel.selectedServer?.apiVersion;
-
-    if (apiVersion == null) {
-      if (widget.showAppBar) {
-        return Scaffold(
-          appBar: AppBar(
-            title: Text(AppLocalizations.of(context)!.findDomainsInLists),
-          ),
-          body: const SafeArea(child: EmptyDataScreen()),
-        );
-      }
-      return const SafeArea(child: EmptyDataScreen());
-    }
-
-    if (apiVersion == 'v5') {
-      if (widget.showAppBar) {
-        return Scaffold(
-          appBar: AppBar(
-            title: Text(AppLocalizations.of(context)!.findDomainsInLists),
-          ),
-          body: const SafeArea(child: PiHoleV5NotSupportedScreen()),
-        );
-      }
-      return const SafeArea(child: PiHoleV5NotSupportedScreen());
-    }
 
     final content = SafeArea(
       child: ListView(
@@ -141,10 +110,6 @@ class _FindDomainsInListsScreenState extends State<FindDomainsInListsScreen> {
         ],
       ),
     );
-
-    if (!widget.showAppBar) {
-      return content;
-    }
 
     return Scaffold(
       appBar: AppBar(

--- a/lib/ui/settings/server_settings/group_client/widgets/group_client_screen.dart
+++ b/lib/ui/settings/server_settings/group_client/widgets/group_client_screen.dart
@@ -6,12 +6,9 @@ import 'package:pi_hole_client/routing/route_extra.dart';
 import 'package:pi_hole_client/routing/routes.dart';
 import 'package:pi_hole_client/ui/core/l10n/generated/app_localizations.dart';
 import 'package:pi_hole_client/ui/core/themes/theme.dart';
-import 'package:pi_hole_client/ui/core/ui/components/empty_data_screen.dart';
-import 'package:pi_hole_client/ui/core/ui/components/pi_hole_v5_not_supported_screen.dart';
 import 'package:pi_hole_client/ui/core/ui/helpers/responsive.dart';
 import 'package:pi_hole_client/ui/core/view_models/app_config_viewmodel.dart';
 import 'package:pi_hole_client/ui/core/view_models/local_dns_viewmodel.dart';
-import 'package:pi_hole_client/ui/core/view_models/servers_viewmodel.dart';
 import 'package:pi_hole_client/ui/domains/view_models/domains_viewmodel.dart';
 import 'package:pi_hole_client/ui/settings/server_settings/adlists/view_models/adlists_viewmodel.dart';
 import 'package:pi_hole_client/ui/settings/server_settings/group_client/view_models/clients_viewmodel.dart';
@@ -26,30 +23,7 @@ class GroupClientScreen extends StatelessWidget {
   const GroupClientScreen({super.key});
 
   @override
-  Widget build(BuildContext context) {
-    final serversViewModel = Provider.of<ServersViewModel>(context);
-    final apiVersion = serversViewModel.selectedServer?.apiVersion;
-
-    if (serversViewModel.selectedServer == null) {
-      return Scaffold(
-        appBar: AppBar(
-          title: Text(AppLocalizations.of(context)!.groupsAndClients),
-        ),
-        body: const SafeArea(child: EmptyDataScreen()),
-      );
-    }
-
-    if (apiVersion == 'v5') {
-      return Scaffold(
-        appBar: AppBar(
-          title: Text(AppLocalizations.of(context)!.groupsAndClients),
-        ),
-        body: const SafeArea(child: PiHoleV5NotSupportedScreen()),
-      );
-    }
-
-    return const GroupClientScreenWidget();
-  }
+  Widget build(BuildContext context) => const GroupClientScreenWidget();
 }
 
 class GroupClientScreenWidget extends StatefulWidget {

--- a/lib/ui/settings/server_settings/widgets/advanced_server_options_screen.dart
+++ b/lib/ui/settings/server_settings/widgets/advanced_server_options_screen.dart
@@ -5,14 +5,11 @@ import 'package:pi_hole_client/routing/routes.dart';
 import 'package:pi_hole_client/ui/core/l10n/generated/app_localizations.dart';
 import 'package:pi_hole_client/ui/core/themes/theme.dart';
 import 'package:pi_hole_client/ui/core/ui/components/custom_button_list_tile.dart';
-import 'package:pi_hole_client/ui/core/ui/components/empty_data_screen.dart';
-import 'package:pi_hole_client/ui/core/ui/components/pi_hole_v5_not_supported_screen.dart';
 import 'package:pi_hole_client/ui/core/ui/components/section_label.dart';
 import 'package:pi_hole_client/ui/core/ui/helpers/snackbar.dart';
 import 'package:pi_hole_client/ui/core/ui/modals/confirmation_modal.dart';
 import 'package:pi_hole_client/ui/core/ui/modals/process_modal.dart';
 import 'package:pi_hole_client/ui/core/view_models/app_config_viewmodel.dart';
-import 'package:pi_hole_client/ui/core/view_models/servers_viewmodel.dart';
 import 'package:pi_hole_client/utils/logger.dart';
 import 'package:provider/provider.dart';
 import 'package:skeletonizer/skeletonizer.dart';
@@ -87,29 +84,8 @@ class _AdvancedServerOptionsScreenState
   @override
   Widget build(BuildContext context) {
     final appConfigViewModel = context.read<AppConfigViewModel>();
-    final isV5 = context.select<ServersViewModel, bool>(
-      (vm) => vm.selectedServer?.apiVersion == 'v5',
-    );
-    final bundle = context.watch<RepositoryBundle?>();
+    final bundle = context.watch<RepositoryBundle?>()!;
     final theme = Theme.of(context).extension<AppColors>()!;
-
-    if (bundle == null) {
-      return Scaffold(
-        appBar: AppBar(
-          title: Text(AppLocalizations.of(context)!.advancedSetup),
-        ),
-        body: const SafeArea(child: EmptyDataScreen()),
-      );
-    }
-
-    if (isV5) {
-      return Scaffold(
-        appBar: AppBar(
-          title: Text(AppLocalizations.of(context)!.advancedSetup),
-        ),
-        body: const SafeArea(child: PiHoleV5NotSupportedScreen()),
-      );
-    }
 
     final loggingEnabled = isLoggingEnabled;
 

--- a/lib/ui/settings/server_settings/widgets/advanced_server_options_screen.dart
+++ b/lib/ui/settings/server_settings/widgets/advanced_server_options_screen.dart
@@ -24,47 +24,18 @@ class AdvancedServerOptionsScreen extends StatefulWidget {
 
 class _AdvancedServerOptionsScreenState
     extends State<AdvancedServerOptionsScreen> {
-  RepositoryBundle? _bundle;
-  RepositoryBundle? _previousBundle;
   bool? isLoggingEnabled;
   bool isLoading = true;
 
   @override
-  void didChangeDependencies() {
-    super.didChangeDependencies();
-    final currentBundle = context.watch<RepositoryBundle?>();
-
-    if (currentBundle != _previousBundle) {
-      _previousBundle = currentBundle;
-      _bundle = currentBundle;
-
-      if (_bundle != null) {
-        _loadQueryLoggingStatus();
-      } else {
-        setState(() {
-          isLoading = false;
-          isLoggingEnabled = null;
-        });
-      }
-    }
-  }
-
-  @override
-  void dispose() {
-    isLoggingEnabled = null;
-    isLoading = true;
-    super.dispose();
+  void initState() {
+    super.initState();
+    _loadQueryLoggingStatus();
   }
 
   Future<void> _loadQueryLoggingStatus() async {
-    if (!mounted || _bundle == null) return;
-
-    setState(() {
-      isLoading = true;
-      isLoggingEnabled = null;
-    });
-
-    final result = await _bundle!.config.fetchDnsQueryLogging();
+    final bundle = context.read<RepositoryBundle?>()!;
+    final result = await bundle.config.fetchDnsQueryLogging();
     if (!mounted) return;
 
     setState(() {
@@ -84,7 +55,7 @@ class _AdvancedServerOptionsScreenState
   @override
   Widget build(BuildContext context) {
     final appConfigViewModel = context.read<AppConfigViewModel>();
-    final bundle = context.watch<RepositoryBundle?>()!;
+    final bundle = context.read<RepositoryBundle?>()!;
     final theme = Theme.of(context).extension<AppColors>()!;
 
     final loggingEnabled = isLoggingEnabled;

--- a/test/routing/server_scoped_route_test.dart
+++ b/test/routing/server_scoped_route_test.dart
@@ -1,0 +1,253 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pi_hole_client/data/repositories/api/interfaces/repository_bundle.dart';
+import 'package:pi_hole_client/domain/model/server/server.dart';
+import 'package:pi_hole_client/routing/server_scoped_route.dart';
+import 'package:pi_hole_client/ui/core/l10n/generated/app_localizations.dart';
+import 'package:pi_hole_client/ui/core/themes/theme.dart';
+import 'package:pi_hole_client/ui/core/ui/components/empty_data_screen.dart';
+import 'package:pi_hole_client/ui/core/ui/components/pi_hole_v5_not_supported_screen.dart';
+import 'package:pi_hole_client/ui/core/view_models/servers_viewmodel.dart';
+import 'package:provider/provider.dart';
+
+import '../../testing/fakes/viewmodels/fake_servers_viewmodel.dart';
+import '../../testing/test_app.dart';
+
+const _v5Server = Server(
+  address: 'http://localhost:8081',
+  alias: 'v5 server',
+  apiVersion: 'v5',
+);
+
+const _v6Server = Server(
+  address: 'http://localhost:8082',
+  alias: 'v6 server',
+  apiVersion: 'v6',
+);
+
+class _BuilderCounter extends StatelessWidget {
+  const _BuilderCounter({required this.label, required this.onBuild});
+
+  final String label;
+  final VoidCallback onBuild;
+
+  @override
+  Widget build(BuildContext context) {
+    onBuild();
+    return Text(label);
+  }
+}
+
+Widget _wrap({
+  required Widget child,
+  required FakeServersViewModel serversViewModel,
+  required RepositoryBundle? bundle,
+}) {
+  return MaterialApp(
+    theme: lightTheme(null),
+    locale: const Locale('en'),
+    supportedLocales: AppLocalizations.supportedLocales,
+    localizationsDelegates: AppLocalizations.localizationsDelegates,
+    home: MultiProvider(
+      providers: [
+        ChangeNotifierProvider<ServersViewModel>.value(value: serversViewModel),
+        Provider<RepositoryBundle?>.value(value: bundle),
+      ],
+      child: child,
+    ),
+  );
+}
+
+void main() async {
+  await initTestApp();
+
+  group('ServerScopedRoute', () {
+    testWidgets('renders EmptyDataScreen when bundle is null', (tester) async {
+      final vm = FakeServersViewModel()..selectedServer = _v6Server;
+
+      await tester.pumpWidget(
+        _wrap(
+          serversViewModel: vm,
+          bundle: null,
+          child: ServerScopedRoute(
+            title: 'Adlists',
+            builder: (_, _) => const Text('SHOULD_NOT_SHOW'),
+          ),
+        ),
+      );
+
+      expect(find.byType(EmptyDataScreen), findsOneWidget);
+      expect(find.text('Adlists'), findsOneWidget);
+      expect(find.text('SHOULD_NOT_SHOW'), findsNothing);
+    });
+
+    testWidgets('renders EmptyDataScreen when selectedServer is null', (
+      tester,
+    ) async {
+      final vm = FakeServersViewModel();
+      final bundle = createFakeRepositoryBundle();
+
+      await tester.pumpWidget(
+        _wrap(
+          serversViewModel: vm,
+          bundle: bundle,
+          child: ServerScopedRoute(
+            title: 'Adlists',
+            builder: (_, _) => const Text('SHOULD_NOT_SHOW'),
+          ),
+        ),
+      );
+
+      expect(find.byType(EmptyDataScreen), findsOneWidget);
+      expect(find.text('SHOULD_NOT_SHOW'), findsNothing);
+    });
+
+    testWidgets(
+      'renders PiHoleV5NotSupportedScreen when v6Only and selected server is v5',
+      (tester) async {
+        final vm = FakeServersViewModel()..selectedServer = _v5Server;
+        final bundle = createFakeRepositoryBundle(apiVersion: 'v5');
+
+        await tester.pumpWidget(
+          _wrap(
+            serversViewModel: vm,
+            bundle: bundle,
+            child: ServerScopedRoute(
+              title: 'Sessions',
+              required: RequiredApiVersion.v6Only,
+              builder: (_, _) => const Text('SHOULD_NOT_SHOW'),
+            ),
+          ),
+        );
+
+        expect(find.byType(PiHoleV5NotSupportedScreen), findsOneWidget);
+        expect(find.text('Sessions'), findsOneWidget);
+        expect(find.text('SHOULD_NOT_SHOW'), findsNothing);
+      },
+    );
+
+    testWidgets('invokes builder when v6Only and server is v6', (tester) async {
+      final vm = FakeServersViewModel()..selectedServer = _v6Server;
+      final bundle = createFakeRepositoryBundle();
+      var buildCount = 0;
+
+      await tester.pumpWidget(
+        _wrap(
+          serversViewModel: vm,
+          bundle: bundle,
+          child: ServerScopedRoute(
+            title: 'Sessions',
+            required: RequiredApiVersion.v6Only,
+            builder: (_, _) =>
+                _BuilderCounter(label: 'OK', onBuild: () => buildCount++),
+          ),
+        ),
+      );
+
+      expect(find.text('OK'), findsOneWidget);
+      expect(find.byType(PiHoleV5NotSupportedScreen), findsNothing);
+      expect(find.byType(EmptyDataScreen), findsNothing);
+      expect(buildCount, 1);
+    });
+
+    testWidgets('invokes builder when required is any and server is v5', (
+      tester,
+    ) async {
+      final vm = FakeServersViewModel()..selectedServer = _v5Server;
+      final bundle = createFakeRepositoryBundle(apiVersion: 'v5');
+
+      await tester.pumpWidget(
+        _wrap(
+          serversViewModel: vm,
+          bundle: bundle,
+          child: ServerScopedRoute(
+            title: 'Server Info',
+            builder: (_, _) => const Text('INFO_V5'),
+          ),
+        ),
+      );
+
+      expect(find.text('INFO_V5'), findsOneWidget);
+      expect(find.byType(PiHoleV5NotSupportedScreen), findsNothing);
+    });
+
+    testWidgets('passes non-null bundle and server to builder', (tester) async {
+      final vm = FakeServersViewModel()..selectedServer = _v6Server;
+      final bundle = createFakeRepositoryBundle();
+      RepositoryBundle? capturedBundle;
+      Server? capturedServer;
+
+      await tester.pumpWidget(
+        _wrap(
+          serversViewModel: vm,
+          bundle: bundle,
+          child: ServerScopedRoute(
+            title: 'Adlists',
+            builder: (b, s) {
+              capturedBundle = b;
+              capturedServer = s;
+              return const Text('OK');
+            },
+          ),
+        ),
+      );
+
+      expect(capturedBundle, same(bundle));
+      expect(capturedServer, _v6Server);
+    });
+
+    testWidgets('rebuilds subtree when bundle identity changes', (tester) async {
+      final vm = FakeServersViewModel()..selectedServer = _v6Server;
+      final bundle1 = createFakeRepositoryBundle();
+      final bundle2 = createFakeRepositoryBundle();
+      var buildCount = 0;
+
+      Widget app(RepositoryBundle bundle) => _wrap(
+        serversViewModel: vm,
+        bundle: bundle,
+        child: ServerScopedRoute(
+          title: 'Adlists',
+          builder: (_, _) =>
+              _BuilderCounter(label: 'OK', onBuild: () => buildCount++),
+        ),
+      );
+
+      await tester.pumpWidget(app(bundle1));
+      expect(buildCount, 1);
+
+      await tester.pumpWidget(app(bundle2));
+      // Identity changed → KeyedSubtree creates a new element, builder runs again.
+      expect(buildCount, 2);
+      expect(find.text('OK'), findsOneWidget);
+    });
+
+    testWidgets(
+      'switches from PiHoleV5NotSupportedScreen to builder when server changes v5 -> v6',
+      (tester) async {
+        final vm = FakeServersViewModel()..selectedServer = _v5Server;
+        final bundle = createFakeRepositoryBundle();
+
+        await tester.pumpWidget(
+          _wrap(
+            serversViewModel: vm,
+            bundle: bundle,
+            child: ServerScopedRoute(
+              title: 'Sessions',
+              required: RequiredApiVersion.v6Only,
+              builder: (_, _) => const Text('SESSIONS_OK'),
+            ),
+          ),
+        );
+
+        expect(find.byType(PiHoleV5NotSupportedScreen), findsOneWidget);
+        expect(find.text('SESSIONS_OK'), findsNothing);
+
+        vm.selectedServer = _v6Server;
+        await tester.pump();
+
+        expect(find.byType(PiHoleV5NotSupportedScreen), findsNothing);
+        expect(find.text('SESSIONS_OK'), findsOneWidget);
+      },
+    );
+  });
+}

--- a/test/ui/settings/server_settings/adlists/adlists_test.dart
+++ b/test/ui/settings/server_settings/adlists/adlists_test.dart
@@ -11,9 +11,7 @@ import 'package:pi_hole_client/domain/model/list/adlist.dart';
 import 'package:pi_hole_client/domain/model/server/server.dart';
 import 'package:pi_hole_client/routing/route_extra.dart';
 import 'package:pi_hole_client/routing/routes.dart';
-import 'package:pi_hole_client/ui/core/ui/components/empty_data_screen.dart';
 import 'package:pi_hole_client/ui/core/ui/components/labeled_multi_select_tile.dart';
-import 'package:pi_hole_client/ui/core/ui/components/pi_hole_v5_not_supported_screen.dart';
 import 'package:pi_hole_client/ui/core/ui/modals/delete_modal.dart';
 import 'package:pi_hole_client/ui/core/view_models/servers_viewmodel.dart';
 import 'package:pi_hole_client/ui/settings/server_settings/adlists/view_models/adlists_viewmodel.dart';
@@ -119,15 +117,6 @@ const _serverV6 = Server(
   alias: 'test v6',
   defaultServer: false,
   apiVersion: 'v6',
-  allowUntrustedCert: true,
-  ignoreCertificateErrors: false,
-);
-
-const _serverV5 = Server(
-  address: 'http://localhost:8080',
-  alias: 'test v5',
-  defaultServer: false,
-  apiVersion: 'v5',
   allowUntrustedCert: true,
   ignoreCertificateErrors: false,
 );
@@ -281,54 +270,6 @@ void main() async {
       expect(find.text('Blocklist'), findsOneWidget);
       expect(find.text('There are no adlists to show here.'), findsOneWidget);
       expect(find.text('Choose an adlist to see its details'), findsOneWidget);
-    });
-
-    testWidgets('should show not supported screen with V5 server', (
-      WidgetTester tester,
-    ) async {
-      tester.view.physicalSize = const Size(1080, 2400);
-      tester.view.devicePixelRatio = 2.0;
-
-      fakeServersViewModel.selectedServer = _serverV5;
-
-      addTearDown(() {
-        tester.view.resetPhysicalSize();
-        tester.view.resetDevicePixelRatio();
-      });
-
-      await tester.pumpWidget(buildAdlistWidget());
-
-      expect(find.byType(AdlistScreen), findsOneWidget);
-      await tester.pumpAndSettle();
-
-      expect(find.byType(PiHoleV5NotSupportedScreen), findsOneWidget);
-      expect(find.text('Adlists'), findsOneWidget);
-      expect(find.text('Allowlist'), findsNothing);
-      expect(find.text('Blocklist'), findsNothing);
-    });
-
-    testWidgets('should show empty data screen when no server selected', (
-      WidgetTester tester,
-    ) async {
-      tester.view.physicalSize = const Size(1080, 2400);
-      tester.view.devicePixelRatio = 2.0;
-
-      fakeServersViewModel.selectedServer = null;
-
-      addTearDown(() {
-        tester.view.resetPhysicalSize();
-        tester.view.resetDevicePixelRatio();
-      });
-
-      await tester.pumpWidget(buildAdlistWidget());
-
-      expect(find.byType(AdlistScreen), findsOneWidget);
-      await tester.pumpAndSettle();
-
-      expect(find.byType(EmptyDataScreen), findsOneWidget);
-      expect(find.text('Adlists'), findsOneWidget);
-      expect(find.text('Allowlist'), findsNothing);
-      expect(find.text('Blocklist'), findsNothing);
     });
 
     testWidgets(

--- a/test/ui/settings/server_settings/advanced_settings/find_domains_in_lists/find_domains_in_lists_screen_test.dart
+++ b/test/ui/settings/server_settings/advanced_settings/find_domains_in_lists/find_domains_in_lists_screen_test.dart
@@ -6,7 +6,6 @@ import 'package:pi_hole_client/data/repositories/api/interfaces/repository_bundl
 import 'package:pi_hole_client/domain/model/server/server.dart';
 import 'package:pi_hole_client/routing/route_extra.dart';
 import 'package:pi_hole_client/routing/routes.dart';
-import 'package:pi_hole_client/ui/core/ui/components/pi_hole_v5_not_supported_screen.dart';
 import 'package:pi_hole_client/ui/core/view_models/servers_viewmodel.dart';
 import 'package:pi_hole_client/ui/settings/server_settings/adlists/view_models/adlists_viewmodel.dart';
 import 'package:pi_hole_client/ui/settings/server_settings/adlists/widgets/adlist_details_screen.dart';
@@ -156,42 +155,6 @@ void main() async {
         find.text('Please enter a maximum number greater than 0.'),
         findsOneWidget,
       );
-    });
-
-    testWidgets('shows v5 not supported screen when api is v5', (
-      WidgetTester tester,
-    ) async {
-      final v5ServersViewModel = FakeServersViewModel()
-        ..selectedServer = const Server(
-          address: 'http://localhost:8080',
-          alias: 'test v5',
-          defaultServer: false,
-          apiVersion: 'v5',
-          allowUntrustedCert: true,
-          ignoreCertificateErrors: false,
-        );
-
-      await tester.pumpWidget(
-        buildTestApp(
-          MultiProvider(
-            providers: [
-              ChangeNotifierProvider<ServersViewModel>.value(
-                value: v5ServersViewModel,
-              ),
-              ChangeNotifierProvider<FindDomainsInListsViewModel>.value(
-                value: findDomainsInListsViewModel,
-              ),
-              ChangeNotifierProvider<GroupsViewModel>.value(
-                value: groupsViewModel,
-              ),
-            ],
-            child: const FindDomainsInListsScreen(),
-          ),
-        ),
-      );
-      await tester.pumpAndSettle();
-
-      expect(find.byType(PiHoleV5NotSupportedScreen), findsOneWidget);
     });
 
     testWidgets('renders summary and results after successful search', (

--- a/test/ui/settings/server_settings/group_client/group_client_screen_test.dart
+++ b/test/ui/settings/server_settings/group_client/group_client_screen_test.dart
@@ -9,8 +9,6 @@ import 'package:pi_hole_client/domain/model/group/group.dart';
 import 'package:pi_hole_client/domain/model/server/server.dart';
 import 'package:pi_hole_client/routing/route_extra.dart';
 import 'package:pi_hole_client/routing/routes.dart';
-import 'package:pi_hole_client/ui/core/ui/components/empty_data_screen.dart';
-import 'package:pi_hole_client/ui/core/ui/components/pi_hole_v5_not_supported_screen.dart';
 import 'package:pi_hole_client/ui/core/ui/modals/delete_modal.dart';
 import 'package:pi_hole_client/ui/core/view_models/local_dns_viewmodel.dart';
 import 'package:pi_hole_client/ui/core/view_models/servers_viewmodel.dart';
@@ -46,15 +44,6 @@ const _serverV6 = Server(
   alias: 'test v6',
   defaultServer: false,
   apiVersion: 'v6',
-  allowUntrustedCert: true,
-  ignoreCertificateErrors: false,
-);
-
-const _serverV5 = Server(
-  address: 'http://localhost:8080',
-  alias: 'test v5',
-  defaultServer: false,
-  apiVersion: 'v5',
   allowUntrustedCert: true,
   ignoreCertificateErrors: false,
 );
@@ -160,50 +149,6 @@ void main() async {
       expect(find.text('Groups'), findsOneWidget);
       expect(find.text('Clients'), findsOneWidget);
       expect(find.text('Default'), findsOneWidget);
-    });
-
-    testWidgets('should show not supported screen with V5 server', (
-      WidgetTester tester,
-    ) async {
-      tester.view.physicalSize = const Size(1080, 2400);
-      tester.view.devicePixelRatio = 2.0;
-
-      fakeServersViewModel.selectedServer = _serverV5;
-
-      addTearDown(() {
-        tester.view.resetPhysicalSize();
-        tester.view.resetDevicePixelRatio();
-      });
-
-      await tester.pumpWidget(buildWidget(const GroupClientScreen()));
-
-      expect(find.byType(GroupClientScreen), findsOneWidget);
-      await tester.pump();
-
-      expect(find.byType(PiHoleV5NotSupportedScreen), findsOneWidget);
-      expect(find.text('Groups & Clients'), findsOneWidget);
-    });
-
-    testWidgets('should show empty data screen when no server selected', (
-      WidgetTester tester,
-    ) async {
-      tester.view.physicalSize = const Size(1080, 2400);
-      tester.view.devicePixelRatio = 2.0;
-
-      fakeServersViewModel.selectedServer = null;
-
-      addTearDown(() {
-        tester.view.resetPhysicalSize();
-        tester.view.resetDevicePixelRatio();
-      });
-
-      await tester.pumpWidget(buildWidget(const GroupClientScreen()));
-
-      expect(find.byType(GroupClientScreen), findsOneWidget);
-      await tester.pump();
-
-      expect(find.byType(EmptyDataScreen), findsOneWidget);
-      expect(find.text('Groups & Clients'), findsOneWidget);
     });
 
     testWidgets('should call search on clients viewmodel', (


### PR DESCRIPTION
## Overview
Introduces a single `ServerScopedRoute` guard widget to consolidate three concerns that were previously scattered across the router and individual screens: no-server-selected handling, v6-only gating, and subtree reset on server switch. This removes duplicated boilerplate from four screens and closes gaps where v6-only routes (sessions, DHCP, local DNS, interface, network) had no router-level protection.

## Changes
- Added `ServerScopedRoute` widget that renders `EmptyDataScreen` when no server is selected, `PiHoleV5NotSupportedScreen` when a v6-only route is hit on a v5 server, and otherwise invokes the builder with a non-null bundle and server. Wraps the child in `KeyedSubtree(ObjectKey(bundle))` so stale ViewModel state is torn down on server switch.
- Wired all `/settings/server/*` routes in `app_router.dart` through `ServerScopedRoute` with the appropriate `RequiredApiVersion` (v5/v6-agnostic vs. v6-only).
- Removed duplicated bundle-null and v5 early-return guards from `adlist_screen`, `group_client_screen`, `find_domains_in_lists_screen`, and `advanced_server_options_screen`.
- Adjusted `PiHoleV5NotSupportedScreen` to be embeddable (no inner `Scaffold`) since the guard now supplies the outer `Scaffold` and AppBar title.
- Added widget tests for `ServerScopedRoute` covering bundle null, server null, v6Only + v5 → unsupported screen, v6Only + v6 → builder, any + v5 → builder, bundle identity change, and v5 → v6 runtime transition.
- Dropped now-redundant screen-level guard tests that were coupled to the old architecture; equivalent coverage lives in the new route-level tests.