### PR TITLE
fix(sessions): prevent duplicate Pi-hole sessions on HTTPS connections

### DIFF
--- a/lib/data/repositories/api/v6/auth_repository.dart
+++ b/lib/data/repositories/api/v6/auth_repository.dart
@@ -18,6 +18,8 @@ class AuthRepositoryV6 extends BaseV6SidRepository implements AuthRepository {
   @override
   Future<Result<Auth>> createSession(String password) async {
     return runWithResultRetry<Auth>(
+      // POST /api/auth is non-idempotent - retrying creates duplicate sessions
+      maxRetries: 0,
       action: () async {
         final result = await _client.postAuth(password: password);
         final auth = result.map((e) => e.toDomain());
@@ -31,7 +33,6 @@ class AuthRepositoryV6 extends BaseV6SidRepository implements AuthRepository {
         }
         return auth;
       },
-      onRetry: (_) => clearSid(),
     );
   }
 

--- a/lib/data/repositories/api/v6/v6_session_cache.dart
+++ b/lib/data/repositories/api/v6/v6_session_cache.dart
@@ -96,14 +96,18 @@ class V6SessionCache {
 
   Future<void> _renew() async {
     final pw = (await _creds.password).getOrNull() ?? '';
-    if (pw.isEmpty) throw Exception('Cannot renew session: no password configured');
+    if (pw.isEmpty) {
+      throw Exception('Cannot renew session: no password configured');
+    }
     // Purge the stale SID from storage before POST /api/auth.
     // If postAuth succeeds, saveSid() restores it.
     // If postAuth fails (e.g. HTTPS response lost after Pi-hole creates the session),
     // storage stays empty → next getSid() throws SidNotFoundException → no retry loop.
     final deleteResult = await _creds.deleteSid();
     if (deleteResult.isError()) {
-      logger.w('[V6SessionCache] Failed to purge stale SID: ${deleteResult.exceptionOrNull()}');
+      logger.w(
+        '[V6SessionCache] Failed to purge stale SID: ${deleteResult.exceptionOrNull()}',
+      );
     }
     final result = await _client.postAuth(password: pw);
     final auth = result.getOrThrow().toDomain();

--- a/lib/data/repositories/api/v6/v6_session_cache.dart
+++ b/lib/data/repositories/api/v6/v6_session_cache.dart
@@ -97,6 +97,11 @@ class V6SessionCache {
   Future<void> _renew() async {
     final pw = (await _creds.password).getOrNull() ?? '';
     if (pw.isEmpty) throw Exception('Cannot renew session: no password configured');
+    // Purge the stale SID from storage before POST /api/auth.
+    // If postAuth succeeds, saveSid() restores it.
+    // If postAuth fails (e.g. HTTPS response lost after Pi-hole creates the session),
+    // storage stays empty → next getSid() throws SidNotFoundException → no retry loop.
+    await _creds.deleteSid();
     final result = await _client.postAuth(password: pw);
     final auth = result.getOrThrow().toDomain();
     if (!auth.valid) throw Exception('Session renewal failed');

--- a/lib/data/repositories/api/v6/v6_session_cache.dart
+++ b/lib/data/repositories/api/v6/v6_session_cache.dart
@@ -101,7 +101,10 @@ class V6SessionCache {
     // If postAuth succeeds, saveSid() restores it.
     // If postAuth fails (e.g. HTTPS response lost after Pi-hole creates the session),
     // storage stays empty → next getSid() throws SidNotFoundException → no retry loop.
-    await _creds.deleteSid();
+    final deleteResult = await _creds.deleteSid();
+    if (deleteResult.isError()) {
+      logger.w('[V6SessionCache] Failed to purge stale SID: ${deleteResult.exceptionOrNull()}');
+    }
     final result = await _client.postAuth(password: pw);
     final auth = result.getOrThrow().toDomain();
     if (!auth.valid) throw Exception('Session renewal failed');

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -170,7 +170,6 @@ Future<void> initializeSentry(AppConfigViewModel configProvider) async {
   }
 }
 
-
 void main() async {
   // 1. System init
   await initializeFlutter();

--- a/test/data/repositories/api/v6/actions_respository_test.dart
+++ b/test/data/repositories/api/v6/actions_respository_test.dart
@@ -17,7 +17,10 @@ void main() {
     setUp(() {
       creds = FakeSessionCredentialService();
       client = FakePiholeV6ApiClient();
-      repository = ActionsRepositoryV6(client: client, sessionCache: V6SessionCache(creds: creds, client: client));
+      repository = ActionsRepositoryV6(
+        client: client,
+        sessionCache: V6SessionCache(creds: creds, client: client),
+      );
     });
 
     test('should flush ARP successfully', () async {
@@ -47,7 +50,10 @@ void main() {
     setUp(() {
       creds = FakeSessionCredentialService();
       client = FakePiholeV6ApiClient();
-      repository = ActionsRepositoryV6(client: client, sessionCache: V6SessionCache(creds: creds, client: client));
+      repository = ActionsRepositoryV6(
+        client: client,
+        sessionCache: V6SessionCache(creds: creds, client: client),
+      );
     });
 
     test('should flush logs successfully', () async {
@@ -70,7 +76,10 @@ void main() {
     setUp(() {
       creds = FakeSessionCredentialService();
       client = FakePiholeV6ApiClient();
-      repository = ActionsRepositoryV6(client: client, sessionCache: V6SessionCache(creds: creds, client: client));
+      repository = ActionsRepositoryV6(
+        client: client,
+        sessionCache: V6SessionCache(creds: creds, client: client),
+      );
     });
 
     test('should update gravity successfully', () async {
@@ -104,7 +113,10 @@ void main() {
     setUp(() {
       creds = FakeSessionCredentialService();
       client = FakePiholeV6ApiClient();
-      repository = ActionsRepositoryV6(client: client, sessionCache: V6SessionCache(creds: creds, client: client));
+      repository = ActionsRepositoryV6(
+        client: client,
+        sessionCache: V6SessionCache(creds: creds, client: client),
+      );
     });
 
     test('should restart DNS successfully', () async {

--- a/test/data/repositories/api/v6/adlist_respository_test.dart
+++ b/test/data/repositories/api/v6/adlist_respository_test.dart
@@ -17,7 +17,10 @@ void main() {
     setUp(() {
       creds = FakeSessionCredentialService();
       client = FakePiholeV6ApiClient();
-      repository = AdlistRepositoryV6(client: client, sessionCache: V6SessionCache(creds: creds, client: client));
+      repository = AdlistRepositoryV6(
+        client: client,
+        sessionCache: V6SessionCache(creds: creds, client: client),
+      );
     });
 
     test('should get adlists successfully', () async {
@@ -37,7 +40,10 @@ void main() {
     setUp(() {
       creds = FakeSessionCredentialService();
       client = FakePiholeV6ApiClient();
-      repository = AdlistRepositoryV6(client: client, sessionCache: V6SessionCache(creds: creds, client: client));
+      repository = AdlistRepositoryV6(
+        client: client,
+        sessionCache: V6SessionCache(creds: creds, client: client),
+      );
     });
 
     test('should add adlist successfully', () async {
@@ -63,7 +69,10 @@ void main() {
     setUp(() {
       creds = FakeSessionCredentialService();
       client = FakePiholeV6ApiClient();
-      repository = AdlistRepositoryV6(client: client, sessionCache: V6SessionCache(creds: creds, client: client));
+      repository = AdlistRepositoryV6(
+        client: client,
+        sessionCache: V6SessionCache(creds: creds, client: client),
+      );
     });
 
     test('should remove adlist successfully', () async {
@@ -89,7 +98,10 @@ void main() {
     setUp(() {
       creds = FakeSessionCredentialService();
       client = FakePiholeV6ApiClient();
-      repository = AdlistRepositoryV6(client: client, sessionCache: V6SessionCache(creds: creds, client: client));
+      repository = AdlistRepositoryV6(
+        client: client,
+        sessionCache: V6SessionCache(creds: creds, client: client),
+      );
     });
 
     test('should remove adlist successfully', () async {

--- a/test/data/repositories/api/v6/auth_repository_test.dart
+++ b/test/data/repositories/api/v6/auth_repository_test.dart
@@ -15,7 +15,10 @@ void main() {
   setUp(() {
     client = FakePiholeV6ApiClient();
     creds = FakeSessionCredentialService();
-    repository = AuthRepositoryV6(client: client, sessionCache: V6SessionCache(creds: creds, client: client));
+    repository = AuthRepositoryV6(
+      client: client,
+      sessionCache: V6SessionCache(creds: creds, client: client),
+    );
   });
 
   group('createSession', () {

--- a/test/data/repositories/api/v6/client_repository_test.dart
+++ b/test/data/repositories/api/v6/client_repository_test.dart
@@ -15,7 +15,10 @@ void main() {
   setUp(() {
     creds = FakeSessionCredentialService();
     client = FakePiholeV6ApiClient();
-    repository = ClientRepositoryV6(client: client, sessionCache: V6SessionCache(creds: creds, client: client));
+    repository = ClientRepositoryV6(
+      client: client,
+      sessionCache: V6SessionCache(creds: creds, client: client),
+    );
   });
 
   group('fetchClients', () {

--- a/test/data/repositories/api/v6/config_repository_test.dart
+++ b/test/data/repositories/api/v6/config_repository_test.dart
@@ -16,7 +16,10 @@ void main() {
     setUp(() {
       client = FakePiholeV6ApiClient();
       creds = FakeSessionCredentialService();
-      repository = ConfigRepositoryV6(client: client, sessionCache: V6SessionCache(creds: creds, client: client));
+      repository = ConfigRepositoryV6(
+        client: client,
+        sessionCache: V6SessionCache(creds: creds, client: client),
+      );
     });
 
     test('should fetch DNS query logging successfully', () async {
@@ -36,7 +39,10 @@ void main() {
     setUp(() {
       client = FakePiholeV6ApiClient();
       creds = FakeSessionCredentialService();
-      repository = ConfigRepositoryV6(client: client, sessionCache: V6SessionCache(creds: creds, client: client));
+      repository = ConfigRepositoryV6(
+        client: client,
+        sessionCache: V6SessionCache(creds: creds, client: client),
+      );
     });
 
     test('should fetch DNS query logging successfully', () async {

--- a/test/data/repositories/api/v6/dhcp_repository_test.dart
+++ b/test/data/repositories/api/v6/dhcp_repository_test.dart
@@ -16,7 +16,10 @@ void main() {
     setUp(() {
       client = FakePiholeV6ApiClient();
       creds = FakeSessionCredentialService();
-      repository = DhcpRepositoryV6(client: client, sessionCache: V6SessionCache(creds: creds, client: client));
+      repository = DhcpRepositoryV6(
+        client: client,
+        sessionCache: V6SessionCache(creds: creds, client: client),
+      );
     });
 
     test('should fetch DHCP leases successfully', () async {
@@ -36,7 +39,10 @@ void main() {
     setUp(() {
       client = FakePiholeV6ApiClient();
       creds = FakeSessionCredentialService();
-      repository = DhcpRepositoryV6(client: client, sessionCache: V6SessionCache(creds: creds, client: client));
+      repository = DhcpRepositoryV6(
+        client: client,
+        sessionCache: V6SessionCache(creds: creds, client: client),
+      );
     });
 
     test('should fetch DHCP lease successfully', () async {

--- a/test/data/repositories/api/v6/dns_repository_test.dart
+++ b/test/data/repositories/api/v6/dns_repository_test.dart
@@ -16,7 +16,10 @@ void main() {
     setUp(() {
       client = FakePiholeV6ApiClient();
       creds = FakeSessionCredentialService();
-      repository = DnsRepositoryV6(client: client, sessionCache: V6SessionCache(creds: creds, client: client));
+      repository = DnsRepositoryV6(
+        client: client,
+        sessionCache: V6SessionCache(creds: creds, client: client),
+      );
     });
 
     test('should fetch DNS blocking status successfully', () async {
@@ -36,7 +39,10 @@ void main() {
     setUp(() {
       client = FakePiholeV6ApiClient();
       creds = FakeSessionCredentialService();
-      repository = DnsRepositoryV6(client: client, sessionCache: V6SessionCache(creds: creds, client: client));
+      repository = DnsRepositoryV6(
+        client: client,
+        sessionCache: V6SessionCache(creds: creds, client: client),
+      );
     });
 
     test('should enable DNS blocking successfully', () async {
@@ -57,7 +63,10 @@ void main() {
     setUp(() {
       client = FakePiholeV6ApiClient();
       creds = FakeSessionCredentialService();
-      repository = DnsRepositoryV6(client: client, sessionCache: V6SessionCache(creds: creds, client: client));
+      repository = DnsRepositoryV6(
+        client: client,
+        sessionCache: V6SessionCache(creds: creds, client: client),
+      );
     });
 
     test('should disable DNS blocking successfully', () async {

--- a/test/data/repositories/api/v6/domain_repository_test.dart
+++ b/test/data/repositories/api/v6/domain_repository_test.dart
@@ -17,7 +17,10 @@ void main() {
     setUp(() {
       client = FakePiholeV6ApiClient();
       creds = FakeSessionCredentialService();
-      repository = DomainRepositoryV6(client: client, sessionCache: V6SessionCache(creds: creds, client: client));
+      repository = DomainRepositoryV6(
+        client: client,
+        sessionCache: V6SessionCache(creds: creds, client: client),
+      );
     });
 
     test('should fetch all domains successfully', () async {
@@ -37,7 +40,10 @@ void main() {
     setUp(() {
       client = FakePiholeV6ApiClient();
       creds = FakeSessionCredentialService();
-      repository = DomainRepositoryV6(client: client, sessionCache: V6SessionCache(creds: creds, client: client));
+      repository = DomainRepositoryV6(
+        client: client,
+        sessionCache: V6SessionCache(creds: creds, client: client),
+      );
     });
 
     test('should add domain successfully', () async {
@@ -65,7 +71,10 @@ void main() {
     setUp(() {
       client = FakePiholeV6ApiClient();
       creds = FakeSessionCredentialService();
-      repository = DomainRepositoryV6(client: client, sessionCache: V6SessionCache(creds: creds, client: client));
+      repository = DomainRepositoryV6(
+        client: client,
+        sessionCache: V6SessionCache(creds: creds, client: client),
+      );
     });
 
     test('should update domain successfully', () async {
@@ -99,7 +108,10 @@ void main() {
     setUp(() {
       client = FakePiholeV6ApiClient();
       creds = FakeSessionCredentialService();
-      repository = DomainRepositoryV6(client: client, sessionCache: V6SessionCache(creds: creds, client: client));
+      repository = DomainRepositoryV6(
+        client: client,
+        sessionCache: V6SessionCache(creds: creds, client: client),
+      );
     });
 
     test('should delete domain successfully', () async {

--- a/test/data/repositories/api/v6/ftl_repository_test.dart
+++ b/test/data/repositories/api/v6/ftl_repository_test.dart
@@ -16,7 +16,10 @@ void main() {
     setUp(() {
       client = FakePiholeV6ApiClient();
       creds = FakeSessionCredentialService();
-      repository = FtlRepositoryV6(client: client, sessionCache: V6SessionCache(creds: creds, client: client));
+      repository = FtlRepositoryV6(
+        client: client,
+        sessionCache: V6SessionCache(creds: creds, client: client),
+      );
     });
 
     test('should fetch info client successfully', () async {
@@ -36,7 +39,10 @@ void main() {
     setUp(() {
       client = FakePiholeV6ApiClient();
       creds = FakeSessionCredentialService();
-      repository = FtlRepositoryV6(client: client, sessionCache: V6SessionCache(creds: creds, client: client));
+      repository = FtlRepositoryV6(
+        client: client,
+        sessionCache: V6SessionCache(creds: creds, client: client),
+      );
     });
 
     test('should fetch info ftl successfully', () async {
@@ -62,7 +68,10 @@ void main() {
     setUp(() {
       client = FakePiholeV6ApiClient();
       creds = FakeSessionCredentialService();
-      repository = FtlRepositoryV6(client: client, sessionCache: V6SessionCache(creds: creds, client: client));
+      repository = FtlRepositoryV6(
+        client: client,
+        sessionCache: V6SessionCache(creds: creds, client: client),
+      );
     });
 
     test('should fetch info host successfully', () async {
@@ -82,7 +91,10 @@ void main() {
     setUp(() {
       client = FakePiholeV6ApiClient();
       creds = FakeSessionCredentialService();
-      repository = FtlRepositoryV6(client: client, sessionCache: V6SessionCache(creds: creds, client: client));
+      repository = FtlRepositoryV6(
+        client: client,
+        sessionCache: V6SessionCache(creds: creds, client: client),
+      );
     });
 
     test('should fetch gravity messages successfully', () async {
@@ -102,7 +114,10 @@ void main() {
     setUp(() {
       client = FakePiholeV6ApiClient();
       creds = FakeSessionCredentialService();
-      repository = FtlRepositoryV6(client: client, sessionCache: V6SessionCache(creds: creds, client: client));
+      repository = FtlRepositoryV6(
+        client: client,
+        sessionCache: V6SessionCache(creds: creds, client: client),
+      );
     });
 
     test('should delete info message successfully', () async {
@@ -122,7 +137,10 @@ void main() {
     setUp(() {
       client = FakePiholeV6ApiClient();
       creds = FakeSessionCredentialService();
-      repository = FtlRepositoryV6(client: client, sessionCache: V6SessionCache(creds: creds, client: client));
+      repository = FtlRepositoryV6(
+        client: client,
+        sessionCache: V6SessionCache(creds: creds, client: client),
+      );
     });
 
     test('should fetch info metrics successfully', () async {
@@ -142,7 +160,10 @@ void main() {
     setUp(() {
       client = FakePiholeV6ApiClient();
       creds = FakeSessionCredentialService();
-      repository = FtlRepositoryV6(client: client, sessionCache: V6SessionCache(creds: creds, client: client));
+      repository = FtlRepositoryV6(
+        client: client,
+        sessionCache: V6SessionCache(creds: creds, client: client),
+      );
     });
 
     test('should fetch all sensors successfully', () async {
@@ -162,7 +183,10 @@ void main() {
     setUp(() {
       client = FakePiholeV6ApiClient();
       creds = FakeSessionCredentialService();
-      repository = FtlRepositoryV6(client: client, sessionCache: V6SessionCache(creds: creds, client: client));
+      repository = FtlRepositoryV6(
+        client: client,
+        sessionCache: V6SessionCache(creds: creds, client: client),
+      );
     });
 
     test('should fetch info system successfully', () async {
@@ -188,7 +212,10 @@ void main() {
     setUp(() {
       client = FakePiholeV6ApiClient();
       creds = FakeSessionCredentialService();
-      repository = FtlRepositoryV6(client: client, sessionCache: V6SessionCache(creds: creds, client: client));
+      repository = FtlRepositoryV6(
+        client: client,
+        sessionCache: V6SessionCache(creds: creds, client: client),
+      );
     });
 
     test('should fetch info version successfully', () async {
@@ -214,7 +241,10 @@ void main() {
     setUp(() {
       client = FakePiholeV6ApiClient();
       creds = FakeSessionCredentialService();
-      repository = FtlRepositoryV6(client: client, sessionCache: V6SessionCache(creds: creds, client: client));
+      repository = FtlRepositoryV6(
+        client: client,
+        sessionCache: V6SessionCache(creds: creds, client: client),
+      );
     });
 
     test('should fetch all server info successfully', () async {

--- a/test/data/repositories/api/v6/group_repository_test.dart
+++ b/test/data/repositories/api/v6/group_repository_test.dart
@@ -15,7 +15,10 @@ void main() {
   setUp(() {
     creds = FakeSessionCredentialService();
     client = FakePiholeV6ApiClient();
-    repository = GroupRepositoryV6(client: client, sessionCache: V6SessionCache(creds: creds, client: client));
+    repository = GroupRepositoryV6(
+      client: client,
+      sessionCache: V6SessionCache(creds: creds, client: client),
+    );
   });
 
   group('fetchGroups', () {

--- a/test/data/repositories/api/v6/local_dns_repository_test.dart
+++ b/test/data/repositories/api/v6/local_dns_repository_test.dart
@@ -16,7 +16,10 @@ void main() {
     setUp(() {
       client = FakePiholeV6ApiClient();
       creds = FakeSessionCredentialService();
-      repository = LocalDnsRepositoryV6(client: client, sessionCache: V6SessionCache(creds: creds, client: client));
+      repository = LocalDnsRepositoryV6(
+        client: client,
+        sessionCache: V6SessionCache(creds: creds, client: client),
+      );
     });
 
     test('should fetch records successfully', () async {
@@ -37,7 +40,10 @@ void main() {
     setUp(() {
       client = FakePiholeV6ApiClient();
       creds = FakeSessionCredentialService();
-      repository = LocalDnsRepositoryV6(client: client, sessionCache: V6SessionCache(creds: creds, client: client));
+      repository = LocalDnsRepositoryV6(
+        client: client,
+        sessionCache: V6SessionCache(creds: creds, client: client),
+      );
     });
 
     test('should add record successfully', () async {
@@ -62,7 +68,10 @@ void main() {
     setUp(() {
       client = FakePiholeV6ApiClient();
       creds = FakeSessionCredentialService();
-      repository = LocalDnsRepositoryV6(client: client, sessionCache: V6SessionCache(creds: creds, client: client));
+      repository = LocalDnsRepositoryV6(
+        client: client,
+        sessionCache: V6SessionCache(creds: creds, client: client),
+      );
     });
 
     test('should delete record successfully', () async {
@@ -90,7 +99,10 @@ void main() {
     setUp(() {
       client = FakePiholeV6ApiClient();
       creds = FakeSessionCredentialService();
-      repository = LocalDnsRepositoryV6(client: client, sessionCache: V6SessionCache(creds: creds, client: client));
+      repository = LocalDnsRepositoryV6(
+        client: client,
+        sessionCache: V6SessionCache(creds: creds, client: client),
+      );
     });
 
     test('should fail when fetching current config fails', () async {

--- a/test/data/repositories/api/v6/metrics_repository_test.dart
+++ b/test/data/repositories/api/v6/metrics_repository_test.dart
@@ -16,7 +16,10 @@ void main() {
     setUp(() {
       creds = FakeSessionCredentialService();
       client = FakePiholeV6ApiClient();
-      repository = MetricsRepositoryV6(client: client, sessionCache: V6SessionCache(creds: creds, client: client));
+      repository = MetricsRepositoryV6(
+        client: client,
+        sessionCache: V6SessionCache(creds: creds, client: client),
+      );
     });
 
     test('should get history successfully', () async {
@@ -36,7 +39,10 @@ void main() {
     setUp(() {
       creds = FakeSessionCredentialService();
       client = FakePiholeV6ApiClient();
-      repository = MetricsRepositoryV6(client: client, sessionCache: V6SessionCache(creds: creds, client: client));
+      repository = MetricsRepositoryV6(
+        client: client,
+        sessionCache: V6SessionCache(creds: creds, client: client),
+      );
     });
 
     test('should get history client successfully', () async {
@@ -56,7 +62,10 @@ void main() {
     setUp(() {
       creds = FakeSessionCredentialService();
       client = FakePiholeV6ApiClient();
-      repository = MetricsRepositoryV6(client: client, sessionCache: V6SessionCache(creds: creds, client: client));
+      repository = MetricsRepositoryV6(
+        client: client,
+        sessionCache: V6SessionCache(creds: creds, client: client),
+      );
     });
 
     test('should get queries successfully', () async {
@@ -82,7 +91,10 @@ void main() {
     setUp(() {
       creds = FakeSessionCredentialService();
       client = FakePiholeV6ApiClient();
-      repository = MetricsRepositoryV6(client: client, sessionCache: V6SessionCache(creds: creds, client: client));
+      repository = MetricsRepositoryV6(
+        client: client,
+        sessionCache: V6SessionCache(creds: creds, client: client),
+      );
     });
 
     test('should get stats summary successfully', () async {
@@ -102,7 +114,10 @@ void main() {
     setUp(() {
       creds = FakeSessionCredentialService();
       client = FakePiholeV6ApiClient();
-      repository = MetricsRepositoryV6(client: client, sessionCache: V6SessionCache(creds: creds, client: client));
+      repository = MetricsRepositoryV6(
+        client: client,
+        sessionCache: V6SessionCache(creds: creds, client: client),
+      );
     });
 
     test('should get stats upstreams successfully', () async {
@@ -122,7 +137,10 @@ void main() {
     setUp(() {
       creds = FakeSessionCredentialService();
       client = FakePiholeV6ApiClient();
-      repository = MetricsRepositoryV6(client: client, sessionCache: V6SessionCache(creds: creds, client: client));
+      repository = MetricsRepositoryV6(
+        client: client,
+        sessionCache: V6SessionCache(creds: creds, client: client),
+      );
     });
 
     test('should get stats top domains blocked successfully', () async {
@@ -142,7 +160,10 @@ void main() {
     setUp(() {
       creds = FakeSessionCredentialService();
       client = FakePiholeV6ApiClient();
-      repository = MetricsRepositoryV6(client: client, sessionCache: V6SessionCache(creds: creds, client: client));
+      repository = MetricsRepositoryV6(
+        client: client,
+        sessionCache: V6SessionCache(creds: creds, client: client),
+      );
     });
 
     test('should get stats top domains allowed successfully', () async {
@@ -162,7 +183,10 @@ void main() {
     setUp(() {
       creds = FakeSessionCredentialService();
       client = FakePiholeV6ApiClient();
-      repository = MetricsRepositoryV6(client: client, sessionCache: V6SessionCache(creds: creds, client: client));
+      repository = MetricsRepositoryV6(
+        client: client,
+        sessionCache: V6SessionCache(creds: creds, client: client),
+      );
     });
 
     test('should get stats top clients blocked successfully', () async {
@@ -182,7 +206,10 @@ void main() {
     setUp(() {
       creds = FakeSessionCredentialService();
       client = FakePiholeV6ApiClient();
-      repository = MetricsRepositoryV6(client: client, sessionCache: V6SessionCache(creds: creds, client: client));
+      repository = MetricsRepositoryV6(
+        client: client,
+        sessionCache: V6SessionCache(creds: creds, client: client),
+      );
     });
 
     test('should get stats top clients allowed successfully', () async {
@@ -202,7 +229,10 @@ void main() {
     setUp(() {
       creds = FakeSessionCredentialService();
       client = FakePiholeV6ApiClient();
-      repository = MetricsRepositoryV6(client: client, sessionCache: V6SessionCache(creds: creds, client: client));
+      repository = MetricsRepositoryV6(
+        client: client,
+        sessionCache: V6SessionCache(creds: creds, client: client),
+      );
     });
 
     test('should get stats over time successfully', () async {

--- a/test/data/repositories/api/v6/network_repository_test.dart
+++ b/test/data/repositories/api/v6/network_repository_test.dart
@@ -16,7 +16,10 @@ void main() {
     setUp(() {
       creds = FakeSessionCredentialService();
       client = FakePiholeV6ApiClient();
-      repository = NetworkRepositoryV6(client: client, sessionCache: V6SessionCache(creds: creds, client: client));
+      repository = NetworkRepositoryV6(
+        client: client,
+        sessionCache: V6SessionCache(creds: creds, client: client),
+      );
     });
 
     test('should get devices successfully', () async {
@@ -36,7 +39,10 @@ void main() {
     setUp(() {
       creds = FakeSessionCredentialService();
       client = FakePiholeV6ApiClient();
-      repository = NetworkRepositoryV6(client: client, sessionCache: V6SessionCache(creds: creds, client: client));
+      repository = NetworkRepositoryV6(
+        client: client,
+        sessionCache: V6SessionCache(creds: creds, client: client),
+      );
     });
 
     test('should get devices successfully', () async {
@@ -59,7 +65,10 @@ void main() {
     setUp(() {
       creds = FakeSessionCredentialService();
       client = FakePiholeV6ApiClient();
-      repository = NetworkRepositoryV6(client: client, sessionCache: V6SessionCache(creds: creds, client: client));
+      repository = NetworkRepositoryV6(
+        client: client,
+        sessionCache: V6SessionCache(creds: creds, client: client),
+      );
     });
 
     test('should get gateways successfully', () async {

--- a/test/data/repositories/api/v6/realtime_status_repository_test.dart
+++ b/test/data/repositories/api/v6/realtime_status_repository_test.dart
@@ -16,7 +16,10 @@ void main() {
     setUp(() {
       client = FakePiholeV6ApiClient();
       creds = FakeSessionCredentialService();
-      repository = RealtimeStatusRepositoryV6(client: client, sessionCache: V6SessionCache(creds: creds, client: client));
+      repository = RealtimeStatusRepositoryV6(
+        client: client,
+        sessionCache: V6SessionCache(creds: creds, client: client),
+      );
     });
 
     test('fetchRealtimeStatus should return NotSupportedException', () async {

--- a/test/data/repositories/api/v6/v6_session_cache_test.dart
+++ b/test/data/repositories/api/v6/v6_session_cache_test.dart
@@ -113,13 +113,15 @@ void main() {
       expect(client.postAuthCallCount, 1);
     });
 
-    test('second clearAndRenewSid after first completes calls postAuth again',
-        () async {
-      await cache.clearAndRenewSid();
-      await cache.clearAndRenewSid();
+    test(
+      'second clearAndRenewSid after first completes calls postAuth again',
+      () async {
+        await cache.clearAndRenewSid();
+        await cache.clearAndRenewSid();
 
-      expect(client.postAuthCallCount, 2);
-    });
+        expect(client.postAuthCallCount, 2);
+      },
+    );
 
     test('cache stays cleared after postAuth fails', () async {
       client.shouldFail = true;
@@ -132,23 +134,27 @@ void main() {
       expect(sid, 'sid_after_failure');
     });
 
-    test('does not call postAuth and clears cache when password is empty',
-        () async {
-      creds.addressPassword = '';
-      await cache.getSid();
-      await cache.clearAndRenewSid();
+    test(
+      'does not call postAuth and clears cache when password is empty',
+      () async {
+        creds.addressPassword = '';
+        await cache.getSid();
+        await cache.clearAndRenewSid();
 
-      expect(client.postAuthCallCount, 0);
-      creds.addressSid = 'sid_after_empty_password';
-      final sid = await cache.getSid();
-      expect(sid, 'sid_after_empty_password');
-    });
+        expect(client.postAuthCallCount, 0);
+        creds.addressSid = 'sid_after_empty_password';
+        final sid = await cache.getSid();
+        expect(sid, 'sid_after_empty_password');
+      },
+    );
 
-    test('deleteSid is called before postAuth to prevent stale-SID loop',
-        () async {
-      await cache.clearAndRenewSid();
-      expect(creds.deleteSidCallCount, 1);
-    });
+    test(
+      'deleteSid is called before postAuth to prevent stale-SID loop',
+      () async {
+        await cache.clearAndRenewSid();
+        expect(creds.deleteSidCallCount, 1);
+      },
+    );
 
     test('deleteSid is called even when postAuth fails', () async {
       client.shouldFail = true;

--- a/test/data/repositories/api/v6/v6_session_cache_test.dart
+++ b/test/data/repositories/api/v6/v6_session_cache_test.dart
@@ -143,5 +143,17 @@ void main() {
       final sid = await cache.getSid();
       expect(sid, 'sid_after_empty_password');
     });
+
+    test('deleteSid is called before postAuth to prevent stale-SID loop',
+        () async {
+      await cache.clearAndRenewSid();
+      expect(creds.deleteSidCallCount, 1);
+    });
+
+    test('deleteSid is called even when postAuth fails', () async {
+      client.shouldFail = true;
+      await cache.clearAndRenewSid();
+      expect(creds.deleteSidCallCount, 1);
+    });
   });
 }

--- a/testing/fakes/services/fake_session_credential_service.dart
+++ b/testing/fakes/services/fake_session_credential_service.dart
@@ -5,6 +5,7 @@ class FakeSessionCredentialService implements SessionCredentialService {
   bool shouldFailSave = false;
   bool shouldFailRead = false;
   bool shouldFailDelete = false;
+  int deleteSidCallCount = 0;
 
   String addressPassword = 'pass123';
   String addressToken = 'token123';
@@ -47,6 +48,7 @@ class FakeSessionCredentialService implements SessionCredentialService {
 
   @override
   Future<Result<void>> deleteSid() async {
+    deleteSidCallCount++;
     if (shouldFailDelete) {
       return Failure(Exception('Forced delete failure'));
     }

--- a/testing/fakes/services/fake_session_credential_service.dart
+++ b/testing/fakes/services/fake_session_credential_service.dart
@@ -86,5 +86,4 @@ class FakeSessionCredentialService implements SessionCredentialService {
     }
     return Success.unit();
   }
-
 }


### PR DESCRIPTION
## Overview
Two session-accumulation bugs affect HTTPS Pi-hole v6 servers but not HTTP. The first creates duplicate sessions when switching servers because `POST /api/auth` was retried on failure (non-idempotent). The second causes sessions to accumulate on every auto-refresh tick after a session is invalidated, because the stale SID remained in storage and kept triggering re-authentication in a loop.

## Changes
- Disable retries for `createSession` (`maxRetries: 0`) since `POST /api/auth` is non-idempotent — a retry after a lost HTTPS response would cause Pi-hole to hold two valid sessions simultaneously
- Purge the stale SID from storage at the start of `_renew()` before calling `POST /api/auth`; if the request fails (e.g. HTTPS TLS response lost), storage stays empty so the next `getSid()` throws `SidNotFoundException` instead of returning the old SID and triggering another renewal loop
- Add tests verifying `deleteSid()` is called during renewal both on success and on failure
