### PR TITLE
fix(sessions): centralize v6 session management and prevent duplicate sessions

### DIFF
--- a/lib/data/repositories/api/repository_factory.dart
+++ b/lib/data/repositories/api/repository_factory.dart
@@ -28,6 +28,7 @@ import 'package:pi_hole_client/data/repositories/api/v6/metrics_repository.dart'
 import 'package:pi_hole_client/data/repositories/api/v6/network_repository.dart';
 import 'package:pi_hole_client/data/repositories/api/v6/realtime_status_repository.dart'
     as v6;
+import 'package:pi_hole_client/data/repositories/api/v6/v6_session_cache.dart';
 import 'package:pi_hole_client/data/services/api/pihole_v5_api_client.dart';
 import 'package:pi_hole_client/data/services/api/pihole_v6_api_client.dart';
 import 'package:pi_hole_client/data/services/local/secure_storage_service.dart';
@@ -45,32 +46,49 @@ class RepositoryBundleFactory {
     switch (server.apiVersion) {
       case SupportedApiVersions.v6:
         final client = PiholeV6ApiClient(url: server.address);
-        final auth = AuthRepositoryV6(client: client, creds: creds);
-        // Register a renewal callback so that any v6 repository can trigger
-        // re-authentication transparently when a session expires (401/403).
-        creds.setRenewCallback(() async {
-          final pwResult = await creds.password;
-          final pw = pwResult.getOrNull() ?? '';
-          if (pw.isEmpty) return;
-          await auth.createSession(pw);
-        });
+        final sessionCache = V6SessionCache(creds: creds, client: client);
+
         return RepositoryBundle(
-          actions: ActionsRepositoryV6(client: client, creds: creds),
-          adlist: AdlistRepositoryV6(client: client, creds: creds),
-          auth: auth,
-          client: ClientRepositoryV6(client: client, creds: creds),
-          config: ConfigRepositoryV6(client: client, creds: creds),
-          dhcp: DhcpRepositoryV6(client: client, creds: creds),
-          dns: DnsRepositoryV6(client: client, creds: creds),
-          domain: DomainRepositoryV6(client: client, creds: creds),
-          ftl: FtlRepositoryV6(client: client, creds: creds),
-          group: GroupRepositoryV6(client: client, creds: creds),
-          localDns: LocalDnsRepositoryV6(client: client, creds: creds),
-          metrics: MetricsRepositoryV6(client: client, creds: creds),
-          network: NetworkRepositoryV6(client: client, creds: creds),
+          actions: ActionsRepositoryV6(
+            client: client,
+            sessionCache: sessionCache,
+          ),
+          adlist: AdlistRepositoryV6(
+            client: client,
+            sessionCache: sessionCache,
+          ),
+          auth: AuthRepositoryV6(client: client, sessionCache: sessionCache),
+          client: ClientRepositoryV6(
+            client: client,
+            sessionCache: sessionCache,
+          ),
+          config: ConfigRepositoryV6(
+            client: client,
+            sessionCache: sessionCache,
+          ),
+          dhcp: DhcpRepositoryV6(client: client, sessionCache: sessionCache),
+          dns: DnsRepositoryV6(client: client, sessionCache: sessionCache),
+          domain: DomainRepositoryV6(
+            client: client,
+            sessionCache: sessionCache,
+          ),
+          ftl: FtlRepositoryV6(client: client, sessionCache: sessionCache),
+          group: GroupRepositoryV6(client: client, sessionCache: sessionCache),
+          localDns: LocalDnsRepositoryV6(
+            client: client,
+            sessionCache: sessionCache,
+          ),
+          metrics: MetricsRepositoryV6(
+            client: client,
+            sessionCache: sessionCache,
+          ),
+          network: NetworkRepositoryV6(
+            client: client,
+            sessionCache: sessionCache,
+          ),
           realtimeStatus: v6.RealtimeStatusRepositoryV6(
             client: client,
-            creds: creds,
+            sessionCache: sessionCache,
           ),
           serverAddress: server.address,
           apiVersion: server.apiVersion,

--- a/lib/data/repositories/api/v6/actions_respository.dart
+++ b/lib/data/repositories/api/v6/actions_respository.dart
@@ -10,8 +10,7 @@ class ActionsRepositoryV6 extends BaseV6SidRepository
     implements ActionsRepository {
   ActionsRepositoryV6({
     required PiholeV6ApiClient client,
-    required super.creds,
-    super.sid,
+    required super.sessionCache,
   }) : _client = client;
 
   final PiholeV6ApiClient _client;

--- a/lib/data/repositories/api/v6/adlist_repository.dart
+++ b/lib/data/repositories/api/v6/adlist_repository.dart
@@ -13,8 +13,7 @@ class AdlistRepositoryV6 extends BaseV6SidRepository
     implements AdListRepository {
   AdlistRepositoryV6({
     required PiholeV6ApiClient client,
-    required super.creds,
-    super.sid,
+    required super.sessionCache,
   }) : _client = client;
 
   final PiholeV6ApiClient _client;

--- a/lib/data/repositories/api/v6/auth_repository.dart
+++ b/lib/data/repositories/api/v6/auth_repository.dart
@@ -10,8 +10,7 @@ import 'package:result_dart/result_dart.dart';
 class AuthRepositoryV6 extends BaseV6SidRepository implements AuthRepository {
   AuthRepositoryV6({
     required PiholeV6ApiClient client,
-    required super.creds,
-    super.sid,
+    required super.sessionCache,
   }) : _client = client;
 
   final PiholeV6ApiClient _client;

--- a/lib/data/repositories/api/v6/base_v6_sid_repository.dart
+++ b/lib/data/repositories/api/v6/base_v6_sid_repository.dart
@@ -1,91 +1,24 @@
-import 'dart:async';
+import 'package:pi_hole_client/data/repositories/api/v6/v6_session_cache.dart';
 
-import 'package:pi_hole_client/data/services/local/session_credential_service.dart';
-import 'package:pi_hole_client/utils/exceptions.dart';
-import 'package:pi_hole_client/utils/logger.dart';
-import 'package:pi_hole_client/utils/widget_channel.dart';
-
-/// An abstract base class that manages retrieval and caching of a V5 token
-/// using a [SessionCredentialService].
+/// Abstract base class for all v6 repositories.
 ///
-/// This repository provides a common mechanism to:
-/// - Retrieve a token from the provided [SessionCredentialService]
-/// - Cache the token for subsequent calls to avoid redundant network requests
-/// - Prevent concurrent token requests by sharing the same pending [Future]
-/// - Clear the cached token to force a refresh on the nex
+/// Delegates all SID management to the shared [V6SessionCache], which is
+/// created once per server and injected into every v6 repository. This
+/// guarantees that all repositories see the same cached SID and that
+/// concurrent session renewals are deduplicated to a single request.
 abstract class BaseV6SidRepository {
-  BaseV6SidRepository({required SessionCredentialService creds, String? sid})
-    : _creds = creds,
-      _sid = sid;
+  BaseV6SidRepository({required V6SessionCache sessionCache})
+    : _sessionCache = sessionCache;
 
-  final SessionCredentialService _creds;
+  final V6SessionCache _sessionCache;
 
-  /// The server address this repository is scoped to.
-  String get serverAddress => _creds.address;
+  String get serverAddress => _sessionCache.serverAddress;
 
-  String? _sid;
-  Future<String>? _loadingSid;
+  Future<String> getSid() => _sessionCache.getSid();
 
-  /// Retrieves the current V6 SID, fetching it from the credential service if necessary.
-  ///
-  /// This method implements caching and request deduplication:
-  /// - If a SID is already cached in [_sid], it is returned immediately.
-  /// - If a SID retrieval is already in progress, the same pending [Future] stored in
-  ///   [_loadingSid] is returned to avoid duplicate requests.
-  /// - Otherwise, a new request is made to [_creds] to obtain the SID.
-  Future<String> getSid() async {
-    if (_sid != null) return _sid!;
-    if (_loadingSid != null) return _loadingSid!;
+  Future<void> saveSid(String sid) => _sessionCache.saveSid(sid);
 
-    final c = Completer<String>();
-    _loadingSid = c.future;
-    try {
-      final r = await _creds.sid;
-      if (r.isError()) throw SidNotFoundException();
-      _sid = r.getOrThrow();
-      c.complete(_sid!);
-      // Notify the home widget that a valid SID is available.
-      // This covers the case where the app reconnects using a cached SID
-      // (createSession is skipped), preventing a permanent AUTH_REQUIRED state.
-      await WidgetChannel.sendSidUpdated(
-        serverAddress: serverAddress,
-        sid: _sid!,
-      );
-      return _sid!;
-    } catch (e) {
-      c.completeError(e);
-      rethrow;
-    } finally {
-      _loadingSid = null;
-    }
-  }
+  Future<void> clearSid() async => _sessionCache.clearSid();
 
-  /// Saves a new SID to secure storage and updates the in-memory cache.
-  Future<void> saveSid(String sid) async {
-    _sid = sid;
-    await _creds.saveSid(sid);
-  }
-
-  /// Clears the cached V6 SID.
-  Future<void> clearSid() async {
-    _sid = null;
-  }
-
-  /// Clears the cached SID and triggers session renewal.
-  ///
-  /// Used as the `onRetry` callback in repositories so that an expired or
-  /// invalid session causes automatic re-authentication before the next
-  /// attempt. Renewal errors are silently swallowed so the calling retry
-  /// loop can surface the original failure instead.
-  Future<void> clearAndRenewSid() async {
-    _sid = null;
-    logger.d('[$runtimeType] Session expired, attempting renewal...');
-    try {
-      await _creds.renewSession();
-      logger.d('[$runtimeType] Session renewed successfully.');
-    } catch (e) {
-      logger.w('[$runtimeType] Session renewal failed: $e');
-      await WidgetChannel.sendSidInvalidated(serverAddress: _creds.address);
-    }
-  }
+  Future<void> clearAndRenewSid() => _sessionCache.clearAndRenewSid();
 }

--- a/lib/data/repositories/api/v6/client_repository.dart
+++ b/lib/data/repositories/api/v6/client_repository.dart
@@ -10,8 +10,7 @@ class ClientRepositoryV6 extends BaseV6SidRepository
     implements ClientRepository {
   ClientRepositoryV6({
     required PiholeV6ApiClient client,
-    required super.creds,
-    super.sid,
+    required super.sessionCache,
   }) : _client = client;
 
   final PiholeV6ApiClient _client;

--- a/lib/data/repositories/api/v6/config_repository.dart
+++ b/lib/data/repositories/api/v6/config_repository.dart
@@ -11,8 +11,7 @@ class ConfigRepositoryV6 extends BaseV6SidRepository
     implements ConfigRepository {
   ConfigRepositoryV6({
     required PiholeV6ApiClient client,
-    required super.creds,
-    super.sid,
+    required super.sessionCache,
   }) : _client = client;
 
   final PiholeV6ApiClient _client;

--- a/lib/data/repositories/api/v6/dhcp_repository.dart
+++ b/lib/data/repositories/api/v6/dhcp_repository.dart
@@ -9,8 +9,7 @@ import 'package:result_dart/result_dart.dart';
 class DhcpRepositoryV6 extends BaseV6SidRepository implements DhcpRepository {
   DhcpRepositoryV6({
     required PiholeV6ApiClient client,
-    required super.creds,
-    super.sid,
+    required super.sessionCache,
   }) : _client = client;
 
   final PiholeV6ApiClient _client;

--- a/lib/data/repositories/api/v6/dns_repository.dart
+++ b/lib/data/repositories/api/v6/dns_repository.dart
@@ -9,8 +9,7 @@ import 'package:result_dart/result_dart.dart';
 class DnsRepositoryV6 extends BaseV6SidRepository implements DnsRepository {
   DnsRepositoryV6({
     required PiholeV6ApiClient client,
-    required super.creds,
-    super.sid,
+    required super.sessionCache,
   }) : _client = client;
 
   final PiholeV6ApiClient _client;

--- a/lib/data/repositories/api/v6/domain_repository.dart
+++ b/lib/data/repositories/api/v6/domain_repository.dart
@@ -11,8 +11,7 @@ class DomainRepositoryV6 extends BaseV6SidRepository
     implements DomainRepository {
   DomainRepositoryV6({
     required PiholeV6ApiClient client,
-    required super.creds,
-    super.sid,
+    required super.sessionCache,
   }) : _client = client;
 
   final PiholeV6ApiClient _client;

--- a/lib/data/repositories/api/v6/ftl_repository.dart
+++ b/lib/data/repositories/api/v6/ftl_repository.dart
@@ -17,8 +17,7 @@ import 'package:result_dart/result_dart.dart';
 class FtlRepositoryV6 extends BaseV6SidRepository implements FtlRepository {
   FtlRepositoryV6({
     required PiholeV6ApiClient client,
-    required super.creds,
-    super.sid,
+    required super.sessionCache,
   }) : _client = client;
 
   final PiholeV6ApiClient _client;

--- a/lib/data/repositories/api/v6/group_repository.dart
+++ b/lib/data/repositories/api/v6/group_repository.dart
@@ -9,8 +9,7 @@ import 'package:result_dart/result_dart.dart';
 class GroupRepositoryV6 extends BaseV6SidRepository implements GroupRepository {
   GroupRepositoryV6({
     required PiholeV6ApiClient client,
-    required super.creds,
-    super.sid,
+    required super.sessionCache,
   }) : _client = client;
 
   final PiholeV6ApiClient _client;

--- a/lib/data/repositories/api/v6/local_dns_repository.dart
+++ b/lib/data/repositories/api/v6/local_dns_repository.dart
@@ -10,8 +10,7 @@ class LocalDnsRepositoryV6 extends BaseV6SidRepository
     implements LocalDnsRepository {
   LocalDnsRepositoryV6({
     required PiholeV6ApiClient client,
-    required super.creds,
-    super.sid,
+    required super.sessionCache,
   }) : _client = client;
 
   final PiholeV6ApiClient _client;

--- a/lib/data/repositories/api/v6/metrics_repository.dart
+++ b/lib/data/repositories/api/v6/metrics_repository.dart
@@ -17,8 +17,7 @@ class MetricsRepositoryV6 extends BaseV6SidRepository
     implements MetricsRepository {
   MetricsRepositoryV6({
     required PiholeV6ApiClient client,
-    required super.creds,
-    super.sid,
+    required super.sessionCache,
   }) : _client = client;
 
   final PiholeV6ApiClient _client;

--- a/lib/data/repositories/api/v6/network_repository.dart
+++ b/lib/data/repositories/api/v6/network_repository.dart
@@ -10,8 +10,7 @@ class NetworkRepositoryV6 extends BaseV6SidRepository
     implements NetworkRepository {
   NetworkRepositoryV6({
     required PiholeV6ApiClient client,
-    required super.creds,
-    super.sid,
+    required super.sessionCache,
   }) : _client = client;
 
   final PiholeV6ApiClient _client;

--- a/lib/data/repositories/api/v6/realtime_status_repository.dart
+++ b/lib/data/repositories/api/v6/realtime_status_repository.dart
@@ -24,8 +24,7 @@ class RealtimeStatusRepositoryV6 extends BaseV6SidRepository
     implements RealtimeStatusRepository {
   RealtimeStatusRepositoryV6({
     required PiholeV6ApiClient client,
-    required super.creds,
-    super.sid,
+    required super.sessionCache,
   }) {
     // "Use" the parameters to suppress Lint
     client.hashCode;

--- a/lib/data/repositories/api/v6/v6_session_cache.dart
+++ b/lib/data/repositories/api/v6/v6_session_cache.dart
@@ -96,10 +96,10 @@ class V6SessionCache {
 
   Future<void> _renew() async {
     final pw = (await _creds.password).getOrNull() ?? '';
-    if (pw.isEmpty) return;
+    if (pw.isEmpty) throw Exception('Cannot renew session: no password configured');
     final result = await _client.postAuth(password: pw);
-    final auth = result.map((e) => e.toDomain()).getOrNull();
-    if (auth == null || !auth.valid) throw Exception('Session renewal failed');
+    final auth = result.getOrThrow().toDomain();
+    if (!auth.valid) throw Exception('Session renewal failed');
     await saveSid(auth.sid);
     await WidgetChannel.sendSidUpdated(
       serverAddress: serverAddress,

--- a/lib/data/repositories/api/v6/v6_session_cache.dart
+++ b/lib/data/repositories/api/v6/v6_session_cache.dart
@@ -1,0 +1,127 @@
+import 'package:pi_hole_client/data/mapper/v6/auth_mapper.dart';
+import 'package:pi_hole_client/data/services/api/pihole_v6_api_client.dart';
+import 'package:pi_hole_client/data/services/local/session_credential_service.dart';
+import 'package:pi_hole_client/utils/exceptions.dart';
+import 'package:pi_hole_client/utils/logger.dart';
+import 'package:pi_hole_client/utils/widget_channel.dart';
+
+/// Shared session manager for all v6 repositories scoped to the same server.
+///
+/// One instance is created per server in `RepositoryBundleFactory` and
+/// injected into every v6 repository via `BaseV6SidRepository`. This ensures:
+/// - A single in-memory SID cache shared across all repositories.
+/// - Concurrent [getSid] calls share one pending storage read.
+/// - Concurrent [clearAndRenewSid] calls trigger exactly one re-authentication.
+class V6SessionCache {
+  V6SessionCache({
+    required SessionCredentialService creds,
+    required PiholeV6ApiClient client,
+  }) : _creds = creds,
+       _client = client;
+
+  final SessionCredentialService _creds;
+  final PiholeV6ApiClient _client;
+
+  String? _sid;
+  Future<String>? _pendingLoad;
+  Future<void>? _pendingRenewal;
+
+  String get serverAddress => _creds.address;
+
+  // ---------------------------------------------------------------------------
+  // Public API
+  // ---------------------------------------------------------------------------
+
+  /// Returns the cached SID, loading from storage on a cache miss.
+  /// Concurrent calls share one in-flight [Future].
+  Future<String> getSid() => _getOrLoad(() async {
+    final r = await _creds.sid;
+    if (r.isError()) throw SidNotFoundException();
+    final sid = r.getOrThrow();
+    await WidgetChannel.sendSidUpdated(serverAddress: serverAddress, sid: sid);
+    return sid;
+  });
+
+  /// Saves [sid] to the shared cache and persists it to secure storage.
+  Future<void> saveSid(String sid) async {
+    _set(sid);
+    await _creds.saveSid(sid);
+  }
+
+  /// Clears the shared SID cache.
+  void clearSid() => _clear();
+
+  /// Clears the cache and triggers session renewal, deduplicating concurrent
+  /// calls so that only one re-authentication request is made.
+  Future<void> clearAndRenewSid() async {
+    logger.d('[V6SessionCache] Session expired, attempting renewal...');
+    try {
+      await _renewOnce();
+      logger.d('[V6SessionCache] Session renewed successfully.');
+    } catch (e) {
+      logger.w('[V6SessionCache] Session renewal failed: $e');
+      await WidgetChannel.sendSidInvalidated(serverAddress: _creds.address);
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Private cache internals
+  // ---------------------------------------------------------------------------
+
+  Future<String> _getOrLoad(Future<String> Function() loader) async {
+    if (_sid != null) return _sid!;
+    if (_pendingLoad != null) return _pendingLoad!;
+
+    // Share the same Future across concurrent callers.
+    // Using .then to update _sid avoids unhandled-error issues that arise
+    // when a separate Completer future has no listener.
+    final pending = loader().then((sid) {
+      _sid = sid;
+      return sid;
+    });
+    _pendingLoad = pending;
+
+    try {
+      return await pending;
+    } finally {
+      _pendingLoad = null;
+    }
+  }
+
+  void _set(String sid) {
+    _sid = sid;
+  }
+
+  void _clear() {
+    _sid = null;
+  }
+
+  Future<void> _renew() async {
+    final pw = (await _creds.password).getOrNull() ?? '';
+    if (pw.isEmpty) return;
+    final result = await _client.postAuth(password: pw);
+    final auth = result.map((e) => e.toDomain()).getOrNull();
+    if (auth == null || !auth.valid) throw Exception('Session renewal failed');
+    await saveSid(auth.sid);
+    await WidgetChannel.sendSidUpdated(
+      serverAddress: serverAddress,
+      sid: auth.sid,
+    );
+  }
+
+  Future<void> _renewOnce() async {
+    if (_pendingRenewal != null) return _pendingRenewal!;
+
+    _clear();
+
+    // Share the same Future so concurrent callers all wait for the same renewal.
+    final pending = _renew();
+    _pendingRenewal = pending;
+
+    try {
+      await pending;
+    } finally {
+      _pendingRenewal = null;
+    }
+  }
+}

--- a/lib/data/repositories/api/v6/v6_session_cache.dart
+++ b/lib/data/repositories/api/v6/v6_session_cache.dart
@@ -54,10 +54,8 @@ class V6SessionCache {
   /// Clears the cache and triggers session renewal, deduplicating concurrent
   /// calls so that only one re-authentication request is made.
   Future<void> clearAndRenewSid() async {
-    logger.d('[V6SessionCache] Session expired, attempting renewal...');
     try {
       await _renewOnce();
-      logger.d('[V6SessionCache] Session renewed successfully.');
     } catch (e) {
       logger.w('[V6SessionCache] Session renewal failed: $e');
       await WidgetChannel.sendSidInvalidated(serverAddress: _creds.address);
@@ -112,6 +110,7 @@ class V6SessionCache {
   Future<void> _renewOnce() async {
     if (_pendingRenewal != null) return _pendingRenewal!;
 
+    logger.d('[V6SessionCache] Session expired, attempting renewal...');
     _clear();
 
     // Share the same Future so concurrent callers all wait for the same renewal.
@@ -120,6 +119,7 @@ class V6SessionCache {
 
     try {
       await pending;
+      logger.d('[V6SessionCache] Session renewed successfully.');
     } finally {
       _pendingRenewal = null;
     }

--- a/lib/data/services/local/session_credential_service.dart
+++ b/lib/data/services/local/session_credential_service.dart
@@ -22,21 +22,6 @@ class SessionCredentialService {
   /// The server address this service is scoped to.
   String get address => _address;
 
-  Future<void> Function()? _renewCallback;
-
-  /// Registers a callback that performs session renewal (re-authentication).
-  ///
-  /// Called by the factory after creating the auth repository so that any
-  /// repository can trigger a password-based re-login when a session expires.
-  void setRenewCallback(Future<void> Function() callback) {
-    _renewCallback = callback;
-  }
-
-  /// Invokes the registered renewal callback, if any.
-  Future<void> renewSession() async {
-    await _renewCallback?.call();
-  }
-
   /// Retrieves the stored password for the server (v6).
   ///
   /// Returns a [Success] with the password, or [Failure] if not found or an error occurs.

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -11,15 +11,12 @@ import 'package:flutter_phoenix/flutter_phoenix.dart';
 import 'package:local_auth/local_auth.dart';
 import 'package:package_info_plus/package_info_plus.dart';
 import 'package:pi_hole_client/config/dependencies.dart';
-import 'package:pi_hole_client/data/repositories/api/repository_factory.dart';
 import 'package:pi_hole_client/data/repositories/local/app_config_repository.dart';
 import 'package:pi_hole_client/data/repositories/local/gravity_repository.dart';
 import 'package:pi_hole_client/data/repositories/local/interfaces/app_config_repository.dart';
 import 'package:pi_hole_client/data/repositories/local/server_repository.dart';
 import 'package:pi_hole_client/data/services/local/database_service.dart';
 import 'package:pi_hole_client/data/services/local/secure_storage_service.dart';
-import 'package:pi_hole_client/domain/model/enums.dart';
-import 'package:pi_hole_client/domain/model/server/server.dart';
 import 'package:pi_hole_client/pi_hole_client.dart';
 import 'package:pi_hole_client/ui/core/view_models/app_config_viewmodel.dart';
 import 'package:pi_hole_client/ui/core/view_models/servers_viewmodel.dart';
@@ -173,43 +170,6 @@ Future<void> initializeSentry(AppConfigViewModel configProvider) async {
   }
 }
 
-void setupWidgetChannel({
-  required ServersViewModel serversViewModel,
-  required SecureStorageService secureStorageService,
-  required StatusViewModel statusViewModel,
-}) {
-  const widgetChannel = MethodChannel('pihole/widget');
-  widgetChannel.setMethodCallHandler((call) async {
-    if (call.method != 'openServer') return;
-    final args = call.arguments;
-    if (args is! Map) return;
-    final serverId = args['serverId'];
-    if (serverId is! String || serverId.isEmpty) return;
-
-    Server? target;
-    for (final server in serversViewModel.getServersList) {
-      if (server.address == serverId) {
-        target = server;
-        break;
-      }
-    }
-    if (target == null) return;
-
-    // Reset to loading before navigating — prevents stale error state (yellow
-    // icon) from showing while reconnecting after any connection failure.
-    statusViewModel.setServerStatus(LoadStatus.loading);
-    serversViewModel.setselectedServer(server: target, toHomeTab: true);
-    final bundle = RepositoryBundleFactory.create(
-      server: target,
-      storage: secureStorageService,
-    );
-    final result = await bundle.dns.fetchBlockingStatus();
-    serversViewModel.updateselectedServerStatus(
-      result.getOrNull()?.status == DnsBlockingStatus.enabled,
-    );
-    statusViewModel.startAutoRefresh(showLoadingIndicator: false);
-  });
-}
 
 void main() async {
   // 1. System init
@@ -260,11 +220,6 @@ void main() async {
   await WidgetChannel.sendServersUpdated(serversViewModel.getServersList);
 
   // 5. Platform-specific setup
-  setupWidgetChannel(
-    serversViewModel: serversViewModel,
-    secureStorageService: secureStorageService,
-    statusViewModel: statusViewModel,
-  );
   await initializeBiometrics(configProvider, appConfigRepository);
   await initializeVibration(configProvider);
   await initializeDeviceInfo(configProvider);

--- a/lib/ui/shell/base.dart
+++ b/lib/ui/shell/base.dart
@@ -1,8 +1,10 @@
 import 'dart:io';
 
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:pi_hole_client/data/repositories/api/interfaces/repository_bundle.dart';
 import 'package:pi_hole_client/domain/model/enums.dart';
+import 'package:pi_hole_client/domain/model/server/server.dart';
 import 'package:pi_hole_client/ui/core/ui/modals/start_warning_modal.dart';
 import 'package:pi_hole_client/ui/core/view_models/app_config_viewmodel.dart';
 import 'package:pi_hole_client/ui/core/view_models/servers_viewmodel.dart';
@@ -40,6 +42,8 @@ class _BaseState extends State<Base>
         windowManager.addListener(this);
       }
 
+      setupWidgetChannel();
+
       final serversViewModel = context.read<ServersViewModel>();
 
       final appConfigViewModel = context.read<AppConfigViewModel>();
@@ -61,6 +65,43 @@ class _BaseState extends State<Base>
     });
   }
 
+  void setupWidgetChannel() {
+    const MethodChannel('pihole/widget').setMethodCallHandler((call) async {
+      if (call.method != 'openServer') return;
+      final args = call.arguments;
+      if (args is! Map) return;
+      final serverId = args['serverId'];
+      if (serverId is! String || serverId.isEmpty) return;
+
+      if (!mounted) return;
+      final serversViewModel = context.read<ServersViewModel>();
+      Server? target;
+      for (final server in serversViewModel.getServersList) {
+        if (server.address == serverId) {
+          target = server;
+          break;
+        }
+      }
+      if (target == null) return;
+
+      // Reset to loading before navigating — prevents stale error state
+      // (yellow icon) from showing while reconnecting after a prior failure.
+      context.read<StatusViewModel>().setServerStatus(LoadStatus.loading);
+      serversViewModel.setselectedServer(server: target, toHomeTab: true);
+
+      // Wait for ProxyProvider2 to rebuild the bundle for the (possibly new)
+      // server before reading it via context.read<RepositoryBundle?>().
+      await WidgetsBinding.instance.endOfFrame;
+      if (!mounted) return;
+
+      await _fetchAndUpdateStatus();
+      if (!mounted) return;
+      context.read<StatusViewModel>().startAutoRefresh(
+        showLoadingIndicator: false,
+      );
+    });
+  }
+
   @override
   void dispose() {
     WidgetsBinding.instance.removeObserver(this);
@@ -68,6 +109,8 @@ class _BaseState extends State<Base>
     if (isDesktopPlatform()) {
       windowManager.removeListener(this);
     }
+
+    const MethodChannel('pihole/widget').setMethodCallHandler(null);
 
     super.dispose();
   }

--- a/lib/ui/shell/base.dart
+++ b/lib/ui/shell/base.dart
@@ -3,7 +3,6 @@ import 'dart:io';
 import 'package:flutter/material.dart';
 import 'package:pi_hole_client/data/repositories/api/interfaces/repository_bundle.dart';
 import 'package:pi_hole_client/domain/model/enums.dart';
-import 'package:pi_hole_client/domain/model/server/api_versions.dart';
 import 'package:pi_hole_client/ui/core/ui/modals/start_warning_modal.dart';
 import 'package:pi_hole_client/ui/core/view_models/app_config_viewmodel.dart';
 import 'package:pi_hole_client/ui/core/view_models/servers_viewmodel.dart';
@@ -118,27 +117,16 @@ class _BaseState extends State<Base>
 
   /// Fetches the blocking status and updates [ServersViewModel].
   ///
-  /// For v6 servers, if the initial request fails (e.g. expired session),
-  /// re-authenticates with the stored password and retries once.
+  /// Session renewal for v6 is handled transparently inside
+  /// fetchBlockingStatus via runWithResultRetry + clearAndRenewSid,
+  /// so no explicit fallback is needed here.
   Future<void> _fetchAndUpdateStatus() async {
     final serversViewModel = context.read<ServersViewModel>();
     final server = serversViewModel.selectedServer;
     final bundle = context.read<RepositoryBundle?>();
     if (bundle == null || server == null) return;
 
-    var result = await bundle.dns.fetchBlockingStatus();
-
-    // Auto-refresh for v6 can fail if the session has expired
-    if (result.isError() && server.apiVersion == SupportedApiVersions.v6) {
-      final creds = await serversViewModel.fetchCredentials(server.address);
-      final pw = creds.getOrNull()?.password ?? '';
-      if (pw.isNotEmpty) {
-        final authResult = await bundle.auth.createSession(pw);
-        if (authResult.isSuccess()) {
-          result = await bundle.dns.fetchBlockingStatus();
-        }
-      }
-    }
+    final result = await bundle.dns.fetchBlockingStatus();
 
     serversViewModel.updateselectedServerStatus(
       result.getOrNull()?.status == DnsBlockingStatus.enabled,

--- a/test/data/repositories/api/v6/actions_respository_test.dart
+++ b/test/data/repositories/api/v6/actions_respository_test.dart
@@ -1,5 +1,6 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:pi_hole_client/data/repositories/api/v6/actions_respository.dart';
+import 'package:pi_hole_client/data/repositories/api/v6/v6_session_cache.dart';
 import 'package:result_dart/result_dart.dart';
 
 import '../../../../../testing/fakes/services/fake_pihole_v6_api_client.dart';
@@ -16,7 +17,7 @@ void main() {
     setUp(() {
       creds = FakeSessionCredentialService();
       client = FakePiholeV6ApiClient();
-      repository = ActionsRepositoryV6(client: client, creds: creds);
+      repository = ActionsRepositoryV6(client: client, sessionCache: V6SessionCache(creds: creds, client: client));
     });
 
     test('should flush ARP successfully', () async {
@@ -46,7 +47,7 @@ void main() {
     setUp(() {
       creds = FakeSessionCredentialService();
       client = FakePiholeV6ApiClient();
-      repository = ActionsRepositoryV6(client: client, creds: creds);
+      repository = ActionsRepositoryV6(client: client, sessionCache: V6SessionCache(creds: creds, client: client));
     });
 
     test('should flush logs successfully', () async {
@@ -69,7 +70,7 @@ void main() {
     setUp(() {
       creds = FakeSessionCredentialService();
       client = FakePiholeV6ApiClient();
-      repository = ActionsRepositoryV6(client: client, creds: creds);
+      repository = ActionsRepositoryV6(client: client, sessionCache: V6SessionCache(creds: creds, client: client));
     });
 
     test('should update gravity successfully', () async {
@@ -103,7 +104,7 @@ void main() {
     setUp(() {
       creds = FakeSessionCredentialService();
       client = FakePiholeV6ApiClient();
-      repository = ActionsRepositoryV6(client: client, creds: creds);
+      repository = ActionsRepositoryV6(client: client, sessionCache: V6SessionCache(creds: creds, client: client));
     });
 
     test('should restart DNS successfully', () async {

--- a/test/data/repositories/api/v6/adlist_respository_test.dart
+++ b/test/data/repositories/api/v6/adlist_respository_test.dart
@@ -1,5 +1,6 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:pi_hole_client/data/repositories/api/v6/adlist_repository.dart';
+import 'package:pi_hole_client/data/repositories/api/v6/v6_session_cache.dart';
 import 'package:pi_hole_client/domain/model/enums.dart';
 
 import '../../../../../testing/fakes/services/fake_pihole_v6_api_client.dart';
@@ -16,7 +17,7 @@ void main() {
     setUp(() {
       creds = FakeSessionCredentialService();
       client = FakePiholeV6ApiClient();
-      repository = AdlistRepositoryV6(client: client, creds: creds);
+      repository = AdlistRepositoryV6(client: client, sessionCache: V6SessionCache(creds: creds, client: client));
     });
 
     test('should get adlists successfully', () async {
@@ -36,7 +37,7 @@ void main() {
     setUp(() {
       creds = FakeSessionCredentialService();
       client = FakePiholeV6ApiClient();
-      repository = AdlistRepositoryV6(client: client, creds: creds);
+      repository = AdlistRepositoryV6(client: client, sessionCache: V6SessionCache(creds: creds, client: client));
     });
 
     test('should add adlist successfully', () async {
@@ -62,7 +63,7 @@ void main() {
     setUp(() {
       creds = FakeSessionCredentialService();
       client = FakePiholeV6ApiClient();
-      repository = AdlistRepositoryV6(client: client, creds: creds);
+      repository = AdlistRepositoryV6(client: client, sessionCache: V6SessionCache(creds: creds, client: client));
     });
 
     test('should remove adlist successfully', () async {
@@ -88,7 +89,7 @@ void main() {
     setUp(() {
       creds = FakeSessionCredentialService();
       client = FakePiholeV6ApiClient();
-      repository = AdlistRepositoryV6(client: client, creds: creds);
+      repository = AdlistRepositoryV6(client: client, sessionCache: V6SessionCache(creds: creds, client: client));
     });
 
     test('should remove adlist successfully', () async {

--- a/test/data/repositories/api/v6/auth_repository_test.dart
+++ b/test/data/repositories/api/v6/auth_repository_test.dart
@@ -1,5 +1,6 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:pi_hole_client/data/repositories/api/v6/auth_repository.dart';
+import 'package:pi_hole_client/data/repositories/api/v6/v6_session_cache.dart';
 
 import '../../../../../testing/fakes/services/fake_pihole_v6_api_client.dart';
 import '../../../../../testing/fakes/services/fake_session_credential_service.dart';
@@ -14,7 +15,7 @@ void main() {
   setUp(() {
     client = FakePiholeV6ApiClient();
     creds = FakeSessionCredentialService();
-    repository = AuthRepositoryV6(client: client, creds: creds);
+    repository = AuthRepositoryV6(client: client, sessionCache: V6SessionCache(creds: creds, client: client));
   });
 
   group('createSession', () {

--- a/test/data/repositories/api/v6/client_repository_test.dart
+++ b/test/data/repositories/api/v6/client_repository_test.dart
@@ -1,5 +1,6 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:pi_hole_client/data/repositories/api/v6/client_repository.dart';
+import 'package:pi_hole_client/data/repositories/api/v6/v6_session_cache.dart';
 
 import '../../../../../testing/fakes/services/fake_pihole_v6_api_client.dart';
 import '../../../../../testing/fakes/services/fake_session_credential_service.dart';
@@ -14,7 +15,7 @@ void main() {
   setUp(() {
     creds = FakeSessionCredentialService();
     client = FakePiholeV6ApiClient();
-    repository = ClientRepositoryV6(client: client, creds: creds);
+    repository = ClientRepositoryV6(client: client, sessionCache: V6SessionCache(creds: creds, client: client));
   });
 
   group('fetchClients', () {

--- a/test/data/repositories/api/v6/config_repository_test.dart
+++ b/test/data/repositories/api/v6/config_repository_test.dart
@@ -1,5 +1,6 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:pi_hole_client/data/repositories/api/v6/config_repository.dart';
+import 'package:pi_hole_client/data/repositories/api/v6/v6_session_cache.dart';
 
 import '../../../../../testing/fakes/services/fake_pihole_v6_api_client.dart';
 import '../../../../../testing/fakes/services/fake_session_credential_service.dart';
@@ -15,7 +16,7 @@ void main() {
     setUp(() {
       client = FakePiholeV6ApiClient();
       creds = FakeSessionCredentialService();
-      repository = ConfigRepositoryV6(client: client, creds: creds);
+      repository = ConfigRepositoryV6(client: client, sessionCache: V6SessionCache(creds: creds, client: client));
     });
 
     test('should fetch DNS query logging successfully', () async {
@@ -35,7 +36,7 @@ void main() {
     setUp(() {
       client = FakePiholeV6ApiClient();
       creds = FakeSessionCredentialService();
-      repository = ConfigRepositoryV6(client: client, creds: creds);
+      repository = ConfigRepositoryV6(client: client, sessionCache: V6SessionCache(creds: creds, client: client));
     });
 
     test('should fetch DNS query logging successfully', () async {

--- a/test/data/repositories/api/v6/dhcp_repository_test.dart
+++ b/test/data/repositories/api/v6/dhcp_repository_test.dart
@@ -1,5 +1,6 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:pi_hole_client/data/repositories/api/v6/dhcp_repository.dart';
+import 'package:pi_hole_client/data/repositories/api/v6/v6_session_cache.dart';
 
 import '../../../../../testing/fakes/services/fake_pihole_v6_api_client.dart';
 import '../../../../../testing/fakes/services/fake_session_credential_service.dart';
@@ -15,7 +16,7 @@ void main() {
     setUp(() {
       client = FakePiholeV6ApiClient();
       creds = FakeSessionCredentialService();
-      repository = DhcpRepositoryV6(client: client, creds: creds);
+      repository = DhcpRepositoryV6(client: client, sessionCache: V6SessionCache(creds: creds, client: client));
     });
 
     test('should fetch DHCP leases successfully', () async {
@@ -35,7 +36,7 @@ void main() {
     setUp(() {
       client = FakePiholeV6ApiClient();
       creds = FakeSessionCredentialService();
-      repository = DhcpRepositoryV6(client: client, creds: creds);
+      repository = DhcpRepositoryV6(client: client, sessionCache: V6SessionCache(creds: creds, client: client));
     });
 
     test('should fetch DHCP lease successfully', () async {

--- a/test/data/repositories/api/v6/dns_repository_test.dart
+++ b/test/data/repositories/api/v6/dns_repository_test.dart
@@ -1,5 +1,6 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:pi_hole_client/data/repositories/api/v6/dns_repository.dart';
+import 'package:pi_hole_client/data/repositories/api/v6/v6_session_cache.dart';
 
 import '../../../../../testing/fakes/services/fake_pihole_v6_api_client.dart';
 import '../../../../../testing/fakes/services/fake_session_credential_service.dart';
@@ -15,7 +16,7 @@ void main() {
     setUp(() {
       client = FakePiholeV6ApiClient();
       creds = FakeSessionCredentialService();
-      repository = DnsRepositoryV6(client: client, creds: creds);
+      repository = DnsRepositoryV6(client: client, sessionCache: V6SessionCache(creds: creds, client: client));
     });
 
     test('should fetch DNS blocking status successfully', () async {
@@ -35,7 +36,7 @@ void main() {
     setUp(() {
       client = FakePiholeV6ApiClient();
       creds = FakeSessionCredentialService();
-      repository = DnsRepositoryV6(client: client, creds: creds);
+      repository = DnsRepositoryV6(client: client, sessionCache: V6SessionCache(creds: creds, client: client));
     });
 
     test('should enable DNS blocking successfully', () async {
@@ -56,7 +57,7 @@ void main() {
     setUp(() {
       client = FakePiholeV6ApiClient();
       creds = FakeSessionCredentialService();
-      repository = DnsRepositoryV6(client: client, creds: creds);
+      repository = DnsRepositoryV6(client: client, sessionCache: V6SessionCache(creds: creds, client: client));
     });
 
     test('should disable DNS blocking successfully', () async {

--- a/test/data/repositories/api/v6/domain_repository_test.dart
+++ b/test/data/repositories/api/v6/domain_repository_test.dart
@@ -1,5 +1,6 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:pi_hole_client/data/repositories/api/v6/domain_repository.dart';
+import 'package:pi_hole_client/data/repositories/api/v6/v6_session_cache.dart';
 import 'package:pi_hole_client/domain/model/enums.dart';
 
 import '../../../../../testing/fakes/services/fake_pihole_v6_api_client.dart';
@@ -16,7 +17,7 @@ void main() {
     setUp(() {
       client = FakePiholeV6ApiClient();
       creds = FakeSessionCredentialService();
-      repository = DomainRepositoryV6(client: client, creds: creds);
+      repository = DomainRepositoryV6(client: client, sessionCache: V6SessionCache(creds: creds, client: client));
     });
 
     test('should fetch all domains successfully', () async {
@@ -36,7 +37,7 @@ void main() {
     setUp(() {
       client = FakePiholeV6ApiClient();
       creds = FakeSessionCredentialService();
-      repository = DomainRepositoryV6(client: client, creds: creds);
+      repository = DomainRepositoryV6(client: client, sessionCache: V6SessionCache(creds: creds, client: client));
     });
 
     test('should add domain successfully', () async {
@@ -64,7 +65,7 @@ void main() {
     setUp(() {
       client = FakePiholeV6ApiClient();
       creds = FakeSessionCredentialService();
-      repository = DomainRepositoryV6(client: client, creds: creds);
+      repository = DomainRepositoryV6(client: client, sessionCache: V6SessionCache(creds: creds, client: client));
     });
 
     test('should update domain successfully', () async {
@@ -98,7 +99,7 @@ void main() {
     setUp(() {
       client = FakePiholeV6ApiClient();
       creds = FakeSessionCredentialService();
-      repository = DomainRepositoryV6(client: client, creds: creds);
+      repository = DomainRepositoryV6(client: client, sessionCache: V6SessionCache(creds: creds, client: client));
     });
 
     test('should delete domain successfully', () async {

--- a/test/data/repositories/api/v6/ftl_repository_test.dart
+++ b/test/data/repositories/api/v6/ftl_repository_test.dart
@@ -1,5 +1,6 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:pi_hole_client/data/repositories/api/v6/ftl_repository.dart';
+import 'package:pi_hole_client/data/repositories/api/v6/v6_session_cache.dart';
 
 import '../../../../../testing/fakes/services/fake_pihole_v6_api_client.dart';
 import '../../../../../testing/fakes/services/fake_session_credential_service.dart';
@@ -15,7 +16,7 @@ void main() {
     setUp(() {
       client = FakePiholeV6ApiClient();
       creds = FakeSessionCredentialService();
-      repository = FtlRepositoryV6(client: client, creds: creds);
+      repository = FtlRepositoryV6(client: client, sessionCache: V6SessionCache(creds: creds, client: client));
     });
 
     test('should fetch info client successfully', () async {
@@ -35,7 +36,7 @@ void main() {
     setUp(() {
       client = FakePiholeV6ApiClient();
       creds = FakeSessionCredentialService();
-      repository = FtlRepositoryV6(client: client, creds: creds);
+      repository = FtlRepositoryV6(client: client, sessionCache: V6SessionCache(creds: creds, client: client));
     });
 
     test('should fetch info ftl successfully', () async {
@@ -61,7 +62,7 @@ void main() {
     setUp(() {
       client = FakePiholeV6ApiClient();
       creds = FakeSessionCredentialService();
-      repository = FtlRepositoryV6(client: client, creds: creds);
+      repository = FtlRepositoryV6(client: client, sessionCache: V6SessionCache(creds: creds, client: client));
     });
 
     test('should fetch info host successfully', () async {
@@ -81,7 +82,7 @@ void main() {
     setUp(() {
       client = FakePiholeV6ApiClient();
       creds = FakeSessionCredentialService();
-      repository = FtlRepositoryV6(client: client, creds: creds);
+      repository = FtlRepositoryV6(client: client, sessionCache: V6SessionCache(creds: creds, client: client));
     });
 
     test('should fetch gravity messages successfully', () async {
@@ -101,7 +102,7 @@ void main() {
     setUp(() {
       client = FakePiholeV6ApiClient();
       creds = FakeSessionCredentialService();
-      repository = FtlRepositoryV6(client: client, creds: creds);
+      repository = FtlRepositoryV6(client: client, sessionCache: V6SessionCache(creds: creds, client: client));
     });
 
     test('should delete info message successfully', () async {
@@ -121,7 +122,7 @@ void main() {
     setUp(() {
       client = FakePiholeV6ApiClient();
       creds = FakeSessionCredentialService();
-      repository = FtlRepositoryV6(client: client, creds: creds);
+      repository = FtlRepositoryV6(client: client, sessionCache: V6SessionCache(creds: creds, client: client));
     });
 
     test('should fetch info metrics successfully', () async {
@@ -141,7 +142,7 @@ void main() {
     setUp(() {
       client = FakePiholeV6ApiClient();
       creds = FakeSessionCredentialService();
-      repository = FtlRepositoryV6(client: client, creds: creds);
+      repository = FtlRepositoryV6(client: client, sessionCache: V6SessionCache(creds: creds, client: client));
     });
 
     test('should fetch all sensors successfully', () async {
@@ -161,7 +162,7 @@ void main() {
     setUp(() {
       client = FakePiholeV6ApiClient();
       creds = FakeSessionCredentialService();
-      repository = FtlRepositoryV6(client: client, creds: creds);
+      repository = FtlRepositoryV6(client: client, sessionCache: V6SessionCache(creds: creds, client: client));
     });
 
     test('should fetch info system successfully', () async {
@@ -187,7 +188,7 @@ void main() {
     setUp(() {
       client = FakePiholeV6ApiClient();
       creds = FakeSessionCredentialService();
-      repository = FtlRepositoryV6(client: client, creds: creds);
+      repository = FtlRepositoryV6(client: client, sessionCache: V6SessionCache(creds: creds, client: client));
     });
 
     test('should fetch info version successfully', () async {
@@ -213,7 +214,7 @@ void main() {
     setUp(() {
       client = FakePiholeV6ApiClient();
       creds = FakeSessionCredentialService();
-      repository = FtlRepositoryV6(client: client, creds: creds);
+      repository = FtlRepositoryV6(client: client, sessionCache: V6SessionCache(creds: creds, client: client));
     });
 
     test('should fetch all server info successfully', () async {

--- a/test/data/repositories/api/v6/group_repository_test.dart
+++ b/test/data/repositories/api/v6/group_repository_test.dart
@@ -1,5 +1,6 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:pi_hole_client/data/repositories/api/v6/group_repository.dart';
+import 'package:pi_hole_client/data/repositories/api/v6/v6_session_cache.dart';
 
 import '../../../../../testing/fakes/services/fake_pihole_v6_api_client.dart';
 import '../../../../../testing/fakes/services/fake_session_credential_service.dart';
@@ -14,7 +15,7 @@ void main() {
   setUp(() {
     creds = FakeSessionCredentialService();
     client = FakePiholeV6ApiClient();
-    repository = GroupRepositoryV6(client: client, creds: creds);
+    repository = GroupRepositoryV6(client: client, sessionCache: V6SessionCache(creds: creds, client: client));
   });
 
   group('fetchGroups', () {

--- a/test/data/repositories/api/v6/local_dns_repository_test.dart
+++ b/test/data/repositories/api/v6/local_dns_repository_test.dart
@@ -1,5 +1,6 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:pi_hole_client/data/repositories/api/v6/local_dns_repository.dart';
+import 'package:pi_hole_client/data/repositories/api/v6/v6_session_cache.dart';
 import 'package:pi_hole_client/domain/model/local_dns/local_dns.dart';
 
 import '../../../../../testing/fakes/services/fake_pihole_v6_api_client.dart';
@@ -15,7 +16,7 @@ void main() {
     setUp(() {
       client = FakePiholeV6ApiClient();
       creds = FakeSessionCredentialService();
-      repository = LocalDnsRepositoryV6(client: client, creds: creds);
+      repository = LocalDnsRepositoryV6(client: client, sessionCache: V6SessionCache(creds: creds, client: client));
     });
 
     test('should fetch records successfully', () async {
@@ -36,7 +37,7 @@ void main() {
     setUp(() {
       client = FakePiholeV6ApiClient();
       creds = FakeSessionCredentialService();
-      repository = LocalDnsRepositoryV6(client: client, creds: creds);
+      repository = LocalDnsRepositoryV6(client: client, sessionCache: V6SessionCache(creds: creds, client: client));
     });
 
     test('should add record successfully', () async {
@@ -61,7 +62,7 @@ void main() {
     setUp(() {
       client = FakePiholeV6ApiClient();
       creds = FakeSessionCredentialService();
-      repository = LocalDnsRepositoryV6(client: client, creds: creds);
+      repository = LocalDnsRepositoryV6(client: client, sessionCache: V6SessionCache(creds: creds, client: client));
     });
 
     test('should delete record successfully', () async {
@@ -89,7 +90,7 @@ void main() {
     setUp(() {
       client = FakePiholeV6ApiClient();
       creds = FakeSessionCredentialService();
-      repository = LocalDnsRepositoryV6(client: client, creds: creds);
+      repository = LocalDnsRepositoryV6(client: client, sessionCache: V6SessionCache(creds: creds, client: client));
     });
 
     test('should fail when fetching current config fails', () async {

--- a/test/data/repositories/api/v6/metrics_repository_test.dart
+++ b/test/data/repositories/api/v6/metrics_repository_test.dart
@@ -1,5 +1,6 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:pi_hole_client/data/repositories/api/v6/metrics_repository.dart';
+import 'package:pi_hole_client/data/repositories/api/v6/v6_session_cache.dart';
 
 import '../../../../../testing/fakes/services/fake_pihole_v6_api_client.dart';
 import '../../../../../testing/fakes/services/fake_session_credential_service.dart';
@@ -15,7 +16,7 @@ void main() {
     setUp(() {
       creds = FakeSessionCredentialService();
       client = FakePiholeV6ApiClient();
-      repository = MetricsRepositoryV6(client: client, creds: creds);
+      repository = MetricsRepositoryV6(client: client, sessionCache: V6SessionCache(creds: creds, client: client));
     });
 
     test('should get history successfully', () async {
@@ -35,7 +36,7 @@ void main() {
     setUp(() {
       creds = FakeSessionCredentialService();
       client = FakePiholeV6ApiClient();
-      repository = MetricsRepositoryV6(client: client, creds: creds);
+      repository = MetricsRepositoryV6(client: client, sessionCache: V6SessionCache(creds: creds, client: client));
     });
 
     test('should get history client successfully', () async {
@@ -55,7 +56,7 @@ void main() {
     setUp(() {
       creds = FakeSessionCredentialService();
       client = FakePiholeV6ApiClient();
-      repository = MetricsRepositoryV6(client: client, creds: creds);
+      repository = MetricsRepositoryV6(client: client, sessionCache: V6SessionCache(creds: creds, client: client));
     });
 
     test('should get queries successfully', () async {
@@ -81,7 +82,7 @@ void main() {
     setUp(() {
       creds = FakeSessionCredentialService();
       client = FakePiholeV6ApiClient();
-      repository = MetricsRepositoryV6(client: client, creds: creds);
+      repository = MetricsRepositoryV6(client: client, sessionCache: V6SessionCache(creds: creds, client: client));
     });
 
     test('should get stats summary successfully', () async {
@@ -101,7 +102,7 @@ void main() {
     setUp(() {
       creds = FakeSessionCredentialService();
       client = FakePiholeV6ApiClient();
-      repository = MetricsRepositoryV6(client: client, creds: creds);
+      repository = MetricsRepositoryV6(client: client, sessionCache: V6SessionCache(creds: creds, client: client));
     });
 
     test('should get stats upstreams successfully', () async {
@@ -121,7 +122,7 @@ void main() {
     setUp(() {
       creds = FakeSessionCredentialService();
       client = FakePiholeV6ApiClient();
-      repository = MetricsRepositoryV6(client: client, creds: creds);
+      repository = MetricsRepositoryV6(client: client, sessionCache: V6SessionCache(creds: creds, client: client));
     });
 
     test('should get stats top domains blocked successfully', () async {
@@ -141,7 +142,7 @@ void main() {
     setUp(() {
       creds = FakeSessionCredentialService();
       client = FakePiholeV6ApiClient();
-      repository = MetricsRepositoryV6(client: client, creds: creds);
+      repository = MetricsRepositoryV6(client: client, sessionCache: V6SessionCache(creds: creds, client: client));
     });
 
     test('should get stats top domains allowed successfully', () async {
@@ -161,7 +162,7 @@ void main() {
     setUp(() {
       creds = FakeSessionCredentialService();
       client = FakePiholeV6ApiClient();
-      repository = MetricsRepositoryV6(client: client, creds: creds);
+      repository = MetricsRepositoryV6(client: client, sessionCache: V6SessionCache(creds: creds, client: client));
     });
 
     test('should get stats top clients blocked successfully', () async {
@@ -181,7 +182,7 @@ void main() {
     setUp(() {
       creds = FakeSessionCredentialService();
       client = FakePiholeV6ApiClient();
-      repository = MetricsRepositoryV6(client: client, creds: creds);
+      repository = MetricsRepositoryV6(client: client, sessionCache: V6SessionCache(creds: creds, client: client));
     });
 
     test('should get stats top clients allowed successfully', () async {
@@ -201,7 +202,7 @@ void main() {
     setUp(() {
       creds = FakeSessionCredentialService();
       client = FakePiholeV6ApiClient();
-      repository = MetricsRepositoryV6(client: client, creds: creds);
+      repository = MetricsRepositoryV6(client: client, sessionCache: V6SessionCache(creds: creds, client: client));
     });
 
     test('should get stats over time successfully', () async {

--- a/test/data/repositories/api/v6/network_repository_test.dart
+++ b/test/data/repositories/api/v6/network_repository_test.dart
@@ -1,5 +1,6 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:pi_hole_client/data/repositories/api/v6/network_repository.dart';
+import 'package:pi_hole_client/data/repositories/api/v6/v6_session_cache.dart';
 
 import '../../../../../testing/fakes/services/fake_pihole_v6_api_client.dart';
 import '../../../../../testing/fakes/services/fake_session_credential_service.dart';
@@ -15,7 +16,7 @@ void main() {
     setUp(() {
       creds = FakeSessionCredentialService();
       client = FakePiholeV6ApiClient();
-      repository = NetworkRepositoryV6(client: client, creds: creds);
+      repository = NetworkRepositoryV6(client: client, sessionCache: V6SessionCache(creds: creds, client: client));
     });
 
     test('should get devices successfully', () async {
@@ -35,7 +36,7 @@ void main() {
     setUp(() {
       creds = FakeSessionCredentialService();
       client = FakePiholeV6ApiClient();
-      repository = NetworkRepositoryV6(client: client, creds: creds);
+      repository = NetworkRepositoryV6(client: client, sessionCache: V6SessionCache(creds: creds, client: client));
     });
 
     test('should get devices successfully', () async {
@@ -58,7 +59,7 @@ void main() {
     setUp(() {
       creds = FakeSessionCredentialService();
       client = FakePiholeV6ApiClient();
-      repository = NetworkRepositoryV6(client: client, creds: creds);
+      repository = NetworkRepositoryV6(client: client, sessionCache: V6SessionCache(creds: creds, client: client));
     });
 
     test('should get gateways successfully', () async {

--- a/test/data/repositories/api/v6/realtime_status_repository_test.dart
+++ b/test/data/repositories/api/v6/realtime_status_repository_test.dart
@@ -1,5 +1,6 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:pi_hole_client/data/repositories/api/v6/realtime_status_repository.dart';
+import 'package:pi_hole_client/data/repositories/api/v6/v6_session_cache.dart';
 import 'package:pi_hole_client/data/repositories/utils/constants.dart';
 
 import '../../../../../testing/fakes/services/fake_pihole_v6_api_client.dart';
@@ -15,7 +16,7 @@ void main() {
     setUp(() {
       client = FakePiholeV6ApiClient();
       creds = FakeSessionCredentialService();
-      repository = RealtimeStatusRepositoryV6(client: client, creds: creds);
+      repository = RealtimeStatusRepositoryV6(client: client, sessionCache: V6SessionCache(creds: creds, client: client));
     });
 
     test('fetchRealtimeStatus should return NotSupportedException', () async {

--- a/test/data/repositories/api/v6/v6_session_cache_test.dart
+++ b/test/data/repositories/api/v6/v6_session_cache_test.dart
@@ -1,0 +1,135 @@
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pi_hole_client/data/repositories/api/v6/v6_session_cache.dart';
+import 'package:pi_hole_client/utils/exceptions.dart';
+
+import '../../../../../testing/fakes/services/fake_pihole_v6_api_client.dart';
+import '../../../../../testing/fakes/services/fake_session_credential_service.dart';
+
+void main() {
+  late V6SessionCache cache;
+  late FakeSessionCredentialService creds;
+  late FakePiholeV6ApiClient client;
+
+  setUp(() {
+    creds = FakeSessionCredentialService();
+    client = FakePiholeV6ApiClient();
+    cache = V6SessionCache(creds: creds, client: client);
+  });
+
+  // ---------------------------------------------------------------------------
+  // getSid
+  // ---------------------------------------------------------------------------
+  group('getSid', () {
+    test('loads from storage on cache miss and returns value', () async {
+      final sid = await cache.getSid();
+      expect(sid, 'sid123');
+    });
+
+    test('returns cached value without hitting storage again', () async {
+      await cache.getSid();
+      creds.shouldFailRead = true;
+      final sid = await cache.getSid();
+      expect(sid, 'sid123');
+    });
+
+    test('concurrent calls all return the same value', () async {
+      final concurrentCreds = FakeSessionCredentialService()
+        ..addressSid = 'sid_shared';
+      final concurrentCache = V6SessionCache(
+        creds: concurrentCreds,
+        client: FakePiholeV6ApiClient(),
+      );
+
+      final results = await Future.wait([
+        concurrentCache.getSid(),
+        concurrentCache.getSid(),
+        concurrentCache.getSid(),
+      ]);
+      expect(results, ['sid_shared', 'sid_shared', 'sid_shared']);
+    });
+
+    test('throws SidNotFoundException when storage read fails', () async {
+      creds.shouldFailRead = true;
+      await expectLater(cache.getSid(), throwsA(isA<SidNotFoundException>()));
+    });
+
+    test('allows retry after storage read failure', () async {
+      creds.shouldFailRead = true;
+      await expectLater(cache.getSid(), throwsA(isA<SidNotFoundException>()));
+
+      creds.shouldFailRead = false;
+      final sid = await cache.getSid();
+      expect(sid, 'sid123');
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // saveSid / clearSid
+  // ---------------------------------------------------------------------------
+  group('saveSid and clearSid', () {
+    test('saveSid primes cache so next getSid skips storage', () async {
+      await cache.saveSid('sid_new');
+      creds.shouldFailRead = true;
+      final sid = await cache.getSid();
+      expect(sid, 'sid_new');
+    });
+
+    test('clearSid forces next getSid to reload from storage', () async {
+      await cache.getSid();
+      cache.clearSid();
+      creds.addressSid = 'sid_reloaded';
+      final sid = await cache.getSid();
+      expect(sid, 'sid_reloaded');
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // clearAndRenewSid
+  // ---------------------------------------------------------------------------
+  group('clearAndRenewSid', () {
+    test('calls postAuth once and clears cache beforehand', () async {
+      await cache.getSid();
+      await cache.clearAndRenewSid();
+
+      expect(client.postAuthCallCount, 1);
+      // After renewal, new SID from kSrvPostAuth is cached.
+      creds.shouldFailRead = true;
+      final sid = await cache.getSid();
+      expect(sid, 'n9n9f6c3umrumfq2ese1lvu2pg');
+    });
+
+    test('concurrent calls invoke postAuth exactly once', () async {
+      client.authPauseCompleter = Completer<void>();
+
+      final f1 = cache.clearAndRenewSid();
+      final f2 = cache.clearAndRenewSid();
+      final f3 = cache.clearAndRenewSid();
+
+      client.authPauseCompleter!.complete();
+      await Future.wait([f1, f2, f3]);
+
+      expect(client.postAuthCallCount, 1);
+    });
+
+    test('second clearAndRenewSid after first completes calls postAuth again',
+        () async {
+      await cache.clearAndRenewSid();
+      await cache.clearAndRenewSid();
+
+      expect(client.postAuthCallCount, 2);
+    });
+
+    test('cache stays cleared after postAuth fails', () async {
+      client.shouldFail = true;
+      await cache.getSid();
+      await cache.clearAndRenewSid();
+
+      client.shouldFail = false;
+      creds.addressSid = 'sid_after_failure';
+      final sid = await cache.getSid();
+      expect(sid, 'sid_after_failure');
+    });
+  });
+}

--- a/test/data/repositories/api/v6/v6_session_cache_test.dart
+++ b/test/data/repositories/api/v6/v6_session_cache_test.dart
@@ -131,5 +131,17 @@ void main() {
       final sid = await cache.getSid();
       expect(sid, 'sid_after_failure');
     });
+
+    test('does not call postAuth and clears cache when password is empty',
+        () async {
+      creds.addressPassword = '';
+      await cache.getSid();
+      await cache.clearAndRenewSid();
+
+      expect(client.postAuthCallCount, 0);
+      creds.addressSid = 'sid_after_empty_password';
+      final sid = await cache.getSid();
+      expect(sid, 'sid_after_empty_password');
+    });
   });
 }

--- a/testing/fakes/services/fake_pihole_v6_api_client.dart
+++ b/testing/fakes/services/fake_pihole_v6_api_client.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:pi_hole_client/data/model/v6/action/action.dart' show Action;
 import 'package:pi_hole_client/data/model/v6/auth/auth.dart' show Session;
 import 'package:pi_hole_client/data/model/v6/auth/sessions.dart'
@@ -58,6 +60,8 @@ class FakePiholeV6ApiClient implements PiholeV6ApiClient {
   bool shouldFail = false;
   bool shouldFlushNetworkReturn404 = false;
   bool shouldPostDnsBlockingReturnEnabled = false;
+  int postAuthCallCount = 0;
+  Completer<void>? authPauseCompleter;
   bool shouldGetInfoVersionWithDocker = false;
   bool shouldGetInfoSystemOld = false;
   bool shouldGetInfoFtlV63 = false;
@@ -70,6 +74,8 @@ class FakePiholeV6ApiClient implements PiholeV6ApiClient {
   // ==========================================================================
   @override
   Future<Result<Session>> postAuth({required String password}) async {
+    postAuthCallCount++;
+    if (authPauseCompleter != null) await authPauseCompleter!.future;
     if (shouldFail) {
       return Failure(Exception('Forced postAuth failure'));
     }

--- a/testing/fakes/services/fake_session_credential_service.dart
+++ b/testing/fakes/services/fake_session_credential_service.dart
@@ -85,9 +85,4 @@ class FakeSessionCredentialService implements SessionCredentialService {
     return Success.unit();
   }
 
-  @override
-  void setRenewCallback(Future<void> Function() callback) {}
-
-  @override
-  Future<void> renewSession() async {}
 }


### PR DESCRIPTION
## Overview
v6 session management was scattered across each repository and lacked shared state, causing two independent POST /auth requests when launching the app from a home screen widget after a session deletion. This PR introduces a shared `V6SessionCache` per server, moves session renewal logic out of the UI layer, and eliminates the double-session race on widget cold start.

## Changes
- Add `V6SessionCache`: a per-server session manager shared across all v6 repositories that deduplicates concurrent `getSid` reads and `clearAndRenewSid` renewals via in-flight Future sharing.
- Simplify `BaseV6SidRepository` to delegate all SID management to the injected `V6SessionCache`; update `RepositoryBundleFactory` to create one cache instance per server and inject it into all 14 v6 repositories.
- Remove the in-memory SID cache from `SessionCredentialService` (responsibility moved to `V6SessionCache`) and consolidate session renewal logs to fire exactly once per renewal.
- Move the `openServer` widget channel handler from `setupWidgetChannel()` in `main.dart` into `Base.initState`, so both the widget-tap and normal startup paths share the same `RepositoryBundle` and `V6SessionCache`, preventing a second `POST /auth` on home widget cold start.
- Remove the manual re-auth fallback in the UI shell (`_fetchAndUpdateStatus`) — session renewal is now handled transparently inside repositories via `runWithResultRetry` + `clearAndRenewSid`.
