### PR TITLE
fix(sessions): close all Pi-hole v6 session multiplication routes

### DIFF
--- a/lib/data/repositories/api/v5/domain_repository.dart
+++ b/lib/data/repositories/api/v5/domain_repository.dart
@@ -45,7 +45,7 @@ class DomainRepositoryV5 extends BaseV5TokenRepository
 
         return Success(domainLists);
       },
-      onRetry: (_) => clearToken(),
+      onRetry: (_, _) => clearToken(),
     );
   }
 
@@ -89,7 +89,7 @@ class DomainRepositoryV5 extends BaseV5TokenRepository
           ),
         );
       },
-      onRetry: (_) => clearToken(),
+      onRetry: (_, _) => clearToken(),
     );
   }
 
@@ -127,7 +127,7 @@ class DomainRepositoryV5 extends BaseV5TokenRepository
         }
         return Success.unit();
       },
-      onRetry: (_) => clearToken(),
+      onRetry: (_, _) => clearToken(),
     );
   }
 }

--- a/lib/data/repositories/api/v5/ftl_repository.dart
+++ b/lib/data/repositories/api/v5/ftl_repository.dart
@@ -89,7 +89,7 @@ class FtlRepositoryV5 extends BaseV5TokenRepository implements FtlRepository {
         final result = await _client.getVersions(token);
         return result.map((v) => v.toDomain());
       },
-      onRetry: (_) => clearToken(),
+      onRetry: (_, _) => clearToken(),
     );
   }
 
@@ -101,7 +101,7 @@ class FtlRepositoryV5 extends BaseV5TokenRepository implements FtlRepository {
         final result = await _client.getVersions(token);
         return result.map((v) => PiholeServer(version: v.toDomain()));
       },
-      onRetry: (_) => clearToken(),
+      onRetry: (_, _) => clearToken(),
     );
   }
 }

--- a/lib/data/repositories/api/v5/metrics_repository.dart
+++ b/lib/data/repositories/api/v5/metrics_repository.dart
@@ -57,7 +57,7 @@ class MetricsRepositoryV5 extends BaseV5TokenRepository
         );
         return response.map((q) => q.toDomain());
       },
-      onRetry: (_) => clearToken(),
+      onRetry: (_, _) => clearToken(),
     );
   }
 
@@ -119,7 +119,7 @@ class MetricsRepositoryV5 extends BaseV5TokenRepository
         final response = await _client.getOverTimeData(token);
         return response.map((o) => o.toDomain());
       },
-      onRetry: (_) => clearToken(),
+      onRetry: (_, _) => clearToken(),
     );
   }
 }

--- a/lib/data/repositories/api/v5/realtime_status_repository.dart
+++ b/lib/data/repositories/api/v5/realtime_status_repository.dart
@@ -23,7 +23,7 @@ class RealTimeStatusRepositoryV5 extends BaseV5TokenRepository
         final response = await _client.getRealTimeStatus(token);
         return response.map((status) => status.toDomain());
       },
-      onRetry: (_) => clearToken(),
+      onRetry: (_, _) => clearToken(),
     );
   }
 }

--- a/lib/data/repositories/api/v6/actions_respository.dart
+++ b/lib/data/repositories/api/v6/actions_respository.dart
@@ -38,7 +38,7 @@ class ActionsRepositoryV6 extends BaseV6SidRepository
 
         return networkResult.map((_) => unit);
       },
-      onRetry: (_) => clearAndRenewSid(),
+      onRetry: (_, e) => renewSidIfExpired(e),
     );
   }
 
@@ -50,7 +50,7 @@ class ActionsRepositoryV6 extends BaseV6SidRepository
         final result = await _client.postActionFlushLogs(sid);
         return result.map((_) => unit);
       },
-      onRetry: (_) => clearAndRenewSid(),
+      onRetry: (_, e) => renewSidIfExpired(e),
     );
   }
 
@@ -63,7 +63,7 @@ class ActionsRepositoryV6 extends BaseV6SidRepository
       },
       maxRetries: 1,
       delay: const Duration(milliseconds: 10),
-      onRetry: (attempt, error, st) => clearAndRenewSid(),
+      onRetry: (attempt, error, st) => renewSidIfExpired(error),
     );
 
     yield* stream;
@@ -77,7 +77,7 @@ class ActionsRepositoryV6 extends BaseV6SidRepository
         final result = await _client.postActionRestartDns(sid);
         return result.map((_) => unit);
       },
-      onRetry: (_) => clearAndRenewSid(),
+      onRetry: (_, e) => renewSidIfExpired(e),
     );
   }
 }

--- a/lib/data/repositories/api/v6/adlist_repository.dart
+++ b/lib/data/repositories/api/v6/adlist_repository.dart
@@ -29,7 +29,7 @@ class AdlistRepositoryV6 extends BaseV6SidRepository
         final result = await _client.getLists(sid, adlist: adlist, type: type);
         return result.map((e) => e.toDomain());
       },
-      onRetry: (_) => clearAndRenewSid(),
+      onRetry: (_, e) => renewSidIfExpired(e),
     );
   }
 
@@ -54,7 +54,7 @@ class AdlistRepositoryV6 extends BaseV6SidRepository
         );
         return result.map((e) => e.toSingleDomain());
       },
