### PR TITLE
ci(sqlite3): package sqlite3 native assets for Linux and Windows installer

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -134,6 +134,23 @@ jobs:
       - name: Build linux
         run: flutter build linux --release
 
+      - name: Copy sqlite3 native asset to Linux bundle
+        run: |
+          mkdir -p $LINUX_RELEASE_PATH/lib
+
+          if [ -f build/native_assets/linux/libsqlite3.so ]; then
+            cp build/native_assets/linux/libsqlite3.so $LINUX_RELEASE_PATH/lib/
+          elif [ -f build/native_assets/linux/sqlite3.so ]; then
+            cp build/native_assets/linux/sqlite3.so $LINUX_RELEASE_PATH/lib/
+          else
+            echo "sqlite3 native asset not found"
+            find build/native_assets -iname '*sqlite*' || true
+            exit 1
+          fi
+
+          echo "SQLite files in Linux bundle:"
+          find $LINUX_RELEASE_PATH -iname '*sqlite*'
+
       - name: Install flutter_to_debian
         run: dart pub global activate flutter_to_debian
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1264,14 +1264,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.3.1"
-  sqlite3_flutter_libs:
-    dependency: "direct main"
-    description:
-      name: sqlite3_flutter_libs
-      sha256: "3ed7553eee7bb368f8950f58ba29f634e06e813c029aff6a0d60862b96de8454"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.6.0+eol"
   stack_trace:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -56,8 +56,7 @@ dependencies:
   url_launcher: ^6.2.4
   percent_indicator: ^4.2.5
   flutter_app_lock: ^4.3.0
-  sqlite3_flutter_libs: ^0.6.0+eol
-  sqlite3: ^3.3.1 # Versions above 3 cause a "Couldn't resolve native function 'sqlite3_initialize'" error on Windows.
+  sqlite3: ^3.3.1
   sqflite_common_ffi: ^2.3.7+1
   sentry_flutter: ^9.18.0
   flutter_dotenv: ^6.0.0

--- a/windows/innosetup_installer_builder.iss
+++ b/windows/innosetup_installer_builder.iss
@@ -41,8 +41,7 @@ Source: "..\build\windows\x64\runner\Release\dynamic_color_plugin.dll"; DestDir:
 Source: "..\build\windows\x64\runner\Release\flutter_windows.dll"; DestDir: "{app}"; Flags: ignoreversion
 Source: "..\build\windows\x64\runner\Release\local_auth_windows_plugin.dll"; DestDir: "{app}"; Flags: ignoreversion
 Source: "..\build\windows\x64\runner\Release\permission_handler_windows_plugin.dll"; DestDir: "{app}"; Flags: ignoreversion
-Source: "..\build\windows\x64\runner\Release\sqlite3.dll"; DestDir: "{app}"; Flags: ignoreversion
-Source: "..\build\windows\x64\runner\Release\sqlite3_flutter_libs_plugin.dll"; DestDir: "{app}"; Flags: ignoreversion
+Source: "..\build\native_assets\windows\sqlite3.dll"; DestDir: "{app}"; Flags: ignoreversion
 Source: "..\build\windows\x64\runner\Release\url_launcher_windows_plugin.dll"; DestDir: "{app}"; Flags: ignoreversion
 Source: "..\build\windows\x64\runner\Release\window_size_plugin.dll"; DestDir: "{app}"; Flags: ignoreversion
 Source: "..\build\windows\x64\runner\Release\flutter_secure_storage_windows_plugin.dll"; DestDir: "{app}"; Flags: ignoreversion


### PR DESCRIPTION
## Overview
This PR fixes desktop release packaging for SQLite by aligning runtime library handling with native assets output paths. It removes an unnecessary Flutter plugin dependency and updates packaging steps so Linux and Windows artifacts include the required sqlite3 library consistently. These changes reduce installer/runtime failures caused by missing or outdated sqlite3 binary locations.

## Changes
- Removed the direct sqlite3_flutter_libs dependency and kept sqlite3 as the single SQLite runtime dependency.
- Updated the Windows Inno Setup script to package sqlite3.dll from the native assets output path and removed the obsolete sqlite3_flutter_libs plugin DLL entry.
- Added a Linux release workflow step to copy the sqlite3 native library into the app bundle lib directory.
- Added fail-fast and diagnostic output in the Linux packaging step when the sqlite3 native asset is not found.