### PR TITLE
feat(ui): restore fade-through animation on bottom nav tab switching

### DIFF
--- a/lib/routing/app_router.dart
+++ b/lib/routing/app_router.dart
@@ -51,6 +51,7 @@ import 'package:pi_hole_client/ui/settings/server_settings/group_client/widgets/
 import 'package:pi_hole_client/ui/settings/server_settings/group_client/widgets/group_details_screen.dart';
 import 'package:pi_hole_client/ui/settings/server_settings/server_info/widgets/server_info_screen_factory.dart';
 import 'package:pi_hole_client/ui/settings/server_settings/widgets/advanced_server_options_screen.dart';
+import 'package:pi_hole_client/ui/shell/animated_branch_container.dart';
 import 'package:pi_hole_client/ui/shell/app_shell.dart';
 import 'package:pi_hole_client/ui/shell/base.dart';
 import 'package:pi_hole_client/ui/shell/settings_shell.dart';
@@ -63,7 +64,7 @@ import 'package:provider/provider.dart';
 ///
 /// ```txt
 /// ShellRoute (Base – lifecycle management)
-///   └─ StatefulShellRoute.indexedStack (AppShell – NavigationRail / BottomNavBar)
+///   └─ StatefulShellRoute (AppShell – NavigationRail / BottomNavBar)
 ///         ├─ Branch 0: /home, /connect
 ///         ├─ Branch 1: /statistics
 ///         ├─ Branch 2: /logs
@@ -95,9 +96,15 @@ GoRouter createAppRouter({
         builder: (context, state, child) => Base(child: child),
         routes: [
           // Main navigation shell with 5 branches
-          StatefulShellRoute.indexedStack(
+          StatefulShellRoute(
             builder: (context, state, navigationShell) =>
                 AppShell(navigationShell: navigationShell),
+            navigatorContainerBuilder: (context, navigationShell, children) {
+              return AnimatedBranchContainer(
+                currentIndex: navigationShell.currentIndex,
+                children: children,
+              );
+            },
             branches: [
               // ── Branch 0: Home ──
               StatefulShellBranch(

--- a/lib/ui/shell/animated_branch_container.dart
+++ b/lib/ui/shell/animated_branch_container.dart
@@ -1,0 +1,36 @@
+import 'package:animations/animations.dart';
+import 'package:flutter/material.dart';
+
+/// Shows only the active branch navigator and fades between branches.
+///
+/// Unlike an IndexedStack-based container, inactive branches are unmounted so
+/// transient UI state (scroll position, pushed detail screens, dialogs) does
+/// not persist across tab switches.
+class AnimatedBranchContainer extends StatelessWidget {
+  const AnimatedBranchContainer({
+    required this.currentIndex,
+    required this.children,
+    super.key,
+  });
+
+  final int currentIndex;
+  final List<Widget> children;
+
+  @override
+  Widget build(BuildContext context) {
+    return PageTransitionSwitcher(
+      duration: const Duration(milliseconds: 200),
+      transitionBuilder: (child, primaryAnimation, secondaryAnimation) {
+        return FadeThroughTransition(
+          animation: primaryAnimation,
+          secondaryAnimation: secondaryAnimation,
+          child: child,
+        );
+      },
+      child: KeyedSubtree(
+        key: ValueKey(currentIndex),
+        child: children[currentIndex],
+      ),
+    );
+  }
+}

--- a/lib/ui/shell/app_shell.dart
+++ b/lib/ui/shell/app_shell.dart
@@ -1,3 +1,4 @@
+import 'package:animations/animations.dart';
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import 'package:pi_hole_client/ui/core/model/app_screens.dart';
@@ -84,7 +85,7 @@ class AppShell extends StatelessWidget {
               selectedScreen: safeDisplayedIndex,
               onChange: onTabChanged,
             ),
-            Expanded(child: navigationShell),
+            Expanded(child: _animatedShell(navigationShell, currentBranch)),
           ],
         ),
       );
@@ -92,7 +93,7 @@ class AppShell extends StatelessWidget {
 
     // Mobile: content + optional BottomNavBar
     return Scaffold(
-      body: navigationShell,
+      body: _animatedShell(navigationShell, currentBranch),
       bottomNavigationBar: showBottomNav
           ? BottomNavBar(
               screens: screens,
@@ -100,6 +101,18 @@ class AppShell extends StatelessWidget {
               onChange: onTabChanged,
             )
           : null,
+    );
+  }
+
+  Widget _animatedShell(Widget child, int branchIndex) {
+    return PageTransitionSwitcher(
+      duration: const Duration(milliseconds: 200),
+      transitionBuilder: (child, primary, secondary) => FadeThroughTransition(
+        animation: primary,
+        secondaryAnimation: secondary,
+        child: child,
+      ),
+      child: KeyedSubtree(key: ValueKey<int>(branchIndex), child: child),
     );
   }
 }

--- a/lib/ui/shell/app_shell.dart
+++ b/lib/ui/shell/app_shell.dart
@@ -1,4 +1,3 @@
-import 'package:animations/animations.dart';
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import 'package:pi_hole_client/ui/core/model/app_screens.dart';
@@ -85,7 +84,7 @@ class AppShell extends StatelessWidget {
               selectedScreen: safeDisplayedIndex,
               onChange: onTabChanged,
             ),
-            Expanded(child: _animatedShell(navigationShell, currentBranch)),
+            Expanded(child: navigationShell),
           ],
         ),
       );
@@ -93,7 +92,7 @@ class AppShell extends StatelessWidget {
 
     // Mobile: content + optional BottomNavBar
     return Scaffold(
-      body: _animatedShell(navigationShell, currentBranch),
+      body: navigationShell,
       bottomNavigationBar: showBottomNav
           ? BottomNavBar(
               screens: screens,
@@ -101,18 +100,6 @@ class AppShell extends StatelessWidget {
               onChange: onTabChanged,
             )
           : null,
-    );
-  }
-
-  Widget _animatedShell(Widget child, int branchIndex) {
-    return PageTransitionSwitcher(
-      duration: const Duration(milliseconds: 200),
-      transitionBuilder: (child, primary, secondary) => FadeThroughTransition(
-        animation: primary,
-        secondaryAnimation: secondary,
-        child: child,
-      ),
-      child: KeyedSubtree(key: ValueKey<int>(branchIndex), child: child),
     );
   }
 }


### PR DESCRIPTION
## Overview
The fade-through transition that existed in v1.8.0 when switching between bottom navigation tabs was inadvertently dropped during the v1.9.0 architecture refactor (#534), which migrated the navigation shell from a hand-rolled `Base` widget to go_router's `StatefulShellRoute.indexedStack`. This PR restores the original 200ms `FadeThroughTransition` so tab switches regain the visual feedback users had before.