-      onRetry: (_) => clearAndRenewSid(),
+      onRetry: (_, e) => renewSidIfExpired(e),
     );
   }
 
@@ -79,7 +79,7 @@ class AdlistRepositoryV6 extends BaseV6SidRepository
         );
         return result.map((e) => e.toSingleDomain());
       },
-      onRetry: (_) => clearAndRenewSid(),
+      onRetry: (_, e) => renewSidIfExpired(e),
     );
   }
 
@@ -95,7 +95,7 @@ class AdlistRepositoryV6 extends BaseV6SidRepository
         );
         return result.map((_) => unit);
       },
-      onRetry: (_) => clearAndRenewSid(),
+      onRetry: (_, e) => renewSidIfExpired(e),
     );
   }
 
@@ -116,7 +116,7 @@ class AdlistRepositoryV6 extends BaseV6SidRepository
         );
         return result.map((e) => e.toDomain());
       },
-      onRetry: (_) => clearAndRenewSid(),
+      onRetry: (_, e) => renewSidIfExpired(e),
     );
   }
 }

--- a/lib/data/repositories/api/v6/auth_repository.dart
+++ b/lib/data/repositories/api/v6/auth_repository.dart
@@ -44,7 +44,7 @@ class AuthRepositoryV6 extends BaseV6SidRepository implements AuthRepository {
         final result = await _client.deleteAuth(sid);
         return result.map((_) => unit);
       },
-      onRetry: (_) => clearAndRenewSid(),
+      onRetry: (_, e) => renewSidIfExpired(e),
     );
   }
 
@@ -56,7 +56,7 @@ class AuthRepositoryV6 extends BaseV6SidRepository implements AuthRepository {
         final result = await _client.getAuthSessions(sid);
         return result.map((e) => e.toDomain());
       },
-      onRetry: (_) => clearAndRenewSid(),
+      onRetry: (_, e) => renewSidIfExpired(e),
     );
   }
 
@@ -68,7 +68,7 @@ class AuthRepositoryV6 extends BaseV6SidRepository implements AuthRepository {
         final result = await _client.deleteAuthSession(sid, id: id);
         return result.map((_) => unit);
       },
-      onRetry: (_) => clearAndRenewSid(),
+      onRetry: (_, e) => renewSidIfExpired(e),
     );
   }
 }

--- a/lib/data/repositories/api/v6/base_v6_sid_repository.dart
+++ b/lib/data/repositories/api/v6/base_v6_sid_repository.dart
@@ -1,4 +1,5 @@
 import 'package:pi_hole_client/data/repositories/api/v6/v6_session_cache.dart';
+import 'package:pi_hole_client/utils/exceptions.dart';
 
 /// Abstract base class for all v6 repositories.
 ///
@@ -21,4 +22,10 @@ abstract class BaseV6SidRepository {
   Future<void> clearSid() async => _sessionCache.clearSid();
 
   Future<void> clearAndRenewSid() => _sessionCache.clearAndRenewSid();
+
+  Future<void> renewSidIfExpired(Object error) async {
+    if (isReauthRequired(error)) {
+      await clearAndRenewSid();
+    }
+  }
 }

--- a/lib/data/repositories/api/v6/client_repository.dart
+++ b/lib/data/repositories/api/v6/client_repository.dart
@@ -23,7 +23,7 @@ class ClientRepositoryV6 extends BaseV6SidRepository
         final result = await _client.getClients(sid);
         return result.map((e) => e.toDomain());
       },
-      onRetry: (_) => clearAndRenewSid(),
+      onRetry: (_, e) => renewSidIfExpired(e),
     );
   }
 
@@ -44,7 +44,7 @@ class ClientRepositoryV6 extends BaseV6SidRepository
         );
         return result.map((e) => e.toSingleDomain());
       },
-      onRetry: (_) => clearAndRenewSid(),
+      onRetry: (_, e) => renewSidIfExpired(e),
     );
   }
 
@@ -65,7 +65,7 @@ class ClientRepositoryV6 extends BaseV6SidRepository
         );
         return result.map((e) => e.toSingleDomain());
       },
-      onRetry: (_) => clearAndRenewSid(),
+      onRetry: (_, e) => renewSidIfExpired(e),
     );
   }
 
@@ -76,7 +76,7 @@ class ClientRepositoryV6 extends BaseV6SidRepository
         final sid = await getSid();
         return _client.deleteClients(sid, client: client);
       },
-      onRetry: (_) => clearAndRenewSid(),
+      onRetry: (_, e) => renewSidIfExpired(e),
     );
   }
 }

--- a/lib/data/repositories/api/v6/config_repository.dart
+++ b/lib/data/repositories/api/v6/config_repository.dart
@@ -41,7 +41,7 @@ class ConfigRepositoryV6 extends BaseV6SidRepository
         );
         return result.map((e) => e.toDomain());
       },
-      onRetry: (_) => clearAndRenewSid(),
+      onRetry: (_, e) => renewSidIfExpired(e),
     );
   }
 
@@ -53,7 +53,7 @@ class ConfigRepositoryV6 extends BaseV6SidRepository
         final result = await _client.patchConfig(sid, body: configData);
         return result.map((e) => e.toDomain());
       },
