### PR TITLE
feat(ui): restore fade-through animation on bottom nav tab switching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,75 @@
 # Changelog
 
-## [1.8.0](https://github.com/tsutsu3/pi-hole-client/compare/1.7.1_(65)..1.8.0) - 2026-02-03
+## [1.9.0](https://github.com/tsutsu3/pi-hole-client/compare/1.8.0_(75)..1.9.0) - 2026-04-18
+
+### 🐛 Bug Fixes
+
+- *(gravity)* Resolve Dismissible crash on message card deletion ([#532](https://github.com/tsutsu3/pi-hole-client/issues/532)) - ([b0a41f8](https://github.com/tsutsu3/pi-hole-client/commit/b0a41f843dd11fb1f1e7fcfb5d6592e579624cba))
+- *(statistics)* Fix swipe-to-switch tabs causing ~1s white flash ([#567](https://github.com/tsutsu3/pi-hole-client/issues/567)) - ([bc6c66d](https://github.com/tsutsu3/pi-hole-client/commit/bc6c66d4d47f5dae0c23c65db95847ea63266207))
+- *(ui, api)* Address deprecation warnings from Flutter version upgrade ([#566](https://github.com/tsutsu3/pi-hole-client/issues/566)) - ([21f03d5](https://github.com/tsutsu3/pi-hole-client/commit/21f03d530bd863a1ec25850a4ddce129b23a3716))
+- *(widget)* Reset status to loading before navigating from home widget tap ([#557](https://github.com/tsutsu3/pi-hole-client/issues/557)) - ([9da0746](https://github.com/tsutsu3/pi-hole-client/commit/9da074644857ac1c2d9547ab9dfadfa43694474b))
+- *(widget)* Sync blocking status to home widget after timed disable expires ([#540](https://github.com/tsutsu3/pi-hole-client/issues/540)) - ([404bfa7](https://github.com/tsutsu3/pi-hole-client/commit/404bfa7fd0b799fcae1acf3e3e3d3cd034470f66))
+
+### 🚜 Refactor
+
+- *(adlists)* Extract shared scaffold, actions, and icon tab components ([#543](https://github.com/tsutsu3/pi-hole-client/issues/543)) - ([6e8df5c](https://github.com/tsutsu3/pi-hole-client/commit/6e8df5c2abddcfede01923a4c6731caa4f1406b3))
+- *(adlists)* Migrate AdLists, Find Domains, and Gravity screens ([#524](https://github.com/tsutsu3/pi-hole-client/issues/524)) - ([cf25101](https://github.com/tsutsu3/pi-hole-client/commit/cf251013430853514d7e2d5a53a664eb327b603d))
+- *(arch)* Align with Flutter official architecture guidelines ([#556](https://github.com/tsutsu3/pi-hole-client/issues/556)) - ([34e96d4](https://github.com/tsutsu3/pi-hole-client/commit/34e96d4206c8708f5cfd6240d1d110198e4d9ab1))
+- *(arch)* Replace API Gateway layer with Repository/ViewModel pattern ([#534](https://github.com/tsutsu3/pi-hole-client/issues/534)) - ([14fa25b](https://github.com/tsutsu3/pi-hole-client/commit/14fa25b72c83fd7f149dd8f8c795ba53a0e2ff32))
+- *(core)* GoRouter migration, ViewModel renaming, and codebase cleanup ([#526](https://github.com/tsutsu3/pi-hole-client/issues/526)) - ([f7e48b1](https://github.com/tsutsu3/pi-hole-client/commit/f7e48b1ddd335f14160055325f891243179a634c))
+- *(dhcp)* Migrate DHCP screen ([#515](https://github.com/tsutsu3/pi-hole-client/issues/515)) - ([5264a89](https://github.com/tsutsu3/pi-hole-client/commit/5264a89f31a087a810516d21f8bf25754f4cf3f0))
+- *(di)* Restructure provider base DI ([#506](https://github.com/tsutsu3/pi-hole-client/issues/506)) - ([6e4ed94](https://github.com/tsutsu3/pi-hole-client/commit/6e4ed943971ea7fa11500daf8a1cda68d34ff457))
+- *(dns-blocking)* Migrate server enable/disable from Gateway to DnsRepository ([#519](https://github.com/tsutsu3/pi-hole-client/issues/519)) - ([bbe9a8e](https://github.com/tsutsu3/pi-hole-client/commit/bbe9a8ec2b1ed6e5f16d8069a195333fa73d7c5b))
+- *(domains)* Add bottom space height to domains list widget ([#545](https://github.com/tsutsu3/pi-hole-client/issues/545)) - ([376f0c2](https://github.com/tsutsu3/pi-hole-client/commit/376f0c2538544d14d84a8dc6a6400f17279cba03))
+- *(domains)* Extract shared scaffold, actions components ([#544](https://github.com/tsutsu3/pi-hole-client/issues/544)) - ([bc18df1](https://github.com/tsutsu3/pi-hole-client/commit/bc18df18b3d96b6c505e9f6203463f69c0fdf18f))
+- *(domains)* Migrate Domains screen ([#521](https://github.com/tsutsu3/pi-hole-client/issues/521)) - ([bc8f1cb](https://github.com/tsutsu3/pi-hole-client/commit/bc8f1cb00f2cd11f20e2d015f9c06dba8475ed3c))
+- *(groups-clients)* Migrate Groups and Clients screens ([#525](https://github.com/tsutsu3/pi-hole-client/issues/525)) - ([d173598](https://github.com/tsutsu3/pi-hole-client/commit/d1735988bf0a7b3c478d1453083afb6c3e9d99ab))
+- *(home)* Migrate Home and Statistics screens ([#531](https://github.com/tsutsu3/pi-hole-client/issues/531)) - ([cdf273a](https://github.com/tsutsu3/pi-hole-client/commit/cdf273a9f0f5e35767a748f35d183051feb6036f))
+- *(interface)* Migrate Interface screen ([#517](https://github.com/tsutsu3/pi-hole-client/issues/517)) - ([0b4edef](https://github.com/tsutsu3/pi-hole-client/commit/0b4edefd1926e31153993bb77525b20ccbe23f0e))
+- *(local-dns)* Migrate LocalDnsScreen ([#518](https://github.com/tsutsu3/pi-hole-client/issues/518)) - ([3c48d51](https://github.com/tsutsu3/pi-hole-client/commit/3c48d519ec94c723258de89fab1a55409ea652aa))
+- *(logs)* Migrate Logs screen to ViewModel pattern ([#530](https://github.com/tsutsu3/pi-hole-client/issues/530)) - ([70ebf1c](https://github.com/tsutsu3/pi-hole-client/commit/70ebf1cc3e39710e0e61d95681a734705c40d6b0))
+- *(model)* Redesign domain models ([#508](https://github.com/tsutsu3/pi-hole-client/issues/508)) - ([90f97cb](https://github.com/tsutsu3/pi-hole-client/commit/90f97cb497b048d477a136e1970c1c0195e4140f))
+- *(network)* Optimize device loading ([#516](https://github.com/tsutsu3/pi-hole-client/issues/516)) - ([c324cee](https://github.com/tsutsu3/pi-hole-client/commit/c324cee2ad61dee73236edba690899bcfae04387))
+- *(network)* Migrate Network screen ([#514](https://github.com/tsutsu3/pi-hole-client/issues/514)) - ([bf29cce](https://github.com/tsutsu3/pi-hole-client/commit/bf29ccef8d6af74e3462d2305a1baf3a5478700c))
+- *(routing)* Go_router migration across all screens ([#548](https://github.com/tsutsu3/pi-hole-client/issues/548)) - ([35dfe09](https://github.com/tsutsu3/pi-hole-client/commit/35dfe095fe359d2e46995eeb365ce42af0a52db8))
+- *(routing)* Add go_router foundation for future navigation migration ([#503](https://github.com/tsutsu3/pi-hole-client/issues/503)) - ([2a02fe4](https://github.com/tsutsu3/pi-hole-client/commit/2a02fe48a76582ed24640a681d806efb0239ff00))
+- *(server)* Remove TODO for deleting basic auth keys ([#549](https://github.com/tsutsu3/pi-hole-client/issues/549)) - ([75592c1](https://github.com/tsutsu3/pi-hole-client/commit/75592c1c39cdf41d0a65bb498d31479d04b21399))
+- *(server-info)* Migrate ServerInfo screen to ViewModel + go_router pattern ([#513](https://github.com/tsutsu3/pi-hole-client/issues/513)) - ([30e5f6f](https://github.com/tsutsu3/pi-hole-client/commit/30e5f6f86100043dd39a81f90074f1cdb932bdd8))
+- *(server-settings)* Migrate advanced server options ([#520](https://github.com/tsutsu3/pi-hole-client/issues/520)) - ([c00d1d0](https://github.com/tsutsu3/pi-hole-client/commit/c00d1d0092ebcf4532a43a3bcd8e56cbea7fe88b))
+- *(sessions)* Migrate Sessions screen to ViewModel + go_router pattern ([#511](https://github.com/tsutsu3/pi-hole-client/issues/511)) - ([309f97a](https://github.com/tsutsu3/pi-hole-client/commit/309f97a93d3efa624423f545e284e40c0e7d560f))
+- *(ui)* Replace CustomRadio and CustomRadioListTile with Flutter built-ins ([#538](https://github.com/tsutsu3/pi-hole-client/issues/538)) - ([141e10d](https://github.com/tsutsu3/pi-hole-client/commit/141e10d3971637ed943f58ba28ed486bb6b5644a))
+- *(ui)* Replace CustomListTile with Flutter's built-in ListTile ([#537](https://github.com/tsutsu3/pi-hole-client/issues/537)) - ([041420d](https://github.com/tsutsu3/pi-hole-client/commit/041420da1d11c840a29fa5e8893875ecda132eef))
+- *(ui)* Extract color helpers from utils to UI layer ([#509](https://github.com/tsutsu3/pi-hole-client/issues/509)) - ([5830df2](https://github.com/tsutsu3/pi-hole-client/commit/5830df247e8d1a44556981b471235f1e57301f94))
+- *(viewmodel)* Apply command pattern ([#553](https://github.com/tsutsu3/pi-hole-client/issues/553)) - ([0814dd9](https://github.com/tsutsu3/pi-hole-client/commit/0814dd9e759ea889d2d3c50ee03a7249e78acca7))
+- *(viewmodel)* Connect Command listeners to ViewModel notifyListeners ([#551](https://github.com/tsutsu3/pi-hole-client/issues/551)) - ([6c60312](https://github.com/tsutsu3/pi-hole-client/commit/6c60312fd7a3b0bf78b6d51b04c30e4dd04c2ee7))
+- Rename allowSelfSignedCert to allowUntrustedCert and improve certificate UX ([#568](https://github.com/tsutsu3/pi-hole-client/issues/568)) - ([4ca8672](https://github.com/tsutsu3/pi-hole-client/commit/4ca8672014fbc81b149fc6de2456e05eea49cdea))
+
+### ⚡ Performance
+
+- *(ui)* Reduce unnecessary widget rebuilds across multiple screens ([#563](https://github.com/tsutsu3/pi-hole-client/issues/563)) - ([ae0633f](https://github.com/tsutsu3/pi-hole-client/commit/ae0633fddfc37c24797e806e106b1a33c92bb829))
+- Reduce unnecessary widget rebuilds across Home, Statistics, and Logs screens ([#560](https://github.com/tsutsu3/pi-hole-client/issues/560)) - ([6e10fa6](https://github.com/tsutsu3/pi-hole-client/commit/6e10fa6e6b5691907a738b3ec916a39b49f158d6))
+
+### 🎨 Styling
+
+- *(ui)* Remove unnecessary SafeArea and improve LicensePage layout ([#547](https://github.com/tsutsu3/pi-hole-client/issues/547)) - ([86e04af](https://github.com/tsutsu3/pi-hole-client/commit/86e04af897788cff2376e20f96b7c6b7dcebca73))
+- Format dart source files ([#542](https://github.com/tsutsu3/pi-hole-client/issues/542)) - ([cd3ffb4](https://github.com/tsutsu3/pi-hole-client/commit/cd3ffb4f6f8b3060776edd5551c5aec9590cae98))
+
+### 🧪 Testing
+
+- Add comprehensive unit and widget tests for mappers, repositories, and detail screens ([#555](https://github.com/tsutsu3/pi-hole-client/issues/555)) - ([0da256f](https://github.com/tsutsu3/pi-hole-client/commit/0da256fd8d095539ddba6b3abce1c46424c11a78))
+- Add comprehensive unit tests for logs, status, and utility components ([#550](https://github.com/tsutsu3/pi-hole-client/issues/550)) - ([066e7d2](https://github.com/tsutsu3/pi-hole-client/commit/066e7d27e34d6489021bd94ba344693a097d659b))
+
+### ⚙️ Miscellaneous Tasks
+
+- *(api)* Add PiholeV6Service wrapper for OpenAPI-generated v6 client ([#507](https://github.com/tsutsu3/pi-hole-client/issues/507)) - ([e12e52f](https://github.com/tsutsu3/pi-hole-client/commit/e12e52fecf318de08e13abc7a862bc7b486fcaa0))
+- *(coverage)* Update coverage exclusions for generated files ([#510](https://github.com/tsutsu3/pi-hole-client/issues/510)) - ([3900935](https://github.com/tsutsu3/pi-hole-client/commit/39009354fce06e040ae69abf66d477ca9c1f3b63))
+- *(openapi)* Add OpenAPI generator setup and bundled spec ([#502](https://github.com/tsutsu3/pi-hole-client/issues/502)) - ([575a941](https://github.com/tsutsu3/pi-hole-client/commit/575a9410283b92cc7705feb295b35348d474b9c8))
+- *(website)* Fix warnings and bump dependencies ([#565](https://github.com/tsutsu3/pi-hole-client/issues/565)) - ([95b7b32](https://github.com/tsutsu3/pi-hole-client/commit/95b7b320ea0d7a34ba4d9d63c8b59946f7dfae85))
+- *(winget)* Update documentation URL in winget manifest ([#505](https://github.com/tsutsu3/pi-hole-client/issues/505)) - ([9b447f6](https://github.com/tsutsu3/pi-hole-client/commit/9b447f6edfe6d3ba3cb1ff2add17e27c23d53442))
+- *(winget)* Winget manifest for v1.8.0 ([#504](https://github.com/tsutsu3/pi-hole-client/issues/504)) - ([14afaa1](https://github.com/tsutsu3/pi-hole-client/commit/14afaa1730161bbc5c6083fbfeef0ad30b9aab63))
+- Remove unused UseCaseFactory and GraphSection enum ([#573](https://github.com/tsutsu3/pi-hole-client/issues/573)) - ([83e7645](https://github.com/tsutsu3/pi-hole-client/commit/83e76453780398df95daa465dd079f789fec1aec))
+
+## [1.8.0_(75)](https://github.com/tsutsu3/pi-hole-client/compare/1.7.1_(65)..1.8.0_(75)) - 2026-02-07
 
 ### 🚀 Features
 
@@ -42,6 +111,7 @@
 - *(mock)* Add DHCP handler with leases management ([#461](https://github.com/tsutsu3/pi-hole-client/issues/461)) - ([5e6af15](https://github.com/tsutsu3/pi-hole-client/commit/5e6af15133b38c5532d194d603b1af4300f6ffff))
 - *(settings)* Remove deprecated security option from advanced settings ([#476](https://github.com/tsutsu3/pi-hole-client/issues/476)) - ([2a66dc3](https://github.com/tsutsu3/pi-hole-client/commit/2a66dc3fb412874730011e76f8b8c2aafbda9741))
 - *(urls)* Update URLs for connection guide and privacy policy ([#464](https://github.com/tsutsu3/pi-hole-client/issues/464)) - ([d3e6185](https://github.com/tsutsu3/pi-hole-client/commit/d3e6185344897fabdc5a3c62bee83d76d664c7ac))
+- *(website)* Add widget offline state documentation to FAQ and widget guide ([#500](https://github.com/tsutsu3/pi-hole-client/issues/500)) - ([1cc811d](https://github.com/tsutsu3/pi-hole-client/commit/1cc811d0fc17509a5ba35c0d9e60bdc217f3704d))
 - *(website)* Refine certificate checking solution section for clarity ([#485](https://github.com/tsutsu3/pi-hole-client/issues/485)) - ([eab2fe1](https://github.com/tsutsu3/pi-hole-client/commit/eab2fe19bc98709e3544052884094c8dc86086a1))
 - *(website)* Add Android Home Widget docs ([#474](https://github.com/tsutsu3/pi-hole-client/issues/474)) - ([2cc8e43](https://github.com/tsutsu3/pi-hole-client/commit/2cc8e4330ad1e26afef14d2600a1fbdb502adcc8))
 - *(website)* Add Certificate Configuration Guide ([#482](https://github.com/tsutsu3/pi-hole-client/issues/482)) - ([ac0fdd1](https://github.com/tsutsu3/pi-hole-client/commit/ac0fdd1cb582a9be3344382b35ee5a47528dc324))

--- a/lib/ui/shell/app_shell.dart
+++ b/lib/ui/shell/app_shell.dart
@@ -1,3 +1,4 @@
+import 'package:animations/animations.dart';
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import 'package:pi_hole_client/ui/core/model/app_screens.dart';
@@ -84,7 +85,7 @@ class AppShell extends StatelessWidget {
               selectedScreen: safeDisplayedIndex,
               onChange: onTabChanged,
             ),
-            Expanded(child: navigationShell),
+            Expanded(child: _animatedShell(navigationShell, currentBranch)),
           ],
         ),
       );
@@ -92,7 +93,7 @@ class AppShell extends StatelessWidget {
 
     // Mobile: content + optional BottomNavBar
     return Scaffold(
-      body: navigationShell,
+      body: _animatedShell(navigationShell, currentBranch),
       bottomNavigationBar: showBottomNav
           ? BottomNavBar(
               screens: screens,
@@ -100,6 +101,18 @@ class AppShell extends StatelessWidget {
               onChange: onTabChanged,
             )
           : null,
+    );
+  }
+
+  Widget _animatedShell(Widget child, int branchIndex) {
+    return PageTransitionSwitcher(
+      duration: const Duration(milliseconds: 200),
+      transitionBuilder: (child, primary, secondary) => FadeThroughTransition(
+        animation: primary,
+        secondaryAnimation: secondary,
+        child: child,
+      ),
+      child: KeyedSubtree(key: ValueKey<int>(branchIndex), child: child),
     );
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,7 +15,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # In iOS, build-name is used as CFBundleShortVersionString while build-number used as CFBundleVersion.
 # Read more about iOS versioning at
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
-version: 1.8.0+75
+version: 1.9.0+76
 
 environment:
   sdk: ">=3.8.0 <4.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,7 +15,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # In iOS, build-name is used as CFBundleShortVersionString while build-number used as CFBundleVersion.
 # Read more about iOS versioning at
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
-version: 1.9.0+76
+version: 1.9.0+77
 
 environment:
   sdk: ">=3.8.0 <4.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,7 +15,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # In iOS, build-name is used as CFBundleShortVersionString while build-number used as CFBundleVersion.
 # Read more about iOS versioning at
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
-version: 1.9.0+77
+version: 1.9.0+78
 
 environment:
   sdk: ">=3.8.0 <4.0.0"


### PR DESCRIPTION
## Overview
The fade-through transition that existed in v1.8.0 when switching between bottom navigation tabs was inadvertently dropped during the v1.9.0 architecture refactor (#534), which migrated the navigation shell from a hand-rolled `Base` widget to go_router's `StatefulShellRoute.indexedStack`. This PR restores the original 200ms `FadeThroughTransition` so tab switches regain the visual feedback users had before.

## Changes
- Wrap `navigationShell` in `AppShell` with `PageTransitionSwitcher` + `FadeThroughTransition` (200ms) to reintroduce the tab-switch animation, keyed by `navigationShell.currentIndex` so the switcher detects branch changes while the underlying indexed stack continues to preserve each branch's Navigator state.
- Apply the transition on both the mobile (BottomNavBar) and desktop (NavigationRail) layouts.
