### PR TITLE
fix(widget): ensure periodic sync is registered on app cold start

### DIFF
--- a/android/app/src/main/kotlin/io/github/tsutsu3/pi_hole_client/MainActivity.kt
+++ b/android/app/src/main/kotlin/io/github/tsutsu3/pi_hole_client/MainActivity.kt
@@ -116,6 +116,7 @@ class MainActivity : FlutterFragmentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         handleIntent(intent)
+        WidgetUpdateHelper.schedulePeriodicSync(this)
     }
 
     override fun onNewIntent(intent: Intent) {

--- a/android/app/src/main/kotlin/io/github/tsutsu3/pi_hole_client/widget/WidgetUpdateHelper.kt
+++ b/android/app/src/main/kotlin/io/github/tsutsu3/pi_hole_client/widget/WidgetUpdateHelper.kt
@@ -110,13 +110,11 @@ object WidgetUpdateHelper {
      * workers (stats, compact, toggle). It enumerates bound server ids at runtime
      * and fires per-server workers, so the API call count scales with servers, not
      * with widget instance count.
+     *
+     * Safe to call on every app cold start: [ExistingPeriodicWorkPolicy.UPDATE]
+     * preserves the next scheduled run time and does not reset the 30-minute timer.
      */
     fun schedulePeriodicSync(context: Context) {
-        // Cleanup legacy periodic jobs from pre per-server architecture versions.
-        WorkManager.getInstance(context).cancelUniqueWork("pihole_widget_periodic")
-        WorkManager.getInstance(context).cancelUniqueWork("pihole_compact_widget_periodic")
-        WorkManager.getInstance(context).cancelUniqueWork("pihole_toggle_widget_periodic")
-
         val constraints = Constraints.Builder()
             .setRequiredNetworkType(NetworkType.CONNECTED)
             .build()
@@ -130,6 +128,19 @@ object WidgetUpdateHelper {
             ExistingPeriodicWorkPolicy.UPDATE,
             request,
         )
+    }
+
+    /**
+     * Cancels periodic work registered by the pre-per-server architecture (v1.8/v1.9.0).
+     *
+     * Called once from each widget provider's [onUpdate] so the cleanup runs when
+     * the OS triggers a widget refresh after an app update, not on every app cold start.
+     */
+    fun cancelLegacyPeriodicWork(context: Context) {
+        val wm = WorkManager.getInstance(context)
+        wm.cancelUniqueWork("pihole_widget_periodic")
+        wm.cancelUniqueWork("pihole_compact_widget_periodic")
+        wm.cancelUniqueWork("pihole_toggle_widget_periodic")
     }
 
     /**

--- a/android/app/src/main/kotlin/io/github/tsutsu3/pi_hole_client/widget/ui/compact/CompactWidgetProvider.kt
+++ b/android/app/src/main/kotlin/io/github/tsutsu3/pi_hole_client/widget/ui/compact/CompactWidgetProvider.kt
@@ -29,6 +29,7 @@ class CompactWidgetProvider : GlanceAppWidgetReceiver() {
             .mapNotNull { prefs.getServerForWidget(it) }
             .toSet()
             .forEach { serverId -> WidgetUpdateHelper.enqueueServerPadd(context, serverId) }
+        WidgetUpdateHelper.cancelLegacyPeriodicWork(context)
         WidgetUpdateHelper.schedulePeriodicSync(context)
     }
 

--- a/android/app/src/main/kotlin/io/github/tsutsu3/pi_hole_client/widget/ui/stats/PiHoleWidgetProvider.kt
+++ b/android/app/src/main/kotlin/io/github/tsutsu3/pi_hole_client/widget/ui/stats/PiHoleWidgetProvider.kt
@@ -30,6 +30,7 @@ class PiHoleWidgetProvider : GlanceAppWidgetReceiver() {
             .mapNotNull { prefs.getServerForWidget(it) }
             .toSet()
             .forEach { serverId -> WidgetUpdateHelper.enqueueServerPadd(context, serverId) }
+        WidgetUpdateHelper.cancelLegacyPeriodicWork(context)
         WidgetUpdateHelper.schedulePeriodicSync(context)
     }
 

--- a/android/app/src/main/kotlin/io/github/tsutsu3/pi_hole_client/widget/ui/toggle/ToggleWidgetProvider.kt
+++ b/android/app/src/main/kotlin/io/github/tsutsu3/pi_hole_client/widget/ui/toggle/ToggleWidgetProvider.kt
@@ -29,6 +29,7 @@ class ToggleWidgetProvider : GlanceAppWidgetReceiver() {
             .mapNotNull { prefs.getServerForWidget(it) }
             .toSet()
             .forEach { serverId -> WidgetUpdateHelper.enqueueServerBlockingStatus(context, serverId) }
+        WidgetUpdateHelper.cancelLegacyPeriodicWork(context)
         WidgetUpdateHelper.schedulePeriodicSync(context)
     }
 


### PR DESCRIPTION
## Overview
On devices where `ACTION_APPWIDGET_UPDATE` is not reliably fired after an app update (certain OEM launchers on older Android versions), the periodic widget sync worker introduced in the per-server architecture refactor could fail to register, causing home widgets to stop auto-refreshing. This fix ensures the periodic sync job is always registered whenever the app is opened.

## Changes
- Call `WidgetUpdateHelper.schedulePeriodicSync()` from `MainActivity.onCreate` as a fallback registration path, so the periodic sync worker is restored even if `onUpdate` is not triggered after an upgrade