-      onRetry: (_) => clearAndRenewSid(),
+      onRetry: (_, e) => renewSidIfExpired(e),
     );
   }
 }

--- a/lib/data/repositories/api/v6/dhcp_repository.dart
+++ b/lib/data/repositories/api/v6/dhcp_repository.dart
@@ -22,7 +22,7 @@ class DhcpRepositoryV6 extends BaseV6SidRepository implements DhcpRepository {
         final result = await _client.getDhcpLeases(sid);
         return result.map((e) => e.toDomain());
       },
-      onRetry: (_) => clearAndRenewSid(),
+      onRetry: (_, e) => renewSidIfExpired(e),
     );
   }
 
@@ -34,7 +34,7 @@ class DhcpRepositoryV6 extends BaseV6SidRepository implements DhcpRepository {
         final result = await _client.deleteDhcpLeases(sid, ip: ip);
         return result.map((_) => unit);
       },
-      onRetry: (_) => clearAndRenewSid(),
+      onRetry: (_, e) => renewSidIfExpired(e),
     );
   }
 }

--- a/lib/data/repositories/api/v6/dns_repository.dart
+++ b/lib/data/repositories/api/v6/dns_repository.dart
@@ -24,7 +24,7 @@ class DnsRepositoryV6 extends BaseV6SidRepository implements DnsRepository {
         final result = await _client.getDnsBlocking(sid);
         return result.map((e) => e.toDomain());
       },
-      onRetry: skipRenewal ? null : (_) => clearAndRenewSid(),
+      onRetry: skipRenewal ? null : (_, e) => renewSidIfExpired(e),
     );
   }
 
@@ -53,7 +53,7 @@ class DnsRepositoryV6 extends BaseV6SidRepository implements DnsRepository {
         );
         return result.map((e) => e.toDomain());
       },
-      onRetry: (_) => clearAndRenewSid(),
+      onRetry: (_, e) => renewSidIfExpired(e),
     );
   }
 }

--- a/lib/data/repositories/api/v6/domain_repository.dart
+++ b/lib/data/repositories/api/v6/domain_repository.dart
@@ -24,7 +24,7 @@ class DomainRepositoryV6 extends BaseV6SidRepository
         final result = await _client.getDomains(sid);
         return result.map((e) => e.toDomainLists());
       },
-      onRetry: (_) => clearAndRenewSid(),
+      onRetry: (_, e) => renewSidIfExpired(e),
     );
   }
 
@@ -51,7 +51,7 @@ class DomainRepositoryV6 extends BaseV6SidRepository
         );
         return result.map((e) => e.toSingleDomain());
       },
-      onRetry: (_) => clearAndRenewSid(),
+      onRetry: (_, e) => renewSidIfExpired(e),
     );
   }
 
@@ -78,7 +78,7 @@ class DomainRepositoryV6 extends BaseV6SidRepository
         );
         return result.map((e) => e.toSingleDomain());
       },
-      onRetry: (_) => clearAndRenewSid(),
+      onRetry: (_, e) => renewSidIfExpired(e),
     );
   }
 
@@ -99,7 +99,7 @@ class DomainRepositoryV6 extends BaseV6SidRepository
         );
         return result.map((_) => unit);
       },
-      onRetry: (_) => clearAndRenewSid(),
+      onRetry: (_, e) => renewSidIfExpired(e),
     );
   }
 }

--- a/lib/data/repositories/api/v6/ftl_repository.dart
+++ b/lib/data/repositories/api/v6/ftl_repository.dart
@@ -30,7 +30,7 @@ class FtlRepositoryV6 extends BaseV6SidRepository implements FtlRepository {
         final result = await _client.getInfoClient(sid);
         return result.map((e) => e.toDomain());
       },
-      onRetry: (_) => clearAndRenewSid(),
+      onRetry: (_, e) => renewSidIfExpired(e),
     );
   }
 
@@ -42,7 +42,7 @@ class FtlRepositoryV6 extends BaseV6SidRepository implements FtlRepository {
         final result = await _client.getInfoFtl(sid);
         return result.map((e) => e.toDomain());
       },
-      onRetry: (_) => clearAndRenewSid(),
+      onRetry: (_, e) => renewSidIfExpired(e),
     );
   }
 
@@ -54,7 +54,7 @@ class FtlRepositoryV6 extends BaseV6SidRepository implements FtlRepository {
         final result = await _client.getInfoHost(sid);
         return result.map((e) => e.toDomain());
       },
-      onRetry: (_) => clearAndRenewSid(),
+      onRetry: (_, e) => renewSidIfExpired(e),
     );
   }
 
@@ -66,7 +66,7 @@ class FtlRepositoryV6 extends BaseV6SidRepository implements FtlRepository {
         final result = await _client.getInfoMessages(sid);
         return result.map((e) => e.toDomain());
       },
-      onRetry: (_) => clearAndRenewSid(),
+      onRetry: (_, e) => renewSidIfExpired(e),
     );
   }
 
@@ -81,7 +81,7 @@ class FtlRepositoryV6 extends BaseV6SidRepository implements FtlRepository {
         );
         return result.map((_) => unit);
       },
-      onRetry: (_) => clearAndRenewSid(),
+      onRetry: (_, e) => renewSidIfExpired(e),
     );
   }
 
