### PR TITLE
fix(ui): prevent stale server data flashes when switching servers

### DIFF
--- a/lib/routing/server_scoped_route.dart
+++ b/lib/routing/server_scoped_route.dart
@@ -25,7 +25,7 @@ enum RequiredApiVersion {
 /// 2. **v6-only feature on v5 server** — renders a titled
 ///    [PiHoleV5NotSupportedScreen].
 /// 3. **Happy path** — invokes [builder] with the non-null bundle and server,
-///    wrapped in a [KeyedSubtree] keyed on bundle identity so switching
+///    wrapped in a [KeyedSubtree] keyed on server identity so switching
 ///    servers tears down stale ViewModels instead of leaking state.
 class ServerScopedRoute extends StatelessWidget {
   const ServerScopedRoute({
@@ -66,6 +66,6 @@ class ServerScopedRoute extends StatelessWidget {
       );
     }
 
-    return KeyedSubtree(key: ObjectKey(bundle), child: builder(bundle, server));
+    return KeyedSubtree(key: ObjectKey(server), child: builder(bundle, server));
   }
 }

--- a/lib/ui/domains/view_models/domains_viewmodel.dart
+++ b/lib/ui/domains/view_models/domains_viewmodel.dart
@@ -47,6 +47,7 @@ class DomainsViewModel extends ChangeNotifier {
   bool _searchMode = false;
   int? _groupFilter;
   LoadStatus _loadingStatus = LoadStatus.loading;
+  bool _disposed = false;
 
   // --- Getters ---
   List<Domain> get whitelistDomains => _whitelistDomains;
@@ -70,9 +71,10 @@ class DomainsViewModel extends ChangeNotifier {
     _blacklistDomains = [];
     _filteredWhitelistDomains = [];
     _filteredBlacklistDomains = [];
-    notifyListeners();
+    _safeNotifyListeners();
 
     final result = await _domainRepository.fetchAllDomains();
+    if (_disposed) return;
     switch (result) {
       case Success():
         final lists = result.getOrNull();
@@ -80,10 +82,10 @@ class DomainsViewModel extends ChangeNotifier {
         _blacklistDomains = [...lists.denyExact, ...lists.denyRegex];
         _applyFilters();
         _loadingStatus = LoadStatus.loaded;
-        notifyListeners();
+        _safeNotifyListeners();
       case Failure():
         _loadingStatus = LoadStatus.error;
-        notifyListeners();
+        _safeNotifyListeners();
         throw result.exceptionOrNull();
     }
   }
@@ -94,6 +96,7 @@ class DomainsViewModel extends ChangeNotifier {
       domain.kind,
       domain.punyCode,
     );
+    if (_disposed) return;
     switch (result) {
       case Success():
         _removeDomainFromList(domain);
@@ -110,6 +113,7 @@ class DomainsViewModel extends ChangeNotifier {
       params.kind,
       params.domain,
     );
+    if (_disposed) return;
     switch (result) {
       case Success():
         final domain = result.getOrNull();
@@ -119,7 +123,7 @@ class DomainsViewModel extends ChangeNotifier {
           _blacklistDomains = [..._blacklistDomains, domain];
         }
         _applyFilters();
-        notifyListeners();
+        _safeNotifyListeners();
       case Failure():
         throw result.exceptionOrNull();
     }
@@ -134,6 +138,7 @@ class DomainsViewModel extends ChangeNotifier {
       groups: domain.groups,
       enabled: domain.enabled,
     );
+    if (_disposed) return;
     switch (result) {
       case Success():
         final updated = result.getOrNull();
@@ -156,7 +161,7 @@ class DomainsViewModel extends ChangeNotifier {
               .toList();
         }
         _applyFilters();
-        notifyListeners();
+        _safeNotifyListeners();
       case Failure():
         throw result.exceptionOrNull();
     }
@@ -226,11 +231,17 @@ class DomainsViewModel extends ChangeNotifier {
           .where((d) => d.id != domain.id)
           .toList();
     }
+    _safeNotifyListeners();
+  }
+
+  void _safeNotifyListeners() {
+    if (_disposed) return;
     notifyListeners();
   }
 
   @override
   void dispose() {
+    _disposed = true;
     loadDomains.removeListener(notifyListeners);
     loadDomains.isRunning.removeListener(notifyListeners);
     loadDomains.errors.removeListener(notifyListeners);

--- a/lib/ui/domains/view_models/domains_viewmodel.dart
+++ b/lib/ui/domains/view_models/domains_viewmodel.dart
@@ -46,6 +46,7 @@ class DomainsViewModel extends ChangeNotifier {
   String _searchTerm = '';
   bool _searchMode = false;
   int? _groupFilter;
+  LoadStatus _loadingStatus = LoadStatus.loading;
 
   // --- Getters ---
   List<Domain> get whitelistDomains => _whitelistDomains;
@@ -59,13 +60,18 @@ class DomainsViewModel extends ChangeNotifier {
   int? get groupFilter => _groupFilter;
 
   LoadStatus get loadingStatus {
-    if (loadDomains.isRunning.value) return LoadStatus.loading;
-    if (loadDomains.errors.value != null) return LoadStatus.error;
-    return LoadStatus.loaded;
+    return _loadingStatus;
   }
 
   // --- Command implementations ---
   Future<void> _loadDomains() async {
+    _loadingStatus = LoadStatus.loading;
+    _whitelistDomains = [];
+    _blacklistDomains = [];
+    _filteredWhitelistDomains = [];
+    _filteredBlacklistDomains = [];
+    notifyListeners();
+
     final result = await _domainRepository.fetchAllDomains();
     switch (result) {
       case Success():
@@ -73,8 +79,11 @@ class DomainsViewModel extends ChangeNotifier {
         _whitelistDomains = [...lists.allowExact, ...lists.allowRegex];
         _blacklistDomains = [...lists.denyExact, ...lists.denyRegex];
         _applyFilters();
+        _loadingStatus = LoadStatus.loaded;
         notifyListeners();
       case Failure():
+        _loadingStatus = LoadStatus.error;
+        notifyListeners();
         throw result.exceptionOrNull();
     }
   }

--- a/lib/ui/logs/view_models/logs_viewmodel.dart
+++ b/lib/ui/logs/view_models/logs_viewmodel.dart
@@ -605,7 +605,11 @@ class LogsViewModel extends ChangeNotifier {
       notifyListeners();
 
       final newLogs = await _loadNextWithWindowSupport();
-      if (!_isCurrentServerEpoch(serverEpoch)) return;
+      if (!_isCurrentServerEpoch(serverEpoch)) {
+        _isLoadingMore = false;
+        notifyListeners();
+        return;
+      }
 
       _isLoadingMore = false;
       notifyListeners();
@@ -620,7 +624,11 @@ class LogsViewModel extends ChangeNotifier {
       }
     }
 
-    if (!_isCurrentServerEpoch(serverEpoch)) return;
+    if (!_isCurrentServerEpoch(serverEpoch)) {
+      _isLoadingMore = false;
+      notifyListeners();
+      return;
+    }
     if (_paginationService!.finished == LoadStatus.error) {
       _loadStatus = LoadStatus.error;
       notifyListeners();

--- a/lib/ui/logs/view_models/logs_viewmodel.dart
+++ b/lib/ui/logs/view_models/logs_viewmodel.dart
@@ -292,6 +292,7 @@ class LogsViewModel extends ChangeNotifier {
   int _logAutoRefreshTime = 5;
 
   bool _isRevalidating = false;
+  int _serverEpoch = 0;
 
   List<Log> get logsList => _logsList;
   LoadStatus get loadStatus => _loadStatus;
@@ -402,19 +403,32 @@ class LogsViewModel extends ChangeNotifier {
     // Also reset the filter delegate on server switch so stale client/domain
     // selections from the previous server don't bleed into the new one.
     if (repositoryChanged) {
+      _serverEpoch++;
       _filters = version == SupportedApiVersions.v6 ? FiltersV6() : FiltersV5();
-    }
 
-    // Server switch while the screen is visible: clear the log cache so
-    // initializeLoad() shows the full-screen spinner instead of stale logs,
-    // then reinitialize the pagination services and reload.
-    if (repositoryChanged && _screenActive) {
+      // Always reset server-bound state on repository changes, even when
+      // the screen is not visible, to prevent stale data from leaking across
+      // server switches.
+      _stopLiveTimer();
+      _liveLogsService = null;
       _resetLogsCache();
-      _paginationService = _paginationServiceFactory(repository: _repository!);
-      _livePaginationService = _paginationServiceFactory(
-        repository: _repository!,
-      );
-      _scheduleInitializeLoad();
+      _loadStatus = LoadStatus.loading;
+      _isRevalidating = false;
+      _isFiltering = false;
+      _isLoadingMore = false;
+      _enableNextWindow = true;
+
+      // Server switch while the screen is visible: reinitialize pagination
+      // services and trigger a reload.
+      if (_screenActive) {
+        _paginationService = _paginationServiceFactory(
+          repository: _repository!,
+        );
+        _livePaginationService = _paginationServiceFactory(
+          repository: _repository!,
+        );
+        _scheduleInitializeLoad();
+      }
     }
   }
 
@@ -479,6 +493,7 @@ class LogsViewModel extends ChangeNotifier {
   /// wraps a single async action with one completion/error event; it cannot
   /// model the fine-grained, multi-phase state machine required here.
   Future<void> initializeLoad() async {
+    final serverEpoch = _serverEpoch;
     _stopLiveTimer();
     _isFiltering = false;
     _enableNextWindow = true;
@@ -500,7 +515,8 @@ class LogsViewModel extends ChangeNotifier {
     _paginationService!.reset(start, now);
 
     if (hasCache) {
-      await _collectAndReplace();
+      await _collectAndReplace(serverEpoch: serverEpoch);
+      if (!_isCurrentServerEpoch(serverEpoch)) return;
       _isRevalidating = false;
 
       if (_paginationService!.finished != LoadStatus.error) {
@@ -508,7 +524,8 @@ class LogsViewModel extends ChangeNotifier {
       }
       notifyListeners();
     } else {
-      await _enqueueLoad();
+      await _enqueueLoad(serverEpoch: serverEpoch);
+      if (!_isCurrentServerEpoch(serverEpoch)) return;
 
       if (_paginationService!.finished == LoadStatus.error) {
         _loadStatus = LoadStatus.error;
@@ -521,6 +538,7 @@ class LogsViewModel extends ChangeNotifier {
     }
 
     final endTime = _paginationService!.endTime ?? DateTime.now();
+    if (!_isCurrentServerEpoch(serverEpoch)) return;
     _resetLiveBaseline(endTime: endTime);
     _configureLiveUpdates();
   }
@@ -537,6 +555,7 @@ class LogsViewModel extends ChangeNotifier {
     DateTime? inStartTime,
     DateTime? inEndTime,
   }) async {
+    final serverEpoch = _serverEpoch;
     _stopLiveTimer();
     _loadStatus = LoadStatus.loading;
     _isFiltering = true;
@@ -552,15 +571,18 @@ class LogsViewModel extends ChangeNotifier {
       _resetLogsCache();
 
       final newLogs = await _paginationService!.loadNextPage();
+      if (!_isCurrentServerEpoch(serverEpoch)) return;
       logger.d('Loaded ${newLogs.length} logs from $startTime to $endTime');
 
       _addLogs(newLogs);
     }
 
+    if (!_isCurrentServerEpoch(serverEpoch)) return;
     _loadStatus = LoadStatus.loaded;
     notifyListeners();
 
     final liveEndTime = _paginationService!.endTime ?? DateTime.now();
+    if (!_isCurrentServerEpoch(serverEpoch)) return;
     _resetLiveBaseline(endTime: liveEndTime);
     _configureLiveUpdates();
   }
@@ -573,15 +595,17 @@ class LogsViewModel extends ChangeNotifier {
     notifyListeners();
   }
 
-  Future<void> _enqueueLoad() async {
+  Future<void> _enqueueLoad({required int serverEpoch}) async {
     // Allow up to 3 consecutive empty windows before giving up.
     const maxEmptyWindows = 3;
 
     for (var emptyWindowCount = 0; emptyWindowCount < maxEmptyWindows;) {
+      if (!_isCurrentServerEpoch(serverEpoch)) return;
       _isLoadingMore = true;
       notifyListeners();
 
       final newLogs = await _loadNextWithWindowSupport();
+      if (!_isCurrentServerEpoch(serverEpoch)) return;
 
       _isLoadingMore = false;
       notifyListeners();
@@ -596,6 +620,7 @@ class LogsViewModel extends ChangeNotifier {
       }
     }
 
+    if (!_isCurrentServerEpoch(serverEpoch)) return;
     if (_paginationService!.finished == LoadStatus.error) {
       _loadStatus = LoadStatus.error;
       notifyListeners();
@@ -607,14 +632,16 @@ class LogsViewModel extends ChangeNotifier {
 
   /// SWR: collects fresh logs without touching the displayed list, then
   /// atomically replaces [_logsList] and [_loadedLogKeys].
-  Future<void> _collectAndReplace() async {
+  Future<void> _collectAndReplace({required int serverEpoch}) async {
     // Allow up to 3 consecutive empty windows before giving up.
     const maxEmptyWindows = 3;
     final freshLogs = <Log>[];
     final freshKeys = <String>{};
 
     for (var emptyWindowCount = 0; emptyWindowCount < maxEmptyWindows;) {
+      if (!_isCurrentServerEpoch(serverEpoch)) return;
       final newLogs = await _loadNextWithWindowSupport();
+      if (!_isCurrentServerEpoch(serverEpoch)) return;
 
       for (final log in newLogs) {
         final key = _logKey(log);
@@ -625,6 +652,7 @@ class LogsViewModel extends ChangeNotifier {
       if (_isPaginationFinished) emptyWindowCount++;
     }
 
+    if (!_isCurrentServerEpoch(serverEpoch)) return;
     _logsList = freshLogs;
     _loadedLogKeys
       ..clear()
@@ -642,7 +670,7 @@ class LogsViewModel extends ChangeNotifier {
   /// incompatible with the pagination state machine used here.
   Future<void> enqueueLoadMore() async {
     if (_isLoadingMore || _paginationService == null) return;
-    await _enqueueLoad();
+    await _enqueueLoad(serverEpoch: _serverEpoch);
   }
 
   bool get _isPaginationFinished =>
@@ -841,9 +869,16 @@ class LogsViewModel extends ChangeNotifier {
       return;
     }
 
+    final serverEpoch = _serverEpoch;
+    final liveLogsService = _liveLogsService;
+    if (liveLogsService == null) return;
+
     _isLiveTickInProgress = true;
     try {
-      final logs = await _liveLogsService?.tickOnce() ?? const <Log>[];
+      final logs = await liveLogsService.tickOnce();
+      if (!_isCurrentServerEpoch(serverEpoch)) return;
+      if (_liveLogsService != liveLogsService) return;
+      if (!_shouldRunLiveLog) return;
       if (logs.isEmpty) return;
       _addLogs(logs, prepend: true);
     } catch (error, stackTrace) {
@@ -852,4 +887,6 @@ class LogsViewModel extends ChangeNotifier {
       _isLiveTickInProgress = false;
     }
   }
+
+  bool _isCurrentServerEpoch(int epoch) => epoch == _serverEpoch;
 }

--- a/test/ui/domains/view_models/domains_viewmodel_test.dart
+++ b/test/ui/domains/view_models/domains_viewmodel_test.dart
@@ -27,7 +27,7 @@ void main() {
     });
 
     test('initial values are correct', () {
-      expect(viewModel.loadingStatus, LoadStatus.loaded);
+      expect(viewModel.loadingStatus, LoadStatus.loading);
       expect(viewModel.whitelistDomains, []);
       expect(viewModel.blacklistDomains, []);
       expect(viewModel.filteredWhitelistDomains, []);

--- a/test/ui/logs/view_models/logs_viewmodel_test.dart
+++ b/test/ui/logs/view_models/logs_viewmodel_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:pi_hole_client/data/repositories/api/interfaces/metrics_repository.dart';
 import 'package:pi_hole_client/domain/model/enums.dart';
@@ -9,6 +11,7 @@ import 'package:pi_hole_client/domain/model/metrics/top_clients.dart';
 import 'package:pi_hole_client/domain/model/metrics/top_domains.dart';
 import 'package:pi_hole_client/domain/model/metrics/upstreams.dart';
 import 'package:pi_hole_client/domain/model/overtime/overtime.dart';
+import 'package:pi_hole_client/domain/services/live_logs_service.dart';
 import 'package:pi_hole_client/domain/services/logs_pagination_service.dart';
 import 'package:pi_hole_client/ui/logs/view_models/logs_viewmodel.dart';
 import 'package:result_dart/result_dart.dart';
@@ -122,6 +125,51 @@ class _ErrorPaginationService extends LogsPaginationService {
 
   @override
   Future<List<Log>> loadNextPage() async => const [];
+}
+
+/// [LogsPaginationService] that can delay the first page until [gate] completes.
+class _GatePaginationService extends LogsPaginationService {
+  _GatePaginationService(this._logs, {this.gate})
+    : super(repository: _StubMetricsRepository());
+
+  final List<Log> _logs;
+  final Completer<void>? gate;
+  bool _done = false;
+
+  @override
+  LoadStatus get finished => _done ? LoadStatus.loaded : LoadStatus.loading;
+
+  @override
+  void reset(DateTime start, DateTime until) {
+    super.reset(start, until);
+    _done = false;
+  }
+
+  @override
+  Future<List<Log>> loadNextPage() async {
+    if (_done) return const [];
+    if (gate != null && !gate!.isCompleted) await gate!.future;
+    _done = true;
+    return List.of(_logs);
+  }
+}
+
+/// [LiveLogsService] that records tick invocations.
+class _CountingLiveLogsService extends LiveLogsService {
+  _CountingLiveLogsService({
+    required super.paginationService,
+    required super.endTime,
+    required this.onTick,
+  });
+
+  final Future<List<Log>> Function() onTick;
+  int tickCount = 0;
+
+  @override
+  Future<List<Log>> tickOnce() async {
+    tickCount++;
+    return onTick();
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -300,7 +348,7 @@ void main() {
   // selectedStatusTypes / allStatusTypes / isAllowedOrRetried
   // -------------------------------------------------------------------------
 
-  group('LogsViewModel – status type sets', () {
+  group('LogsViewModel - status type sets', () {
     late LogsViewModel vm;
 
     setUp(() => vm = _buildVm());
@@ -357,7 +405,7 @@ void main() {
   // Search, sort, selectedLog (pure state)
   // -------------------------------------------------------------------------
 
-  group('LogsViewModel – search / sort / selectedLog', () {
+  group('LogsViewModel - search / sort / selectedLog', () {
     late LogsViewModel vm;
 
     setUp(() => vm = _buildVm());
@@ -398,7 +446,7 @@ void main() {
   // API version switch resets filter delegate
   // -------------------------------------------------------------------------
 
-  group('LogsViewModel – update() API version switch', () {
+  group('LogsViewModel - update() API version switch', () {
     test('switching from v5 to v6 resets filter state', () {
       final vm = _buildVm();
       vm.setRequestStatus(RequestStatus.blocked);
@@ -408,6 +456,124 @@ void main() {
       vm.update(metricsRepository: _StubMetricsRepository(), apiVersion: 'v6');
       expect(vm.apiVersion, equals('v6'));
       expect(vm.requestStatus, equals(RequestStatus.all));
+      vm.dispose();
+    });
+  });
+
+  group('LogsViewModel - server switch stale-state guard', () {
+    test(
+      'repositoryChanged while screen is inactive clears logs and sets loading',
+      () async {
+        final vm = _buildVm(
+          logs: [_allowedLog(url: 'server-a.com', device: '10.0.0.1', id: 1)],
+        );
+        await _initAndLoad(vm);
+        expect(vm.logsList, isNotEmpty);
+        expect(vm.loadStatus, LoadStatus.loaded);
+
+        vm.disposeScreen();
+        vm.update(
+          metricsRepository: _StubMetricsRepository(),
+          apiVersion: 'v5',
+        );
+
+        expect(vm.logsList, isEmpty);
+        expect(vm.logsListDisplay, isEmpty);
+        expect(vm.loadStatus, LoadStatus.loading);
+        expect(vm.isFiltering, isFalse);
+        expect(vm.isLoadingMore, isFalse);
+        expect(vm.isRevalidating, isFalse);
+        vm.dispose();
+      },
+    );
+
+    test(
+      'configureLive after inactive server switch does not run stale live service',
+      () async {
+        final repoA = _StubMetricsRepository();
+        final repoB = _StubMetricsRepository();
+        final serviceByRepository = <MetricsRepository, LogsPaginationService>{
+          repoA: _ControlledPaginationService([
+            _allowedLog(url: 'a.com', device: '10.0.0.1', id: 1),
+          ]),
+          repoB: _ControlledPaginationService(const []),
+        };
+        final liveService = _CountingLiveLogsService(
+          paginationService: _ControlledPaginationService(const []),
+          endTime: DateTime(2024, 1, 1, 12, 0),
+          onTick: () async => [
+            _allowedLog(url: 'stale-live.com', device: '10.0.0.9', id: 999),
+          ],
+        );
+
+        final vm = LogsViewModel(
+          paginationServiceFactory: ({required MetricsRepository repository}) {
+            return serviceByRepository[repository]!;
+          },
+          liveLogsServiceFactory:
+              ({
+                required LogsPaginationService paginationService,
+                required DateTime endTime,
+              }) {
+                return liveService;
+              },
+        );
+
+        vm.update(metricsRepository: repoA, apiVersion: 'v5');
+        await _initAndLoad(vm); // Creates the live baseline for server A.
+        expect(vm.loadStatus, LoadStatus.loaded);
+
+        vm.disposeScreen();
+        vm.update(metricsRepository: repoB, apiVersion: 'v5');
+        vm.initScreen(logsPerQuery: 2.0);
+        vm.configureLive(
+          liveLogEnabled: true,
+          isLivelogPaused: false,
+          isOnLogsTab: true,
+          logAutoRefreshTime: 1,
+        );
+        await Future<void>.delayed(const Duration(milliseconds: 30));
+
+        expect(liveService.tickCount, equals(0));
+        expect(
+          vm.logsList.where((log) => log.url == 'stale-live.com'),
+          isEmpty,
+        );
+        vm.dispose();
+      },
+    );
+
+    test('old delayed load result is ignored after server switch', () async {
+      final repoA = _StubMetricsRepository();
+      final repoB = _StubMetricsRepository();
+      final gateA = Completer<void>();
+
+      final serviceA = _GatePaginationService([
+        _allowedLog(url: 'old-a.com', device: '10.0.0.1', id: 1),
+      ], gate: gateA);
+      final serviceB = _GatePaginationService([
+        _allowedLog(url: 'new-b.com', device: '10.0.0.2', id: 2),
+      ]);
+
+      final vm = LogsViewModel(
+        paginationServiceFactory: ({required MetricsRepository repository}) {
+          return repository == repoA ? serviceA : serviceB;
+        },
+      );
+
+      vm.update(metricsRepository: repoA, apiVersion: 'v5');
+      vm.initScreen(logsPerQuery: 2.0);
+      final pendingOldLoad = vm.initializeLoad();
+
+      vm.update(metricsRepository: repoB, apiVersion: 'v5');
+      await vm.initializeLoad();
+
+      gateA.complete();
+      await pendingOldLoad;
+
+      expect(vm.loadStatus, LoadStatus.loaded);
+      expect(vm.logsList.length, equals(1));
+      expect(vm.logsList.first.url, equals('new-b.com'));
       vm.dispose();
     });
   });


### PR DESCRIPTION
## Overview
This change fixes a UI state leak where Logs and Domains could briefly show data from the previously selected server before showing the loading indicator and fresh results. It adds stricter reset behavior on server switch and introduces guards to ignore stale async results that complete after the active server changes. The result is a consistent cold-start loading experience per server and safer tab transitions without cross-server data bleed.

## Changes
- Hardened `LogsViewModel` server-switch handling by always resetting server-bound state (cache, load flags, live-log baseline/timer) even when the logs screen is inactive.
- Added an epoch/token guard in logs loading and live refresh flows (`initializeLoad`, filter load, pagination helpers, and live ticks) so delayed results from an old server are dropped instead of mutating current state.
- Updated live-log tick logic to verify both server epoch and live-service instance before applying new entries, preventing stale live updates from being appended after a switch.
- Updated `ServerScopedRoute` subtree keying to use server identity so server-scoped screens are reliably torn down and rebuilt on server changes.
- Changed `DomainsViewModel` loading-state management to explicit `LoadStatus` tracking and immediate list clearing on fetch start, ensuring spinner-first behavior instead of showing stale domain lists.
- Extended and adjusted tests to cover inactive-screen server switches, stale async race protection, live-service stale tick prevention, and the updated initial loading state for domains.