### PR TITLE
fix(sessions): prevent duplicate Pi-hole sessions on server switch

### DIFF
--- a/lib/data/repositories/api/interfaces/dns_repository.dart
+++ b/lib/data/repositories/api/interfaces/dns_repository.dart
@@ -3,7 +3,12 @@ import 'package:result_dart/result_dart.dart';
 
 abstract interface class DnsRepository {
   /// Fetches the current DNS blocking status.
-  Future<Result<Blocking>> fetchBlockingStatus();
+  ///
+  /// When [skipRenewal] is true, the call retries on transient failures but
+  /// never triggers a session renewal via `clearAndRenewSid`. Use this after
+  /// `createSession` to verify the connection without risking a duplicate
+  /// session being created on a transient error.
+  Future<Result<Blocking>> fetchBlockingStatus({bool skipRenewal = false});
 
   /// Enables DNS blocking.
   Future<Result<Blocking>> enableBlocking();

--- a/lib/data/repositories/api/v5/dns_repository.dart
+++ b/lib/data/repositories/api/v5/dns_repository.dart
@@ -16,7 +16,9 @@ class DnsRepositoryV5 extends BaseV5TokenRepository implements DnsRepository {
   final PiholeV5ApiClient _client;
 
   @override
-  Future<Result<Blocking>> fetchBlockingStatus() async {
+  Future<Result<Blocking>> fetchBlockingStatus({
+    bool skipRenewal = false,
+  }) async {
     final token = await getToken();
     final result = await _client.getSummaryRaw(token);
     return result.map(

--- a/lib/data/repositories/api/v6/dns_repository.dart
+++ b/lib/data/repositories/api/v6/dns_repository.dart
@@ -15,14 +15,16 @@ class DnsRepositoryV6 extends BaseV6SidRepository implements DnsRepository {
   final PiholeV6ApiClient _client;
 
   @override
-  Future<Result<Blocking>> fetchBlockingStatus() async {
+  Future<Result<Blocking>> fetchBlockingStatus({
+    bool skipRenewal = false,
+  }) async {
     return runWithResultRetry<Blocking>(
       action: () async {
         final sid = await getSid();
         final result = await _client.getDnsBlocking(sid);
         return result.map((e) => e.toDomain());
       },
-      onRetry: (_) => clearAndRenewSid(),
+      onRetry: skipRenewal ? null : (_) => clearAndRenewSid(),
     );
   }
 

--- a/lib/ui/core/services/server_connection_service.dart
+++ b/lib/ui/core/services/server_connection_service.dart
@@ -165,7 +165,7 @@ class ServerConnectionService {
 
     final bundle = createBundle(server: serverForLogin);
     // Track whether createSession was called so the post-auth probe can be
-    // made with once: true, preventing a duplicate session from being created
+    // made with skipRenewal: true, preventing a duplicate session from being created
     // by clearAndRenewSid if a transient error occurs right after login.
     var sessionJustCreated = false;
     if (serverForLogin.apiVersion == SupportedApiVersions.v6) {

--- a/lib/ui/core/services/server_connection_service.dart
+++ b/lib/ui/core/services/server_connection_service.dart
@@ -77,6 +77,15 @@ class ServerConnectionService {
   final bool showModal;
 
   Future<void> connect() async {
+    // Prevent a second concurrent connection attempt to the same server.
+    // Two callers (e.g. home screen + server list) can both trigger connect()
+    // for the same server at nearly the same time. Without this guard both
+    // would pass the connectingServer != server checks below and each call
+    // createSession(), creating duplicate Pi-hole sessions.
+    if (serversViewModel.connectingServer == server) {
+      return;
+    }
+
     final previouslySelectedServer = serversViewModel.selectedServer;
 
     _startConnection();
@@ -155,6 +164,10 @@ class ServerConnectionService {
     }
 
     final bundle = createBundle(server: serverForLogin);
+    // Track whether createSession was called so the post-auth probe can be
+    // made with once: true, preventing a duplicate session from being created
+    // by clearAndRenewSid if a transient error occurs right after login.
+    var sessionJustCreated = false;
     if (serverForLogin.apiVersion == SupportedApiVersions.v6) {
       final creds = await serversViewModel.fetchCredentials(
         serverForLogin.address,
@@ -162,7 +175,12 @@ class ServerConnectionService {
       final pw = creds.getOrNull()?.password ?? '';
       if (pw.isNotEmpty) {
         // Try existing session first to avoid creating unnecessary sessions.
-        final preCheck = await bundle.dns.fetchBlockingStatus();
+        // Use skipRenewal: true so that no session renewal happens inside the
+        // probe — if the existing session is expired, createSession below is
+        // the sole place that creates a new session, preventing duplicates.
+        final preCheck = await bundle.dns.fetchBlockingStatus(
+          skipRenewal: true,
+        );
         if (preCheck.isSuccess()) {
           process?.close();
           return preCheck;
@@ -175,9 +193,15 @@ class ServerConnectionService {
             authResult.exceptionOrNull() ?? Exception('Auth failed'),
           );
         }
+        sessionJustCreated = true;
       }
     }
-    final result = await bundle.dns.fetchBlockingStatus();
+    // Use skipRenewal: true when a session was just created above to prevent
+    // clearAndRenewSid from creating a second session on transient errors.
+    // Transient errors (e.g. network timeout) are still retried.
+    final result = await bundle.dns.fetchBlockingStatus(
+      skipRenewal: sessionJustCreated,
+    );
     process?.close();
     return result;
   }

--- a/lib/ui/servers/widgets/add_server_fullscreen.dart
+++ b/lib/ui/servers/widgets/add_server_fullscreen.dart
@@ -493,7 +493,10 @@ class _AddServerFullscreenState extends State<AddServerFullscreen> {
             return;
           }
         }
-        final result = await bundle.dns.fetchBlockingStatus();
+        // Use skipRenewal: true because the session was just created above.
+        // Retrying with clearAndRenewSid would create a duplicate session.
+        // Transient errors (e.g. network timeout) are still retried.
+        final result = await bundle.dns.fetchBlockingStatus(skipRenewal: true);
         if (!context.mounted) return;
         if (result.isSuccess()) {
           await Navigator.maybePop(context);
@@ -609,7 +612,10 @@ class _AddServerFullscreenState extends State<AddServerFullscreen> {
           return;
         }
       }
-      final result = await bundle.dns.fetchBlockingStatus();
+      // Use skipRenewal: true because the session was just created above.
+      // Retrying with clearAndRenewSid would create a duplicate session.
+      // Transient errors (e.g. network timeout) are still retried.
+      final result = await bundle.dns.fetchBlockingStatus(skipRenewal: true);
 
       if (result.isSuccess()) {
         final server = serverObj.copyWith(defaultServer: defaultCheckbox);

--- a/testing/fakes/repositories/api/fake_dns_repository.dart
+++ b/testing/fakes/repositories/api/fake_dns_repository.dart
@@ -11,7 +11,9 @@ class FakeDnsRepository implements DnsRepository {
   Exception? failureException;
 
   @override
-  Future<Result<Blocking>> fetchBlockingStatus() async {
+  Future<Result<Blocking>> fetchBlockingStatus({
+    bool skipRenewal = false,
+  }) async {
     if (shouldFail) {
       return Failure(
         failureException ?? Exception('Force fetchBlockingStatus failure'),


### PR DESCRIPTION
## Overview
Switching servers could occasionally create two sessions on the Pi-hole v6 server. This happened when two UI surfaces (home screen server switcher and server management screen) triggered a connection to the same server nearly simultaneously, or when a transient network error occurred immediately after a successful `createSession` call.

## Changes
- Added an early-return guard in `ServerConnectionService.connect()` to reject a second concurrent connection attempt to the same server — the existing `connectingServer` checks were designed for A→B→C interruption, not concurrent A→B + A→B duplication
- Added `skipRenewal` parameter to `fetchBlockingStatus` (interface + v5/v6 implementations) so callers can opt out of `clearAndRenewSid` when a session was just created, preventing a transient retry from spawning a second session
- Applied `skipRenewal: true` in `ServerConnectionService._runLoginQuery` post-auth probe and in `AddServerFullscreen` connection verification, both of which run immediately after `createSession`