@@ -93,7 +93,7 @@ class FtlRepositoryV6 extends BaseV6SidRepository implements FtlRepository {
         final result = await _client.getInfoMetrics(sid);
         return result.map((e) => e.toDomain());
       },
-      onRetry: (_) => clearAndRenewSid(),
+      onRetry: (_, e) => renewSidIfExpired(e),
     );
   }
 
@@ -105,7 +105,7 @@ class FtlRepositoryV6 extends BaseV6SidRepository implements FtlRepository {
         final result = await _client.getInfoSensors(sid);
         return result.map((e) => e.toDomain());
       },
-      onRetry: (_) => clearAndRenewSid(),
+      onRetry: (_, e) => renewSidIfExpired(e),
     );
   }
 
@@ -117,7 +117,7 @@ class FtlRepositoryV6 extends BaseV6SidRepository implements FtlRepository {
         final result = await _client.getInfoSystem(sid);
         return result.map((e) => e.toDomain());
       },
-      onRetry: (_) => clearAndRenewSid(),
+      onRetry: (_, e) => renewSidIfExpired(e),
     );
   }
 
@@ -129,7 +129,7 @@ class FtlRepositoryV6 extends BaseV6SidRepository implements FtlRepository {
         final result = await _client.getInfoVersion(sid);
         return result.map((e) => e.toDomain());
       },
-      onRetry: (_) => clearAndRenewSid(),
+      onRetry: (_, e) => renewSidIfExpired(e),
     );
   }
 
@@ -153,7 +153,7 @@ class FtlRepositoryV6 extends BaseV6SidRepository implements FtlRepository {
           ),
         );
       },
-      onRetry: (_) => clearAndRenewSid(),
+      onRetry: (_, e) => renewSidIfExpired(e),
     );
   }
 }

--- a/lib/data/repositories/api/v6/group_repository.dart
+++ b/lib/data/repositories/api/v6/group_repository.dart
@@ -22,7 +22,7 @@ class GroupRepositoryV6 extends BaseV6SidRepository implements GroupRepository {
         final result = await _client.getGroups(sid);
         return result.map((e) => e.toDomain());
       },
-      onRetry: (_) => clearAndRenewSid(),
+      onRetry: (_, e) => renewSidIfExpired(e),
     );
   }
 
@@ -43,7 +43,7 @@ class GroupRepositoryV6 extends BaseV6SidRepository implements GroupRepository {
         );
         return result.map((e) => e.toSingleDomain());
       },
-      onRetry: (_) => clearAndRenewSid(),
+      onRetry: (_, e) => renewSidIfExpired(e),
     );
   }
 
@@ -64,7 +64,7 @@ class GroupRepositoryV6 extends BaseV6SidRepository implements GroupRepository {
         );
         return result.map((e) => e.toSingleDomain());
       },
-      onRetry: (_) => clearAndRenewSid(),
+      onRetry: (_, e) => renewSidIfExpired(e),
     );
   }
 
@@ -75,7 +75,7 @@ class GroupRepositoryV6 extends BaseV6SidRepository implements GroupRepository {
         final sid = await getSid();
         return _client.deleteGroups(sid, name: name);
       },
-      onRetry: (_) => clearAndRenewSid(),
+      onRetry: (_, e) => renewSidIfExpired(e),
     );
   }
 }

--- a/lib/data/repositories/api/v6/local_dns_repository.dart
+++ b/lib/data/repositories/api/v6/local_dns_repository.dart
@@ -26,7 +26,7 @@ class LocalDnsRepositoryV6 extends BaseV6SidRepository
         );
         return result.map((config) => _parseHosts(config.config?.dns?.hosts));
       },
-      onRetry: (_) => clearAndRenewSid(),
+      onRetry: (_, e) => renewSidIfExpired(e),
     );
   }
 
@@ -44,7 +44,7 @@ class LocalDnsRepositoryV6 extends BaseV6SidRepository
           value: '$ip $name',
         );
       },
-      onRetry: (_) => clearAndRenewSid(),
+      onRetry: (_, e) => renewSidIfExpired(e),
     );
   }
 
@@ -62,7 +62,7 @@ class LocalDnsRepositoryV6 extends BaseV6SidRepository
           value: '$ip $name',
         );
       },
-      onRetry: (_) => clearAndRenewSid(),
+      onRetry: (_, e) => renewSidIfExpired(e),
     );
   }
 
@@ -99,7 +99,7 @@ class LocalDnsRepositoryV6 extends BaseV6SidRepository
         );
         return patchResult.map((_) => unit);
       },
-      onRetry: (_) => clearAndRenewSid(),
+      onRetry: (_, e) => renewSidIfExpired(e),
     );
   }
 

--- a/lib/data/repositories/api/v6/metrics_repository.dart
+++ b/lib/data/repositories/api/v6/metrics_repository.dart
@@ -30,7 +30,7 @@ class MetricsRepositoryV6 extends BaseV6SidRepository
         final result = await _client.getHistory(sid);
         return result.map((e) => e.toDomain());
       },
-      onRetry: (_) => clearAndRenewSid(),
+      onRetry: (_, e) => renewSidIfExpired(e),
     );
   }
 
@@ -42,7 +42,7 @@ class MetricsRepositoryV6 extends BaseV6SidRepository
         final result = await _client.getHistoryClient(sid, count: count);
         return result.map((e) => e.toDomain());
       },
-      onRetry: (_) => clearAndRenewSid(),
+      onRetry: (_, e) => renewSidIfExpired(e),
     );
   }
 
@@ -68,7 +68,7 @@ class MetricsRepositoryV6 extends BaseV6SidRepository
 
         return result.map((e) => e.toDomain());
       },
-      onRetry: (_) => clearAndRenewSid(),
+      onRetry: (_, e) => renewSidIfExpired(e),
     );
   }
 
@@ -80,7 +80,7 @@ class MetricsRepositoryV6 extends BaseV6SidRepository
         final result = await _client.getStatsSummary(sid);
         return result.map((e) => e.toDomain());
       },
-      onRetry: (_) => clearAndRenewSid(),
+      onRetry: (_, e) => renewSidIfExpired(e),
     );
   }
 
@@ -92,7 +92,7 @@ class MetricsRepositoryV6 extends BaseV6SidRepository
         final result = await _client.getStatsUpstreams(sid);
         return result.map((e) => e.toDomain());
       },
-      onRetry: (_) => clearAndRenewSid(),
+      onRetry: (_, e) => renewSidIfExpired(e),
     );
   }
 
@@ -110,7 +110,7 @@ class MetricsRepositoryV6 extends BaseV6SidRepository
         );
         return result.map((e) => e.domains.map((d) => d.toDomain()).toList());
       },
-      onRetry: (_) => clearAndRenewSid(),
+      onRetry: (_, e) => renewSidIfExpired(e),
     );
   }
 

--- a/lib/data/repositories/api/v6/network_repository.dart
+++ b/lib/data/repositories/api/v6/network_repository.dart
@@ -30,7 +30,7 @@ class NetworkRepositoryV6 extends BaseV6SidRepository
         );
         return result.map((e) => e.toDomain());
       },
-      onRetry: (_) => clearAndRenewSid(),
+      onRetry: (_, e) => renewSidIfExpired(e),
     );
   }
 
@@ -45,7 +45,7 @@ class NetworkRepositoryV6 extends BaseV6SidRepository
         );
         return result.map((_) => unit);
       },
-      onRetry: (_) => clearAndRenewSid(),
+      onRetry: (_, e) => renewSidIfExpired(e),
     );
   }
 
@@ -60,7 +60,7 @@ class NetworkRepositoryV6 extends BaseV6SidRepository
         );
         return result.map((e) => e.toDomain());
       },
-      onRetry: (_) => clearAndRenewSid(),
+      onRetry: (_, e) => renewSidIfExpired(e),
     );
   }
 }

--- a/lib/data/repositories/api/v6/v6_session_cache.dart
+++ b/lib/data/repositories/api/v6/v6_session_cache.dart
@@ -16,15 +16,18 @@ class V6SessionCache {
   V6SessionCache({
     required SessionCredentialService creds,
     required PiholeV6ApiClient client,
+    this.renewalCooldown = const Duration(milliseconds: 500),
   }) : _creds = creds,
        _client = client;
 
   final SessionCredentialService _creds;
   final PiholeV6ApiClient _client;
+  final Duration renewalCooldown;
 
   String? _sid;
   Future<String>? _pendingLoad;
   Future<void>? _pendingRenewal;
+  DateTime? _lastRenewalCompletedAt;
 
   String get serverAddress => _creds.address;
 
@@ -122,6 +125,15 @@ class V6SessionCache {
   Future<void> _renewOnce() async {
     if (_pendingRenewal != null) return _pendingRenewal!;
 
+    // Debounce: skip if a renewal just completed within the cooldown window.
+    // Prevents a race condition where multiple onRetry callbacks fire after
+    // _pendingRenewal is cleared (finally) and each starts a new postAuth.
+    final now = DateTime.now();
+    if (_lastRenewalCompletedAt != null &&
+        now.difference(_lastRenewalCompletedAt!) < renewalCooldown) {
+      return;
+    }
+
     logger.d('[V6SessionCache] Session expired, attempting renewal...');
     _clear();
 
@@ -131,6 +143,7 @@ class V6SessionCache {
 
     try {
       await pending;
+      _lastRenewalCompletedAt = DateTime.now();
       logger.d('[V6SessionCache] Session renewed successfully.');
     } finally {
       _pendingRenewal = null;

--- a/lib/data/repositories/utils/call_with_retry.dart
+++ b/lib/data/repositories/utils/call_with_retry.dart
@@ -82,7 +82,8 @@ Future<T> runWithRetry<T>({
 /// - [action]: The asynchronous operation to execute. Must return a [Future<Result<T>>].
 /// - [maxRetries]: Maximum number of retry attempts before giving up. Defaults to 1.
 /// - [delay]: Delay between retry attempts. Defaults to 10 milliseconds.
-/// - [onRetry]: Optional callback invoked after each failed attempt, with the current attempt count.
+/// - [onRetry]: Optional callback invoked after each failed attempt, with the
+///   current attempt count and the failure exception.
 ///
 /// Returns:
 /// - A [Future<Result<T>>] that resolves to the first [Success] returned by [action],
@@ -94,7 +95,7 @@ Future<Result<T>> runWithResultRetry<T extends Object>({
   required Future<Result<T>> Function() action,
   int maxRetries = 1,
   Duration delay = const Duration(milliseconds: 10),
-  Future<void> Function(int attempt)? onRetry,
+  Future<void> Function(int attempt, Object error)? onRetry,
 }) async {
   var attempt = 0;
   Result<T>? lastFailure;
@@ -114,7 +115,10 @@ Future<Result<T>> runWithResultRetry<T extends Object>({
     if (attempt <= maxRetries) {
       if (onRetry != null) {
         try {
-          await onRetry(attempt);
+          final error =
+              lastFailure.exceptionOrNull() ??
+              Exception('Unknown failure on attempt ${attempt - 1}');
+          await onRetry(attempt, error);
         } catch (e, st) {
           return Failure(Exception('Exception on onRetry $attempt: $e\n$st'));
         }

--- a/lib/ui/core/services/server_connection_service.dart
+++ b/lib/ui/core/services/server_connection_service.dart
@@ -185,6 +185,16 @@ class ServerConnectionService {
           process?.close();
           return preCheck;
         }
+        // Only re-authenticate on auth errors (401/SidNotFoundException).
+        // Transient failures (503/504/timeout) should not create a new session
+        // as that would cause session multiplication on the Pi-hole side.
+        final preCheckErr = preCheck.exceptionOrNull();
+        if (!isReauthRequired(preCheckErr)) {
+          process?.close();
+          return Failure(
+            preCheckErr ?? Exception('connection pre-check failed'),
+          );
+        }
         // Session is missing or expired — re-authenticate.
         final authResult = await bundle.auth.createSession(pw);
         if (authResult.isError()) {

--- a/lib/ui/servers/widgets/add_server_fullscreen.dart
+++ b/lib/ui/servers/widgets/add_server_fullscreen.dart
@@ -588,6 +588,24 @@ class _AddServerFullscreenState extends State<AddServerFullscreen> {
 
       serverObj = updatedServer;
 
+      void handleSaveError(Exception e) {
+        if (context.mounted) {
+          setState(() {
+            isConnecting = false;
+            _restoreSecrets();
+          });
+          handleApiErrorResult(
+            context: context,
+            appConfigViewModel: appConfigViewModel,
+            error: e,
+            version: piHoleVersion,
+          );
+        }
+        if (serversViewModel.selectedServer != null) {
+          statusViewModel.startAutoRefresh();
+        }
+      }
+
       final bundle = saveCreateBundle(server: serverObj);
       var sessionJustCreated = false;
       if (serverObj.apiVersion == SupportedApiVersions.v6) {
@@ -600,42 +618,14 @@ class _AddServerFullscreenState extends State<AddServerFullscreen> {
         if (preCheck.isError()) {
           final err = preCheck.exceptionOrNull();
           if (!isReauthRequired(err)) {
-            if (context.mounted) {
-              setState(() {
-                isConnecting = false;
-                _restoreSecrets();
-              });
-              handleApiErrorResult(
-                context: context,
-                appConfigViewModel: appConfigViewModel,
-                error: err!,
-                version: piHoleVersion,
-              );
-            }
-            if (serversViewModel.selectedServer != null) {
-              statusViewModel.startAutoRefresh();
-            }
+            handleSaveError(err!);
             return;
           }
           final authResult = await bundle.auth.createSession(
             passwordFieldController.text,
           );
           if (authResult.isError()) {
-            if (context.mounted) {
-              setState(() {
-                isConnecting = false;
-                _restoreSecrets();
-              });
-              handleApiErrorResult(
-                context: context,
-                appConfigViewModel: appConfigViewModel,
-                error: authResult.exceptionOrNull()!,
-                version: piHoleVersion,
-              );
-            }
-            if (serversViewModel.selectedServer != null) {
-              statusViewModel.startAutoRefresh();
-            }
+            handleSaveError(authResult.exceptionOrNull()!);
             return;
           }
           sessionJustCreated = true;

--- a/lib/ui/servers/widgets/add_server_fullscreen.dart
+++ b/lib/ui/servers/widgets/add_server_fullscreen.dart
@@ -589,33 +589,63 @@ class _AddServerFullscreenState extends State<AddServerFullscreen> {
       serverObj = updatedServer;
 
       final bundle = saveCreateBundle(server: serverObj);
+      var sessionJustCreated = false;
       if (serverObj.apiVersion == SupportedApiVersions.v6) {
-        final authResult = await bundle.auth.createSession(
-          passwordFieldController.text,
+        // Check if the existing session is still valid before creating a new one.
+        // Only re-authenticate on 401/SidNotFoundException to avoid session
+        // multiplication when the server is temporarily unreachable (503/504/timeout).
+        final preCheck = await bundle.dns.fetchBlockingStatus(
+          skipRenewal: true,
         );
-        if (authResult.isError()) {
-          if (context.mounted) {
-            setState(() {
-              isConnecting = false;
-              _restoreSecrets();
-            });
-            handleApiErrorResult(
-              context: context,
-              appConfigViewModel: appConfigViewModel,
-              error: authResult.exceptionOrNull()!,
-              version: piHoleVersion,
-            );
+        if (preCheck.isError()) {
+          final err = preCheck.exceptionOrNull();
+          if (!isReauthRequired(err)) {
+            if (context.mounted) {
+              setState(() {
+                isConnecting = false;
+                _restoreSecrets();
+              });
+              handleApiErrorResult(
+                context: context,
+                appConfigViewModel: appConfigViewModel,
+                error: err!,
+                version: piHoleVersion,
+              );
+            }
+            if (serversViewModel.selectedServer != null) {
+              statusViewModel.startAutoRefresh();
+            }
+            return;
           }
-          if (serversViewModel.selectedServer != null) {
-            statusViewModel.startAutoRefresh();
+          final authResult = await bundle.auth.createSession(
+            passwordFieldController.text,
+          );
+          if (authResult.isError()) {
+            if (context.mounted) {
+              setState(() {
+                isConnecting = false;
+                _restoreSecrets();
+              });
+              handleApiErrorResult(
+                context: context,
+                appConfigViewModel: appConfigViewModel,
+                error: authResult.exceptionOrNull()!,
+                version: piHoleVersion,
+              );
+            }
+            if (serversViewModel.selectedServer != null) {
+              statusViewModel.startAutoRefresh();
+            }
+            return;
           }
-          return;
+          sessionJustCreated = true;
         }
       }
-      // Use skipRenewal: true because the session was just created above.
-      // Retrying with clearAndRenewSid would create a duplicate session.
-      // Transient errors (e.g. network timeout) are still retried.
-      final result = await bundle.dns.fetchBlockingStatus(skipRenewal: true);
+      // skipRenewal: true only when a new session was just created above to
+      // avoid creating a duplicate session on transient retry failures.
+      final result = await bundle.dns.fetchBlockingStatus(
+        skipRenewal: sessionJustCreated,
+      );
 
       if (result.isSuccess()) {
         final server = serverObj.copyWith(defaultServer: defaultCheckbox);

--- a/lib/utils/exceptions.dart
+++ b/lib/utils/exceptions.dart
@@ -42,3 +42,14 @@ class HttpStatusCodeException extends HttpException {
 
   final int statusCode;
 }
+
+/// Returns true when [error] indicates an expired or missing session and
+/// re-authentication via postAuth is appropriate.
+///
+/// Returns false for transient failures (503/504/timeout/500/495) where
+/// calling postAuth would create a duplicate session on the Pi-hole side.
+bool isReauthRequired(Object? error) {
+  if (error is HttpStatusCodeException && error.statusCode == 401) return true;
+  if (error is SidNotFoundException) return true;
+  return false;
+}

--- a/test/data/repositories/api/v6/base_v6_sid_repository_test.dart
+++ b/test/data/repositories/api/v6/base_v6_sid_repository_test.dart
@@ -1,0 +1,91 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pi_hole_client/data/repositories/api/v6/base_v6_sid_repository.dart';
+import 'package:pi_hole_client/data/repositories/api/v6/v6_session_cache.dart';
+import 'package:pi_hole_client/utils/exceptions.dart';
+
+import '../../../../../testing/fakes/services/fake_pihole_v6_api_client.dart';
+import '../../../../../testing/fakes/services/fake_session_credential_service.dart';
+
+// Minimal concrete subclass for testing the base class methods.
+class _TestRepo extends BaseV6SidRepository {
+  _TestRepo({required super.sessionCache});
+}
+
+void main() {
+  late _TestRepo repo;
+  late FakePiholeV6ApiClient client;
+
+  setUp(() {
+    client = FakePiholeV6ApiClient();
+    final creds = FakeSessionCredentialService();
+    final cache = V6SessionCache(creds: creds, client: client);
+    repo = _TestRepo(sessionCache: cache);
+  });
+
+  // ---------------------------------------------------------------------------
+  // renewSidIfExpired
+  // ---------------------------------------------------------------------------
+  group('renewSidIfExpired', () {
+    test('calls clearAndRenewSid when error is 401', () async {
+      await repo.renewSidIfExpired(HttpStatusCodeException(401));
+      expect(client.postAuthCallCount, 1);
+    });
+
+    test('calls clearAndRenewSid when error is SidNotFoundException', () async {
+      await repo.renewSidIfExpired(SidNotFoundException());
+      expect(client.postAuthCallCount, 1);
+    });
+
+    test('does nothing when error is 503', () async {
+      await repo.renewSidIfExpired(HttpStatusCodeException(503));
+      expect(client.postAuthCallCount, 0);
+    });
+
+    test('does nothing when error is 500', () async {
+      await repo.renewSidIfExpired(HttpStatusCodeException(500));
+      expect(client.postAuthCallCount, 0);
+    });
+
+    test('does nothing when error is a generic timeout exception', () async {
+      await repo.renewSidIfExpired(Exception('Connection timed out'));
+      expect(client.postAuthCallCount, 0);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // isReauthRequired
+  // ---------------------------------------------------------------------------
+  group('isReauthRequired', () {
+    test('returns true for 401', () {
+      expect(isReauthRequired(HttpStatusCodeException(401)), isTrue);
+    });
+
+    test('returns true for SidNotFoundException', () {
+      expect(isReauthRequired(SidNotFoundException()), isTrue);
+    });
+
+    test('returns false for 503', () {
+      expect(isReauthRequired(HttpStatusCodeException(503)), isFalse);
+    });
+
+    test('returns false for 504', () {
+      expect(isReauthRequired(HttpStatusCodeException(504)), isFalse);
+    });
+
+    test('returns false for 500', () {
+      expect(isReauthRequired(HttpStatusCodeException(500)), isFalse);
+    });
+
+    test('returns false for 495 (SSL)', () {
+      expect(isReauthRequired(HttpStatusCodeException(495)), isFalse);
+    });
+
+    test('returns false for generic exception', () {
+      expect(isReauthRequired(Exception('timeout')), isFalse);
+    });
+
+    test('returns false for null', () {
+      expect(isReauthRequired(null), isFalse);
+    });
+  });
+}

--- a/test/data/repositories/api/v6/v6_session_cache_test.dart
+++ b/test/data/repositories/api/v6/v6_session_cache_test.dart
@@ -116,8 +116,13 @@ void main() {
     test(
       'second clearAndRenewSid after first completes calls postAuth again',
       () async {
-        await cache.clearAndRenewSid();
-        await cache.clearAndRenewSid();
+        final noDebounceCache = V6SessionCache(
+          creds: creds,
+          client: client,
+          renewalCooldown: Duration.zero,
+        );
+        await noDebounceCache.clearAndRenewSid();
+        await noDebounceCache.clearAndRenewSid();
 
         expect(client.postAuthCallCount, 2);
       },
@@ -161,5 +166,38 @@ void main() {
       await cache.clearAndRenewSid();
       expect(creds.deleteSidCallCount, 1);
     });
+
+    test(
+      'rapid call after renewal completes is debounced within cooldown window',
+      () async {
+        client.authPauseCompleter = Completer<void>();
+
+        final f1 = cache.clearAndRenewSid();
+        final f2 = cache.clearAndRenewSid();
+        client.authPauseCompleter!.complete();
+        await Future.wait([f1, f2]);
+
+        // Immediate call — still within the 500ms cooldown window.
+        await cache.clearAndRenewSid();
+
+        expect(client.postAuthCallCount, 1);
+      },
+    );
+
+    test(
+      'second call after cooldown expires invokes postAuth again',
+      () async {
+        final shortCooldownCache = V6SessionCache(
+          creds: creds,
+          client: client,
+          renewalCooldown: const Duration(milliseconds: 10),
+        );
+        await shortCooldownCache.clearAndRenewSid();
+        await Future<void>.delayed(const Duration(milliseconds: 20));
+        await shortCooldownCache.clearAndRenewSid();
+
+        expect(client.postAuthCallCount, 2);
+      },
+    );
   });
 }

--- a/test/data/repositories/utils/call_with_retry_test.dart
+++ b/test/data/repositories/utils/call_with_retry_test.dart
@@ -80,5 +80,36 @@ void main() {
       expect(result.isError(), isTrue);
       expect(attempts, 4); // 3 retries + initial attempt
     });
+
+    test('passes failure exception to onRetry', () async {
+      final receivedErrors = <Object>[];
+      await runWithResultRetry<String>(
+        action: () async => Failure(Exception('sentinel error')),
+        maxRetries: 1,
+        onRetry: (attempt, error) async {
+          receivedErrors.add(error);
+        },
+      );
+      expect(receivedErrors.length, 1);
+      expect(receivedErrors.first.toString(), contains('sentinel error'));
+    });
+
+    test('passes correct error across multiple retries', () async {
+      var call = 0;
+      final receivedErrors = <Object>[];
+      await runWithResultRetry<String>(
+        action: () async {
+          call++;
+          return Failure(Exception('error $call'));
+        },
+        maxRetries: 2,
+        onRetry: (attempt, error) async {
+          receivedErrors.add(error);
+        },
+      );
+      expect(receivedErrors.length, 2);
+      expect(receivedErrors[0].toString(), contains('error 1'));
+      expect(receivedErrors[1].toString(), contains('error 2'));
+    });
   });
 }


### PR DESCRIPTION
## Overview
Pi-hole v6 creates a new server-side session for every `POST /api/auth` call, so any code path that triggers re-authentication unnecessarily results in duplicate sessions accumulating in the Pi-hole Admin console. This PR closes all identified routes that caused session multiplication, including a race condition where concurrent `onRetry` callbacks fired after the renewal `Future` was cleared and each launched an independent `postAuth`.

## Changes
- Add `isReauthRequired` helper that gates re-authentication strictly to HTTP 401 and `SidNotFoundException`, preventing transient errors (503, 504, timeout) from triggering unnecessary session creation
- Pass the failure exception to `onRetry` callbacks in `runWithResultRetry` and switch all v6 repositories from unconditional `clearAndRenewSid()` to `renewSidIfExpired(error)`, which calls `clearAndRenewSid` only when `isReauthRequired` is true
- Guard `createSession` calls in the server-edit save flow and server-switch flow with a pre-check + `isReauthRequired` condition so they run only when authentication is actually expired, not on network errors
- Add a 500ms renewal cooldown (`renewalCooldown`) to `V6SessionCache._renewOnce()` so that late `onRetry` callbacks arriving after `_pendingRenewal` is cleared are debounced rather than spawning a second `postAuth`
- Add tests for `renewSidIfExpired`, `isReauthRequired`, `onRetry` error propagation, and the session renewal debounce behavior
