### PR TITLE
feat(home): add server status chips with real-time system metrics

### DIFF
--- a/lib/data/mapper/v6/ftl_mapper.dart
+++ b/lib/data/mapper/v6/ftl_mapper.dart
@@ -242,10 +242,14 @@ extension DnsRepliesMapper on s.DnsReplies {
 
 extension InfoSystemMapper on s.InfoSystem {
   d.FtlSystem toDomain() {
+    final raw = system.cpu.load.raw;
     return d.FtlSystem(
       uptime: system.uptime,
       ramUsage: system.memory.ram.percentUsed,
       cpuUsage: system.cpu.percentCpu ?? _average(system.cpu.load.percent),
+      cpuLoad: raw.length >= 3
+          ? d.CpuLoad(avg1m: raw[0], avg5m: raw[1], avg15m: raw[2])
+          : null,
     );
   }
 

--- a/lib/data/mapper/v6/metrics_mapper.dart
+++ b/lib/data/mapper/v6/metrics_mapper.dart
@@ -99,6 +99,7 @@ extension StatsSummaryMapper on ss.StatsSummary {
         total: queries.total,
       ),
       queryTypes: queries.types.toDomain(),
+      frequency: queries.frequency,
     );
   }
 }

--- a/lib/data/model/v6/metrics/stats.dart
+++ b/lib/data/model/v6/metrics/stats.dart
@@ -30,6 +30,7 @@ sealed class StatsQueries with _$StatsQueries {
     required StatsTypes types,
     required StatsStatus status,
     required StatsReplies replies,
+    double? frequency,
   }) = _StatsQueries;
 
   factory StatsQueries.fromJson(Map<String, dynamic> json) =>

--- a/lib/data/model/v6/metrics/stats.freezed.dart
+++ b/lib/data/model/v6/metrics/stats.freezed.dart
@@ -335,7 +335,7 @@ $StatsGravityCopyWith<$Res> get gravity {
 /// @nodoc
 mixin _$StatsQueries {
 
- int get total; int get blocked;@JsonKey(name: 'percent_blocked') double get percentBlocked;@JsonKey(name: 'unique_domains') int get uniqueDomains; int get forwarded; int get cached; StatsTypes get types; StatsStatus get status; StatsReplies get replies;
+ int get total; int get blocked;@JsonKey(name: 'percent_blocked') double get percentBlocked;@JsonKey(name: 'unique_domains') int get uniqueDomains; int get forwarded; int get cached; StatsTypes get types; StatsStatus get status; StatsReplies get replies; double? get frequency;
 /// Create a copy of StatsQueries
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -348,16 +348,16 @@ $StatsQueriesCopyWith<StatsQueries> get copyWith => _$StatsQueriesCopyWithImpl<S
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is StatsQueries&&(identical(other.total, total) || other.total == total)&&(identical(other.blocked, blocked) || other.blocked == blocked)&&(identical(other.percentBlocked, percentBlocked) || other.percentBlocked == percentBlocked)&&(identical(other.uniqueDomains, uniqueDomains) || other.uniqueDomains == uniqueDomains)&&(identical(other.forwarded, forwarded) || other.forwarded == forwarded)&&(identical(other.cached, cached) || other.cached == cached)&&(identical(other.types, types) || other.types == types)&&(identical(other.status, status) || other.status == status)&&(identical(other.replies, replies) || other.replies == replies));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is StatsQueries&&(identical(other.total, total) || other.total == total)&&(identical(other.blocked, blocked) || other.blocked == blocked)&&(identical(other.percentBlocked, percentBlocked) || other.percentBlocked == percentBlocked)&&(identical(other.uniqueDomains, uniqueDomains) || other.uniqueDomains == uniqueDomains)&&(identical(other.forwarded, forwarded) || other.forwarded == forwarded)&&(identical(other.cached, cached) || other.cached == cached)&&(identical(other.types, types) || other.types == types)&&(identical(other.status, status) || other.status == status)&&(identical(other.replies, replies) || other.replies == replies)&&(identical(other.frequency, frequency) || other.frequency == frequency));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,total,blocked,percentBlocked,uniqueDomains,forwarded,cached,types,status,replies);
+int get hashCode => Object.hash(runtimeType,total,blocked,percentBlocked,uniqueDomains,forwarded,cached,types,status,replies,frequency);
 
 @override
 String toString() {
-  return 'StatsQueries(total: $total, blocked: $blocked, percentBlocked: $percentBlocked, uniqueDomains: $uniqueDomains, forwarded: $forwarded, cached: $cached, types: $types, status: $status, replies: $replies)';
+  return 'StatsQueries(total: $total, blocked: $blocked, percentBlocked: $percentBlocked, uniqueDomains: $uniqueDomains, forwarded: $forwarded, cached: $cached, types: $types, status: $status, replies: $replies, frequency: $frequency)';
 }
 
 
@@ -368,7 +368,7 @@ abstract mixin class $StatsQueriesCopyWith<$Res>  {
   factory $StatsQueriesCopyWith(StatsQueries value, $Res Function(StatsQueries) _then) = _$StatsQueriesCopyWithImpl;
 @useResult
 $Res call({
- int total, int blocked,@JsonKey(name: 'percent_blocked') double percentBlocked,@JsonKey(name: 'unique_domains') int uniqueDomains, int forwarded, int cached, StatsTypes types, StatsStatus status, StatsReplies replies
+ int total, int blocked,@JsonKey(name: 'percent_blocked') double percentBlocked,@JsonKey(name: 'unique_domains') int uniqueDomains, int forwarded, int cached, StatsTypes types, StatsStatus status, StatsReplies replies, double? frequency
 });
 
 
@@ -385,7 +385,7 @@ class _$StatsQueriesCopyWithImpl<$Res>
 
 /// Create a copy of StatsQueries
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? total = null,Object? blocked = null,Object? percentBlocked = null,Object? uniqueDomains = null,Object? forwarded = null,Object? cached = null,Object? types = null,Object? status = null,Object? replies = null,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? total = null,Object? blocked = null,Object? percentBlocked = null,Object? uniqueDomains = null,Object? forwarded = null,Object? cached = null,Object? types = null,Object? status = null,Object? replies = null,Object? frequency = freezed,}) {
   return _then(_self.copyWith(
 total: null == total ? _self.total : total // ignore: cast_nullable_to_non_nullable
 as int,blocked: null == blocked ? _self.blocked : blocked // ignore: cast_nullable_to_non_nullable
@@ -396,7 +396,8 @@ as int,cached: null == cached ? _self.cached : cached // ignore: cast_nullable_t
 as int,types: null == types ? _self.types : types // ignore: cast_nullable_to_non_nullable
 as StatsTypes,status: null == status ? _self.status : status // ignore: cast_nullable_to_non_nullable
 as StatsStatus,replies: null == replies ? _self.replies : replies // ignore: cast_nullable_to_non_nullable
-as StatsReplies,
+as StatsReplies,frequency: freezed == frequency ? _self.frequency : frequency // ignore: cast_nullable_to_non_nullable
+as double?,
   ));
 }
 /// Create a copy of StatsQueries
@@ -505,10 +506,10 @@ return $default(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( int total,  int blocked, @JsonKey(name: 'percent_blocked')  double percentBlocked, @JsonKey(name: 'unique_domains')  int uniqueDomains,  int forwarded,  int cached,  StatsTypes types,  StatsStatus status,  StatsReplies replies)?  $default,{required TResult orElse(),}) {final _that = this;
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( int total,  int blocked, @JsonKey(name: 'percent_blocked')  double percentBlocked, @JsonKey(name: 'unique_domains')  int uniqueDomains,  int forwarded,  int cached,  StatsTypes types,  StatsStatus status,  StatsReplies replies,  double? frequency)?  $default,{required TResult orElse(),}) {final _that = this;
 switch (_that) {
 case _StatsQueries() when $default != null:
-return $default(_that.total,_that.blocked,_that.percentBlocked,_that.uniqueDomains,_that.forwarded,_that.cached,_that.types,_that.status,_that.replies);case _:
+return $default(_that.total,_that.blocked,_that.percentBlocked,_that.uniqueDomains,_that.forwarded,_that.cached,_that.types,_that.status,_that.replies,_that.frequency);case _:
   return orElse();
 
 }
@@ -526,10 +527,10 @@ return $default(_that.total,_that.blocked,_that.percentBlocked,_that.uniqueDomai
 /// }
 /// ```
 
-@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( int total,  int blocked, @JsonKey(name: 'percent_blocked')  double percentBlocked, @JsonKey(name: 'unique_domains')  int uniqueDomains,  int forwarded,  int cached,  StatsTypes types,  StatsStatus status,  StatsReplies replies)  $default,) {final _that = this;
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( int total,  int blocked, @JsonKey(name: 'percent_blocked')  double percentBlocked, @JsonKey(name: 'unique_domains')  int uniqueDomains,  int forwarded,  int cached,  StatsTypes types,  StatsStatus status,  StatsReplies replies,  double? frequency)  $default,) {final _that = this;
 switch (_that) {
 case _StatsQueries():
-return $default(_that.total,_that.blocked,_that.percentBlocked,_that.uniqueDomains,_that.forwarded,_that.cached,_that.types,_that.status,_that.replies);}
+return $default(_that.total,_that.blocked,_that.percentBlocked,_that.uniqueDomains,_that.forwarded,_that.cached,_that.types,_that.status,_that.replies,_that.frequency);}
 }
 /// A variant of `when` that fallback to returning `null`
 ///
@@ -543,10 +544,10 @@ return $default(_that.total,_that.blocked,_that.percentBlocked,_that.uniqueDomai
 /// }
 /// ```
 
-@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( int total,  int blocked, @JsonKey(name: 'percent_blocked')  double percentBlocked, @JsonKey(name: 'unique_domains')  int uniqueDomains,  int forwarded,  int cached,  StatsTypes types,  StatsStatus status,  StatsReplies replies)?  $default,) {final _that = this;
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( int total,  int blocked, @JsonKey(name: 'percent_blocked')  double percentBlocked, @JsonKey(name: 'unique_domains')  int uniqueDomains,  int forwarded,  int cached,  StatsTypes types,  StatsStatus status,  StatsReplies replies,  double? frequency)?  $default,) {final _that = this;
 switch (_that) {
 case _StatsQueries() when $default != null:
-return $default(_that.total,_that.blocked,_that.percentBlocked,_that.uniqueDomains,_that.forwarded,_that.cached,_that.types,_that.status,_that.replies);case _:
+return $default(_that.total,_that.blocked,_that.percentBlocked,_that.uniqueDomains,_that.forwarded,_that.cached,_that.types,_that.status,_that.replies,_that.frequency);case _:
   return null;
 
 }
@@ -558,7 +559,7 @@ return $default(_that.total,_that.blocked,_that.percentBlocked,_that.uniqueDomai
 
 @JsonSerializable(explicitToJson: true)
 class _StatsQueries implements StatsQueries {
-  const _StatsQueries({required this.total, required this.blocked, @JsonKey(name: 'percent_blocked') required this.percentBlocked, @JsonKey(name: 'unique_domains') required this.uniqueDomains, required this.forwarded, required this.cached, required this.types, required this.status, required this.replies});
+  const _StatsQueries({required this.total, required this.blocked, @JsonKey(name: 'percent_blocked') required this.percentBlocked, @JsonKey(name: 'unique_domains') required this.uniqueDomains, required this.forwarded, required this.cached, required this.types, required this.status, required this.replies, this.frequency});
   factory _StatsQueries.fromJson(Map<String, dynamic> json) => _$StatsQueriesFromJson(json);
 
 @override final  int total;
@@ -570,6 +571,7 @@ class _StatsQueries implements StatsQueries {
 @override final  StatsTypes types;
 @override final  StatsStatus status;
 @override final  StatsReplies replies;
+@override final  double? frequency;
 
 /// Create a copy of StatsQueries
 /// with the given fields replaced by the non-null parameter values.
@@ -584,16 +586,16 @@ Map<String, dynamic> toJson() {
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is _StatsQueries&&(identical(other.total, total) || other.total == total)&&(identical(other.blocked, blocked) || other.blocked == blocked)&&(identical(other.percentBlocked, percentBlocked) || other.percentBlocked == percentBlocked)&&(identical(other.uniqueDomains, uniqueDomains) || other.uniqueDomains == uniqueDomains)&&(identical(other.forwarded, forwarded) || other.forwarded == forwarded)&&(identical(other.cached, cached) || other.cached == cached)&&(identical(other.types, types) || other.types == types)&&(identical(other.status, status) || other.status == status)&&(identical(other.replies, replies) || other.replies == replies));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _StatsQueries&&(identical(other.total, total) || other.total == total)&&(identical(other.blocked, blocked) || other.blocked == blocked)&&(identical(other.percentBlocked, percentBlocked) || other.percentBlocked == percentBlocked)&&(identical(other.uniqueDomains, uniqueDomains) || other.uniqueDomains == uniqueDomains)&&(identical(other.forwarded, forwarded) || other.forwarded == forwarded)&&(identical(other.cached, cached) || other.cached == cached)&&(identical(other.types, types) || other.types == types)&&(identical(other.status, status) || other.status == status)&&(identical(other.replies, replies) || other.replies == replies)&&(identical(other.frequency, frequency) || other.frequency == frequency));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,total,blocked,percentBlocked,uniqueDomains,forwarded,cached,types,status,replies);
+int get hashCode => Object.hash(runtimeType,total,blocked,percentBlocked,uniqueDomains,forwarded,cached,types,status,replies,frequency);
 
 @override
 String toString() {
-  return 'StatsQueries(total: $total, blocked: $blocked, percentBlocked: $percentBlocked, uniqueDomains: $uniqueDomains, forwarded: $forwarded, cached: $cached, types: $types, status: $status, replies: $replies)';
+  return 'StatsQueries(total: $total, blocked: $blocked, percentBlocked: $percentBlocked, uniqueDomains: $uniqueDomains, forwarded: $forwarded, cached: $cached, types: $types, status: $status, replies: $replies, frequency: $frequency)';
 }
 
 
@@ -604,7 +606,7 @@ abstract mixin class _$StatsQueriesCopyWith<$Res> implements $StatsQueriesCopyWi
   factory _$StatsQueriesCopyWith(_StatsQueries value, $Res Function(_StatsQueries) _then) = __$StatsQueriesCopyWithImpl;
 @override @useResult
 $Res call({
- int total, int blocked,@JsonKey(name: 'percent_blocked') double percentBlocked,@JsonKey(name: 'unique_domains') int uniqueDomains, int forwarded, int cached, StatsTypes types, StatsStatus status, StatsReplies replies
+ int total, int blocked,@JsonKey(name: 'percent_blocked') double percentBlocked,@JsonKey(name: 'unique_domains') int uniqueDomains, int forwarded, int cached, StatsTypes types, StatsStatus status, StatsReplies replies, double? frequency
 });
 
 
@@ -621,7 +623,7 @@ class __$StatsQueriesCopyWithImpl<$Res>
 
 /// Create a copy of StatsQueries
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? total = null,Object? blocked = null,Object? percentBlocked = null,Object? uniqueDomains = null,Object? forwarded = null,Object? cached = null,Object? types = null,Object? status = null,Object? replies = null,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? total = null,Object? blocked = null,Object? percentBlocked = null,Object? uniqueDomains = null,Object? forwarded = null,Object? cached = null,Object? types = null,Object? status = null,Object? replies = null,Object? frequency = freezed,}) {
   return _then(_StatsQueries(
 total: null == total ? _self.total : total // ignore: cast_nullable_to_non_nullable
 as int,blocked: null == blocked ? _self.blocked : blocked // ignore: cast_nullable_to_non_nullable
@@ -632,7 +634,8 @@ as int,cached: null == cached ? _self.cached : cached // ignore: cast_nullable_t
 as int,types: null == types ? _self.types : types // ignore: cast_nullable_to_non_nullable
 as StatsTypes,status: null == status ? _self.status : status // ignore: cast_nullable_to_non_nullable
 as StatsStatus,replies: null == replies ? _self.replies : replies // ignore: cast_nullable_to_non_nullable
-as StatsReplies,
+as StatsReplies,frequency: freezed == frequency ? _self.frequency : frequency // ignore: cast_nullable_to_non_nullable
+as double?,
   ));
 }
 

--- a/lib/data/model/v6/metrics/stats.g.dart
+++ b/lib/data/model/v6/metrics/stats.g.dart
@@ -33,6 +33,7 @@ _StatsQueries _$StatsQueriesFromJson(Map<String, dynamic> json) =>
       types: StatsTypes.fromJson(json['types'] as Map<String, dynamic>),
       status: StatsStatus.fromJson(json['status'] as Map<String, dynamic>),
       replies: StatsReplies.fromJson(json['replies'] as Map<String, dynamic>),
+      frequency: (json['frequency'] as num?)?.toDouble(),
     );
 
 Map<String, dynamic> _$StatsQueriesToJson(_StatsQueries instance) =>
@@ -46,6 +47,7 @@ Map<String, dynamic> _$StatsQueriesToJson(_StatsQueries instance) =>
       'types': instance.types.toJson(),
       'status': instance.status.toJson(),
       'replies': instance.replies.toJson(),
+      'frequency': instance.frequency,
     };
 
 _StatsTypes _$StatsTypesFromJson(Map<String, dynamic> json) => _StatsTypes(

--- a/lib/domain/model/metrics/summary.dart
+++ b/lib/domain/model/metrics/summary.dart
@@ -20,6 +20,7 @@ sealed class Summary with _$Summary {
     required int dnsQueriesAllTypes,
     required ReplyCounts replies,
     required List<QueryTypeStat> queryTypes,
+    double? frequency,
   }) = _Summary;
 
   factory Summary.fromJson(Map<String, dynamic> json) =>

--- a/lib/domain/model/metrics/summary.freezed.dart
+++ b/lib/domain/model/metrics/summary.freezed.dart
@@ -15,7 +15,7 @@ T _$identity<T>(T value) => value;
 /// @nodoc
 mixin _$Summary {
 
- int get domainsBeingBlocked; int get dnsQueriesToday; int get adsBlockedToday; double get adsPercentageToday; int get uniqueDomains; int get queriesForwarded; int get queriesCached; int get clientsEverSeen; int get uniqueClients; int get dnsQueriesAllTypes; ReplyCounts get replies; List<QueryTypeStat> get queryTypes;
+ int get domainsBeingBlocked; int get dnsQueriesToday; int get adsBlockedToday; double get adsPercentageToday; int get uniqueDomains; int get queriesForwarded; int get queriesCached; int get clientsEverSeen; int get uniqueClients; int get dnsQueriesAllTypes; ReplyCounts get replies; List<QueryTypeStat> get queryTypes; double? get frequency;
 /// Create a copy of Summary
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -28,16 +28,16 @@ $SummaryCopyWith<Summary> get copyWith => _$SummaryCopyWithImpl<Summary>(this as
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is Summary&&(identical(other.domainsBeingBlocked, domainsBeingBlocked) || other.domainsBeingBlocked == domainsBeingBlocked)&&(identical(other.dnsQueriesToday, dnsQueriesToday) || other.dnsQueriesToday == dnsQueriesToday)&&(identical(other.adsBlockedToday, adsBlockedToday) || other.adsBlockedToday == adsBlockedToday)&&(identical(other.adsPercentageToday, adsPercentageToday) || other.adsPercentageToday == adsPercentageToday)&&(identical(other.uniqueDomains, uniqueDomains) || other.uniqueDomains == uniqueDomains)&&(identical(other.queriesForwarded, queriesForwarded) || other.queriesForwarded == queriesForwarded)&&(identical(other.queriesCached, queriesCached) || other.queriesCached == queriesCached)&&(identical(other.clientsEverSeen, clientsEverSeen) || other.clientsEverSeen == clientsEverSeen)&&(identical(other.uniqueClients, uniqueClients) || other.uniqueClients == uniqueClients)&&(identical(other.dnsQueriesAllTypes, dnsQueriesAllTypes) || other.dnsQueriesAllTypes == dnsQueriesAllTypes)&&(identical(other.replies, replies) || other.replies == replies)&&const DeepCollectionEquality().equals(other.queryTypes, queryTypes));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is Summary&&(identical(other.domainsBeingBlocked, domainsBeingBlocked) || other.domainsBeingBlocked == domainsBeingBlocked)&&(identical(other.dnsQueriesToday, dnsQueriesToday) || other.dnsQueriesToday == dnsQueriesToday)&&(identical(other.adsBlockedToday, adsBlockedToday) || other.adsBlockedToday == adsBlockedToday)&&(identical(other.adsPercentageToday, adsPercentageToday) || other.adsPercentageToday == adsPercentageToday)&&(identical(other.uniqueDomains, uniqueDomains) || other.uniqueDomains == uniqueDomains)&&(identical(other.queriesForwarded, queriesForwarded) || other.queriesForwarded == queriesForwarded)&&(identical(other.queriesCached, queriesCached) || other.queriesCached == queriesCached)&&(identical(other.clientsEverSeen, clientsEverSeen) || other.clientsEverSeen == clientsEverSeen)&&(identical(other.uniqueClients, uniqueClients) || other.uniqueClients == uniqueClients)&&(identical(other.dnsQueriesAllTypes, dnsQueriesAllTypes) || other.dnsQueriesAllTypes == dnsQueriesAllTypes)&&(identical(other.replies, replies) || other.replies == replies)&&const DeepCollectionEquality().equals(other.queryTypes, queryTypes)&&(identical(other.frequency, frequency) || other.frequency == frequency));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,domainsBeingBlocked,dnsQueriesToday,adsBlockedToday,adsPercentageToday,uniqueDomains,queriesForwarded,queriesCached,clientsEverSeen,uniqueClients,dnsQueriesAllTypes,replies,const DeepCollectionEquality().hash(queryTypes));
+int get hashCode => Object.hash(runtimeType,domainsBeingBlocked,dnsQueriesToday,adsBlockedToday,adsPercentageToday,uniqueDomains,queriesForwarded,queriesCached,clientsEverSeen,uniqueClients,dnsQueriesAllTypes,replies,const DeepCollectionEquality().hash(queryTypes),frequency);
 
 @override
 String toString() {
-  return 'Summary(domainsBeingBlocked: $domainsBeingBlocked, dnsQueriesToday: $dnsQueriesToday, adsBlockedToday: $adsBlockedToday, adsPercentageToday: $adsPercentageToday, uniqueDomains: $uniqueDomains, queriesForwarded: $queriesForwarded, queriesCached: $queriesCached, clientsEverSeen: $clientsEverSeen, uniqueClients: $uniqueClients, dnsQueriesAllTypes: $dnsQueriesAllTypes, replies: $replies, queryTypes: $queryTypes)';
+  return 'Summary(domainsBeingBlocked: $domainsBeingBlocked, dnsQueriesToday: $dnsQueriesToday, adsBlockedToday: $adsBlockedToday, adsPercentageToday: $adsPercentageToday, uniqueDomains: $uniqueDomains, queriesForwarded: $queriesForwarded, queriesCached: $queriesCached, clientsEverSeen: $clientsEverSeen, uniqueClients: $uniqueClients, dnsQueriesAllTypes: $dnsQueriesAllTypes, replies: $replies, queryTypes: $queryTypes, frequency: $frequency)';
 }
 
 
@@ -48,7 +48,7 @@ abstract mixin class $SummaryCopyWith<$Res>  {
   factory $SummaryCopyWith(Summary value, $Res Function(Summary) _then) = _$SummaryCopyWithImpl;
 @useResult
 $Res call({
- int domainsBeingBlocked, int dnsQueriesToday, int adsBlockedToday, double adsPercentageToday, int uniqueDomains, int queriesForwarded, int queriesCached, int clientsEverSeen, int uniqueClients, int dnsQueriesAllTypes, ReplyCounts replies, List<QueryTypeStat> queryTypes
+ int domainsBeingBlocked, int dnsQueriesToday, int adsBlockedToday, double adsPercentageToday, int uniqueDomains, int queriesForwarded, int queriesCached, int clientsEverSeen, int uniqueClients, int dnsQueriesAllTypes, ReplyCounts replies, List<QueryTypeStat> queryTypes, double? frequency
 });
 
 
@@ -65,7 +65,7 @@ class _$SummaryCopyWithImpl<$Res>
 
 /// Create a copy of Summary
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? domainsBeingBlocked = null,Object? dnsQueriesToday = null,Object? adsBlockedToday = null,Object? adsPercentageToday = null,Object? uniqueDomains = null,Object? queriesForwarded = null,Object? queriesCached = null,Object? clientsEverSeen = null,Object? uniqueClients = null,Object? dnsQueriesAllTypes = null,Object? replies = null,Object? queryTypes = null,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? domainsBeingBlocked = null,Object? dnsQueriesToday = null,Object? adsBlockedToday = null,Object? adsPercentageToday = null,Object? uniqueDomains = null,Object? queriesForwarded = null,Object? queriesCached = null,Object? clientsEverSeen = null,Object? uniqueClients = null,Object? dnsQueriesAllTypes = null,Object? replies = null,Object? queryTypes = null,Object? frequency = freezed,}) {
   return _then(_self.copyWith(
 domainsBeingBlocked: null == domainsBeingBlocked ? _self.domainsBeingBlocked : domainsBeingBlocked // ignore: cast_nullable_to_non_nullable
 as int,dnsQueriesToday: null == dnsQueriesToday ? _self.dnsQueriesToday : dnsQueriesToday // ignore: cast_nullable_to_non_nullable
@@ -79,7 +79,8 @@ as int,uniqueClients: null == uniqueClients ? _self.uniqueClients : uniqueClient
 as int,dnsQueriesAllTypes: null == dnsQueriesAllTypes ? _self.dnsQueriesAllTypes : dnsQueriesAllTypes // ignore: cast_nullable_to_non_nullable
 as int,replies: null == replies ? _self.replies : replies // ignore: cast_nullable_to_non_nullable
 as ReplyCounts,queryTypes: null == queryTypes ? _self.queryTypes : queryTypes // ignore: cast_nullable_to_non_nullable
-as List<QueryTypeStat>,
+as List<QueryTypeStat>,frequency: freezed == frequency ? _self.frequency : frequency // ignore: cast_nullable_to_non_nullable
+as double?,
   ));
 }
 /// Create a copy of Summary
@@ -170,10 +171,10 @@ return $default(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( int domainsBeingBlocked,  int dnsQueriesToday,  int adsBlockedToday,  double adsPercentageToday,  int uniqueDomains,  int queriesForwarded,  int queriesCached,  int clientsEverSeen,  int uniqueClients,  int dnsQueriesAllTypes,  ReplyCounts replies,  List<QueryTypeStat> queryTypes)?  $default,{required TResult orElse(),}) {final _that = this;
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( int domainsBeingBlocked,  int dnsQueriesToday,  int adsBlockedToday,  double adsPercentageToday,  int uniqueDomains,  int queriesForwarded,  int queriesCached,  int clientsEverSeen,  int uniqueClients,  int dnsQueriesAllTypes,  ReplyCounts replies,  List<QueryTypeStat> queryTypes,  double? frequency)?  $default,{required TResult orElse(),}) {final _that = this;
 switch (_that) {
 case _Summary() when $default != null:
-return $default(_that.domainsBeingBlocked,_that.dnsQueriesToday,_that.adsBlockedToday,_that.adsPercentageToday,_that.uniqueDomains,_that.queriesForwarded,_that.queriesCached,_that.clientsEverSeen,_that.uniqueClients,_that.dnsQueriesAllTypes,_that.replies,_that.queryTypes);case _:
+return $default(_that.domainsBeingBlocked,_that.dnsQueriesToday,_that.adsBlockedToday,_that.adsPercentageToday,_that.uniqueDomains,_that.queriesForwarded,_that.queriesCached,_that.clientsEverSeen,_that.uniqueClients,_that.dnsQueriesAllTypes,_that.replies,_that.queryTypes,_that.frequency);case _:
   return orElse();
 
 }
@@ -191,10 +192,10 @@ return $default(_that.domainsBeingBlocked,_that.dnsQueriesToday,_that.adsBlocked
 /// }
 /// ```
 
-@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( int domainsBeingBlocked,  int dnsQueriesToday,  int adsBlockedToday,  double adsPercentageToday,  int uniqueDomains,  int queriesForwarded,  int queriesCached,  int clientsEverSeen,  int uniqueClients,  int dnsQueriesAllTypes,  ReplyCounts replies,  List<QueryTypeStat> queryTypes)  $default,) {final _that = this;
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( int domainsBeingBlocked,  int dnsQueriesToday,  int adsBlockedToday,  double adsPercentageToday,  int uniqueDomains,  int queriesForwarded,  int queriesCached,  int clientsEverSeen,  int uniqueClients,  int dnsQueriesAllTypes,  ReplyCounts replies,  List<QueryTypeStat> queryTypes,  double? frequency)  $default,) {final _that = this;
 switch (_that) {
 case _Summary():
-return $default(_that.domainsBeingBlocked,_that.dnsQueriesToday,_that.adsBlockedToday,_that.adsPercentageToday,_that.uniqueDomains,_that.queriesForwarded,_that.queriesCached,_that.clientsEverSeen,_that.uniqueClients,_that.dnsQueriesAllTypes,_that.replies,_that.queryTypes);}
+return $default(_that.domainsBeingBlocked,_that.dnsQueriesToday,_that.adsBlockedToday,_that.adsPercentageToday,_that.uniqueDomains,_that.queriesForwarded,_that.queriesCached,_that.clientsEverSeen,_that.uniqueClients,_that.dnsQueriesAllTypes,_that.replies,_that.queryTypes,_that.frequency);}
 }
 /// A variant of `when` that fallback to returning `null`
 ///
@@ -208,10 +209,10 @@ return $default(_that.domainsBeingBlocked,_that.dnsQueriesToday,_that.adsBlocked
 /// }
 /// ```
 
-@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( int domainsBeingBlocked,  int dnsQueriesToday,  int adsBlockedToday,  double adsPercentageToday,  int uniqueDomains,  int queriesForwarded,  int queriesCached,  int clientsEverSeen,  int uniqueClients,  int dnsQueriesAllTypes,  ReplyCounts replies,  List<QueryTypeStat> queryTypes)?  $default,) {final _that = this;
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( int domainsBeingBlocked,  int dnsQueriesToday,  int adsBlockedToday,  double adsPercentageToday,  int uniqueDomains,  int queriesForwarded,  int queriesCached,  int clientsEverSeen,  int uniqueClients,  int dnsQueriesAllTypes,  ReplyCounts replies,  List<QueryTypeStat> queryTypes,  double? frequency)?  $default,) {final _that = this;
 switch (_that) {
 case _Summary() when $default != null:
-return $default(_that.domainsBeingBlocked,_that.dnsQueriesToday,_that.adsBlockedToday,_that.adsPercentageToday,_that.uniqueDomains,_that.queriesForwarded,_that.queriesCached,_that.clientsEverSeen,_that.uniqueClients,_that.dnsQueriesAllTypes,_that.replies,_that.queryTypes);case _:
+return $default(_that.domainsBeingBlocked,_that.dnsQueriesToday,_that.adsBlockedToday,_that.adsPercentageToday,_that.uniqueDomains,_that.queriesForwarded,_that.queriesCached,_that.clientsEverSeen,_that.uniqueClients,_that.dnsQueriesAllTypes,_that.replies,_that.queryTypes,_that.frequency);case _:
   return null;
 
 }
@@ -223,7 +224,7 @@ return $default(_that.domainsBeingBlocked,_that.dnsQueriesToday,_that.adsBlocked
 
 @JsonSerializable(explicitToJson: true)
 class _Summary implements Summary {
-   _Summary({required this.domainsBeingBlocked, required this.dnsQueriesToday, required this.adsBlockedToday, required this.adsPercentageToday, required this.uniqueDomains, required this.queriesForwarded, required this.queriesCached, required this.clientsEverSeen, required this.uniqueClients, required this.dnsQueriesAllTypes, required this.replies, required final  List<QueryTypeStat> queryTypes}): _queryTypes = queryTypes;
+   _Summary({required this.domainsBeingBlocked, required this.dnsQueriesToday, required this.adsBlockedToday, required this.adsPercentageToday, required this.uniqueDomains, required this.queriesForwarded, required this.queriesCached, required this.clientsEverSeen, required this.uniqueClients, required this.dnsQueriesAllTypes, required this.replies, required final  List<QueryTypeStat> queryTypes, this.frequency}): _queryTypes = queryTypes;
   factory _Summary.fromJson(Map<String, dynamic> json) => _$SummaryFromJson(json);
 
 @override final  int domainsBeingBlocked;
@@ -244,6 +245,7 @@ class _Summary implements Summary {
   return EqualUnmodifiableListView(_queryTypes);
 }
 
+@override final  double? frequency;
 
 /// Create a copy of Summary
 /// with the given fields replaced by the non-null parameter values.
@@ -258,16 +260,16 @@ Map<String, dynamic> toJson() {
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is _Summary&&(identical(other.domainsBeingBlocked, domainsBeingBlocked) || other.domainsBeingBlocked == domainsBeingBlocked)&&(identical(other.dnsQueriesToday, dnsQueriesToday) || other.dnsQueriesToday == dnsQueriesToday)&&(identical(other.adsBlockedToday, adsBlockedToday) || other.adsBlockedToday == adsBlockedToday)&&(identical(other.adsPercentageToday, adsPercentageToday) || other.adsPercentageToday == adsPercentageToday)&&(identical(other.uniqueDomains, uniqueDomains) || other.uniqueDomains == uniqueDomains)&&(identical(other.queriesForwarded, queriesForwarded) || other.queriesForwarded == queriesForwarded)&&(identical(other.queriesCached, queriesCached) || other.queriesCached == queriesCached)&&(identical(other.clientsEverSeen, clientsEverSeen) || other.clientsEverSeen == clientsEverSeen)&&(identical(other.uniqueClients, uniqueClients) || other.uniqueClients == uniqueClients)&&(identical(other.dnsQueriesAllTypes, dnsQueriesAllTypes) || other.dnsQueriesAllTypes == dnsQueriesAllTypes)&&(identical(other.replies, replies) || other.replies == replies)&&const DeepCollectionEquality().equals(other._queryTypes, _queryTypes));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _Summary&&(identical(other.domainsBeingBlocked, domainsBeingBlocked) || other.domainsBeingBlocked == domainsBeingBlocked)&&(identical(other.dnsQueriesToday, dnsQueriesToday) || other.dnsQueriesToday == dnsQueriesToday)&&(identical(other.adsBlockedToday, adsBlockedToday) || other.adsBlockedToday == adsBlockedToday)&&(identical(other.adsPercentageToday, adsPercentageToday) || other.adsPercentageToday == adsPercentageToday)&&(identical(other.uniqueDomains, uniqueDomains) || other.uniqueDomains == uniqueDomains)&&(identical(other.queriesForwarded, queriesForwarded) || other.queriesForwarded == queriesForwarded)&&(identical(other.queriesCached, queriesCached) || other.queriesCached == queriesCached)&&(identical(other.clientsEverSeen, clientsEverSeen) || other.clientsEverSeen == clientsEverSeen)&&(identical(other.uniqueClients, uniqueClients) || other.uniqueClients == uniqueClients)&&(identical(other.dnsQueriesAllTypes, dnsQueriesAllTypes) || other.dnsQueriesAllTypes == dnsQueriesAllTypes)&&(identical(other.replies, replies) || other.replies == replies)&&const DeepCollectionEquality().equals(other._queryTypes, _queryTypes)&&(identical(other.frequency, frequency) || other.frequency == frequency));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,domainsBeingBlocked,dnsQueriesToday,adsBlockedToday,adsPercentageToday,uniqueDomains,queriesForwarded,queriesCached,clientsEverSeen,uniqueClients,dnsQueriesAllTypes,replies,const DeepCollectionEquality().hash(_queryTypes));
+int get hashCode => Object.hash(runtimeType,domainsBeingBlocked,dnsQueriesToday,adsBlockedToday,adsPercentageToday,uniqueDomains,queriesForwarded,queriesCached,clientsEverSeen,uniqueClients,dnsQueriesAllTypes,replies,const DeepCollectionEquality().hash(_queryTypes),frequency);
 
 @override
 String toString() {
-  return 'Summary(domainsBeingBlocked: $domainsBeingBlocked, dnsQueriesToday: $dnsQueriesToday, adsBlockedToday: $adsBlockedToday, adsPercentageToday: $adsPercentageToday, uniqueDomains: $uniqueDomains, queriesForwarded: $queriesForwarded, queriesCached: $queriesCached, clientsEverSeen: $clientsEverSeen, uniqueClients: $uniqueClients, dnsQueriesAllTypes: $dnsQueriesAllTypes, replies: $replies, queryTypes: $queryTypes)';
+  return 'Summary(domainsBeingBlocked: $domainsBeingBlocked, dnsQueriesToday: $dnsQueriesToday, adsBlockedToday: $adsBlockedToday, adsPercentageToday: $adsPercentageToday, uniqueDomains: $uniqueDomains, queriesForwarded: $queriesForwarded, queriesCached: $queriesCached, clientsEverSeen: $clientsEverSeen, uniqueClients: $uniqueClients, dnsQueriesAllTypes: $dnsQueriesAllTypes, replies: $replies, queryTypes: $queryTypes, frequency: $frequency)';
 }
 
 
@@ -278,7 +280,7 @@ abstract mixin class _$SummaryCopyWith<$Res> implements $SummaryCopyWith<$Res> {
   factory _$SummaryCopyWith(_Summary value, $Res Function(_Summary) _then) = __$SummaryCopyWithImpl;
 @override @useResult
 $Res call({
- int domainsBeingBlocked, int dnsQueriesToday, int adsBlockedToday, double adsPercentageToday, int uniqueDomains, int queriesForwarded, int queriesCached, int clientsEverSeen, int uniqueClients, int dnsQueriesAllTypes, ReplyCounts replies, List<QueryTypeStat> queryTypes
+ int domainsBeingBlocked, int dnsQueriesToday, int adsBlockedToday, double adsPercentageToday, int uniqueDomains, int queriesForwarded, int queriesCached, int clientsEverSeen, int uniqueClients, int dnsQueriesAllTypes, ReplyCounts replies, List<QueryTypeStat> queryTypes, double? frequency
 });
 
 
@@ -295,7 +297,7 @@ class __$SummaryCopyWithImpl<$Res>
 
 /// Create a copy of Summary
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? domainsBeingBlocked = null,Object? dnsQueriesToday = null,Object? adsBlockedToday = null,Object? adsPercentageToday = null,Object? uniqueDomains = null,Object? queriesForwarded = null,Object? queriesCached = null,Object? clientsEverSeen = null,Object? uniqueClients = null,Object? dnsQueriesAllTypes = null,Object? replies = null,Object? queryTypes = null,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? domainsBeingBlocked = null,Object? dnsQueriesToday = null,Object? adsBlockedToday = null,Object? adsPercentageToday = null,Object? uniqueDomains = null,Object? queriesForwarded = null,Object? queriesCached = null,Object? clientsEverSeen = null,Object? uniqueClients = null,Object? dnsQueriesAllTypes = null,Object? replies = null,Object? queryTypes = null,Object? frequency = freezed,}) {
   return _then(_Summary(
 domainsBeingBlocked: null == domainsBeingBlocked ? _self.domainsBeingBlocked : domainsBeingBlocked // ignore: cast_nullable_to_non_nullable
 as int,dnsQueriesToday: null == dnsQueriesToday ? _self.dnsQueriesToday : dnsQueriesToday // ignore: cast_nullable_to_non_nullable
@@ -309,7 +311,8 @@ as int,uniqueClients: null == uniqueClients ? _self.uniqueClients : uniqueClient
 as int,dnsQueriesAllTypes: null == dnsQueriesAllTypes ? _self.dnsQueriesAllTypes : dnsQueriesAllTypes // ignore: cast_nullable_to_non_nullable
 as int,replies: null == replies ? _self.replies : replies // ignore: cast_nullable_to_non_nullable
 as ReplyCounts,queryTypes: null == queryTypes ? _self._queryTypes : queryTypes // ignore: cast_nullable_to_non_nullable
-as List<QueryTypeStat>,
+as List<QueryTypeStat>,frequency: freezed == frequency ? _self.frequency : frequency // ignore: cast_nullable_to_non_nullable
+as double?,
   ));
 }
 

--- a/lib/domain/model/metrics/summary.g.dart
+++ b/lib/domain/model/metrics/summary.g.dart
@@ -21,6 +21,7 @@ _Summary _$SummaryFromJson(Map<String, dynamic> json) => _Summary(
   queryTypes: (json['queryTypes'] as List<dynamic>)
       .map((e) => QueryTypeStat.fromJson(e as Map<String, dynamic>))
       .toList(),
+  frequency: (json['frequency'] as num?)?.toDouble(),
 );
 
 Map<String, dynamic> _$SummaryToJson(_Summary instance) => <String, dynamic>{
@@ -36,6 +37,7 @@ Map<String, dynamic> _$SummaryToJson(_Summary instance) => <String, dynamic>{
   'dnsQueriesAllTypes': instance.dnsQueriesAllTypes,
   'replies': instance.replies.toJson(),
   'queryTypes': instance.queryTypes.map((e) => e.toJson()).toList(),
+  'frequency': instance.frequency,
 };
 
 _ReplyCounts _$ReplyCountsFromJson(Map<String, dynamic> json) => _ReplyCounts(

--- a/lib/ui/core/l10n/app_de.arb
+++ b/lib/ui/core/l10n/app_de.arb
@@ -729,5 +729,11 @@
   "domainsWhitelist": "Domains (Whitelist)",
   "domainsBlacklist": "Domains (Blacklist)",
   "adlistsAllow": "Adlists (erlaubt)",
-  "adlistsBlock": "Adlists (blockiert)"
+  "adlistsBlock": "Adlists (blockiert)",
+  "chipTooltipQueriesPerMinute": "Anfragen pro Minute",
+  "chipTooltipCpuLoadAverage": "CPU-Lastdurchschnitt (1 Min / 5 Min / 15 Min)",
+  "chipTooltipCpuUsage": "CPU-Auslastung",
+  "chipTooltipRamUsage": "RAM-Auslastung",
+  "chipTooltipCpuTemperature": "CPU-Temperatur",
+  "chipTooltipSystemUptime": "Systemlaufzeit"
 }

--- a/lib/ui/core/l10n/app_en.arb
+++ b/lib/ui/core/l10n/app_en.arb
@@ -729,5 +729,11 @@
   },
   "unverifiedCertificatesBannerExpand": "Expand",
   "unverifiedCertificatesBannerCollapse": "Collapse",
-  "unverifiedCertificatesBannerLearnMore": "Learn more"
+  "unverifiedCertificatesBannerLearnMore": "Learn more",
+  "chipTooltipQueriesPerMinute": "Queries per minute",
+  "chipTooltipCpuLoadAverage": "CPU load average (1m / 5m / 15m)",
+  "chipTooltipCpuUsage": "CPU usage",
+  "chipTooltipRamUsage": "RAM usage",
+  "chipTooltipCpuTemperature": "CPU temperature",
+  "chipTooltipSystemUptime": "System uptime"
 }

--- a/lib/ui/core/l10n/app_es.arb
+++ b/lib/ui/core/l10n/app_es.arb
@@ -730,5 +730,11 @@
   "domainsWhitelist": "Dominios (lista blanca)",
   "domainsBlacklist": "Dominios (lista negra)",
   "adlistsAllow": "Adlists (permitir)",
-  "adlistsBlock": "Adlists (bloquear)"
+  "adlistsBlock": "Adlists (bloquear)",
+  "chipTooltipQueriesPerMinute": "Consultas por minuto",
+  "chipTooltipCpuLoadAverage": "Carga promedio de CPU (1 min / 5 min / 15 min)",
+  "chipTooltipCpuUsage": "Uso de CPU",
+  "chipTooltipRamUsage": "Uso de RAM",
+  "chipTooltipCpuTemperature": "Temperatura de CPU",
+  "chipTooltipSystemUptime": "Tiempo de actividad del sistema"
 }

--- a/lib/ui/core/l10n/app_ja.arb
+++ b/lib/ui/core/l10n/app_ja.arb
@@ -731,5 +731,11 @@
   },
   "unverifiedCertificatesBannerExpand": "展開",
   "unverifiedCertificatesBannerCollapse": "閉じる",
-  "unverifiedCertificatesBannerLearnMore": "詳しく見る"
+  "unverifiedCertificatesBannerLearnMore": "詳しく見る",
+  "chipTooltipQueriesPerMinute": "1分あたりのクエリ数",
+  "chipTooltipCpuLoadAverage": "CPU負荷平均 (1分 / 5分 / 15分)",
+  "chipTooltipCpuUsage": "CPU使用率",
+  "chipTooltipRamUsage": "メモリ使用率",
+  "chipTooltipCpuTemperature": "CPU温度",
+  "chipTooltipSystemUptime": "システム稼働時間"
 }

--- a/lib/ui/core/l10n/app_pl.arb
+++ b/lib/ui/core/l10n/app_pl.arb
@@ -729,5 +729,11 @@
   "domainsWhitelist": "Domeny (biała lista)",
   "domainsBlacklist": "Domeny (czarna lista)",
   "adlistsAllow": "Adlisty (dozwolone)",
-  "adlistsBlock": "Adlisty (blokowane)"
+  "adlistsBlock": "Adlisty (blokowane)",
+  "chipTooltipQueriesPerMinute": "Zapytania na minutę",
+  "chipTooltipCpuLoadAverage": "Średnie obciążenie CPU (1 min / 5 min / 15 min)",
+  "chipTooltipCpuUsage": "Użycie CPU",
+  "chipTooltipRamUsage": "Użycie RAM",
+  "chipTooltipCpuTemperature": "Temperatura CPU",
+  "chipTooltipSystemUptime": "Czas działania systemu"
 }

--- a/lib/ui/core/l10n/generated/app_localizations.dart
+++ b/lib/ui/core/l10n/generated/app_localizations.dart
@@ -4393,6 +4393,42 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Learn more'**
   String get unverifiedCertificatesBannerLearnMore;
+
+  /// No description provided for @chipTooltipQueriesPerMinute.
+  ///
+  /// In en, this message translates to:
+  /// **'Queries per minute'**
+  String get chipTooltipQueriesPerMinute;
+
+  /// No description provided for @chipTooltipCpuLoadAverage.
+  ///
+  /// In en, this message translates to:
+  /// **'CPU load average (1m / 5m / 15m)'**
+  String get chipTooltipCpuLoadAverage;
+
+  /// No description provided for @chipTooltipCpuUsage.
+  ///
+  /// In en, this message translates to:
+  /// **'CPU usage'**
+  String get chipTooltipCpuUsage;
+
+  /// No description provided for @chipTooltipRamUsage.
+  ///
+  /// In en, this message translates to:
+  /// **'RAM usage'**
+  String get chipTooltipRamUsage;
+
+  /// No description provided for @chipTooltipCpuTemperature.
+  ///
+  /// In en, this message translates to:
+  /// **'CPU temperature'**
+  String get chipTooltipCpuTemperature;
+
+  /// No description provided for @chipTooltipSystemUptime.
+  ///
+  /// In en, this message translates to:
+  /// **'System uptime'**
+  String get chipTooltipSystemUptime;
 }
 
 class _AppLocalizationsDelegate

--- a/lib/ui/core/l10n/generated/app_localizations_de.dart
+++ b/lib/ui/core/l10n/generated/app_localizations_de.dart
@@ -2300,4 +2300,23 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get unverifiedCertificatesBannerLearnMore => 'Mehr erfahren';
+
+  @override
+  String get chipTooltipQueriesPerMinute => 'Anfragen pro Minute';
+
+  @override
+  String get chipTooltipCpuLoadAverage =>
+      'CPU-Lastdurchschnitt (1 Min / 5 Min / 15 Min)';
+
+  @override
+  String get chipTooltipCpuUsage => 'CPU-Auslastung';
+
+  @override
+  String get chipTooltipRamUsage => 'RAM-Auslastung';
+
+  @override
+  String get chipTooltipCpuTemperature => 'CPU-Temperatur';
+
+  @override
+  String get chipTooltipSystemUptime => 'Systemlaufzeit';
 }

--- a/lib/ui/core/l10n/generated/app_localizations_en.dart
+++ b/lib/ui/core/l10n/generated/app_localizations_en.dart
@@ -2264,4 +2264,22 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get unverifiedCertificatesBannerLearnMore => 'Learn more';
+
+  @override
+  String get chipTooltipQueriesPerMinute => 'Queries per minute';
+
+  @override
+  String get chipTooltipCpuLoadAverage => 'CPU load average (1m / 5m / 15m)';
+
+  @override
+  String get chipTooltipCpuUsage => 'CPU usage';
+
+  @override
+  String get chipTooltipRamUsage => 'RAM usage';
+
+  @override
+  String get chipTooltipCpuTemperature => 'CPU temperature';
+
+  @override
+  String get chipTooltipSystemUptime => 'System uptime';
 }

--- a/lib/ui/core/l10n/generated/app_localizations_es.dart
+++ b/lib/ui/core/l10n/generated/app_localizations_es.dart
@@ -2294,4 +2294,23 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String get unverifiedCertificatesBannerLearnMore => 'Más información';
+
+  @override
+  String get chipTooltipQueriesPerMinute => 'Consultas por minuto';
+
+  @override
+  String get chipTooltipCpuLoadAverage =>
+      'Carga promedio de CPU (1 min / 5 min / 15 min)';
+
+  @override
+  String get chipTooltipCpuUsage => 'Uso de CPU';
+
+  @override
+  String get chipTooltipRamUsage => 'Uso de RAM';
+
+  @override
+  String get chipTooltipCpuTemperature => 'Temperatura de CPU';
+
+  @override
+  String get chipTooltipSystemUptime => 'Tiempo de actividad del sistema';
 }

--- a/lib/ui/core/l10n/generated/app_localizations_ja.dart
+++ b/lib/ui/core/l10n/generated/app_localizations_ja.dart
@@ -2206,4 +2206,22 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String get unverifiedCertificatesBannerLearnMore => '詳しく見る';
+
+  @override
+  String get chipTooltipQueriesPerMinute => '1分あたりのクエリ数';
+
+  @override
+  String get chipTooltipCpuLoadAverage => 'CPU負荷平均 (1分 / 5分 / 15分)';
+
+  @override
+  String get chipTooltipCpuUsage => 'CPU使用率';
+
+  @override
+  String get chipTooltipRamUsage => 'メモリ使用率';
+
+  @override
+  String get chipTooltipCpuTemperature => 'CPU温度';
+
+  @override
+  String get chipTooltipSystemUptime => 'システム稼働時間';
 }

--- a/lib/ui/core/l10n/generated/app_localizations_pl.dart
+++ b/lib/ui/core/l10n/generated/app_localizations_pl.dart
@@ -2280,4 +2280,23 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String get unverifiedCertificatesBannerLearnMore => 'Dowiedz się więcej';
+
+  @override
+  String get chipTooltipQueriesPerMinute => 'Zapytania na minutę';
+
+  @override
+  String get chipTooltipCpuLoadAverage =>
+      'Średnie obciążenie CPU (1 min / 5 min / 15 min)';
+
+  @override
+  String get chipTooltipCpuUsage => 'Użycie CPU';
+
+  @override
+  String get chipTooltipRamUsage => 'Użycie RAM';
+
+  @override
+  String get chipTooltipCpuTemperature => 'Temperatura CPU';
+
+  @override
+  String get chipTooltipSystemUptime => 'Czas działania systemu';
 }

--- a/lib/ui/core/themes/theme.dart
+++ b/lib/ui/core/themes/theme.dart
@@ -342,8 +342,9 @@ class GraphColors extends ThemeExtension<GraphColors> {
   }
 
   Color getColor(int index, [Color? defaultColor]) {
-    if (colors.isEmpty)
+    if (colors.isEmpty) {
       return defaultColor ?? const Color.fromARGB(255, 46, 44, 44);
+    }
     if (index < 0) return defaultColor ?? Colors.black;
     return colors[index % colors.length];
   }

--- a/lib/ui/core/themes/theme.dart
+++ b/lib/ui/core/themes/theme.dart
@@ -342,9 +342,61 @@ class GraphColors extends ThemeExtension<GraphColors> {
   }
 
   Color getColor(int index, [Color? defaultColor]) {
-    if (colors.isEmpty) return defaultColor ?? Colors.black;
+    if (colors.isEmpty)
+      return defaultColor ?? const Color.fromARGB(255, 46, 44, 44);
     if (index < 0) return defaultColor ?? Colors.black;
     return colors[index % colors.length];
+  }
+
+  Color getColorByTheme(String themeName, [Color? defaultColor]) {
+    switch (themeName) {
+      case 'blue':
+        return colors[0];
+      case 'red':
+        return colors[1];
+      case 'amber':
+        return colors[2];
+      case 'green':
+        return colors[3];
+      case 'cyan':
+        return colors[4];
+      case 'blueGrey':
+        return colors[5];
+      case 'deepPurple':
+        return colors[6];
+      case 'orange':
+        return colors[7];
+      case 'lightBlue':
+        return colors[8];
+      case 'brown':
+        return colors[9];
+      case 'deepOrange':
+        return colors[10];
+      case 'amberAccent':
+        return colors[11];
+      case 'blueAccent':
+        return colors[12];
+      case 'lightGreen':
+        return colors[13];
+      case 'indigo':
+        return colors[14];
+      case 'redAccent':
+        return colors[15];
+      case 'yellowAccent':
+        return colors[16];
+      case 'purple':
+        return colors[17];
+      case 'limeAccent':
+        return colors[18];
+      case 'teal':
+        return colors[19];
+      case 'pink':
+        return colors[20];
+      case 'greenAccent':
+        return colors[21];
+      default:
+        return defaultColor ?? Colors.black;
+    }
   }
 }
 

--- a/lib/ui/core/view_models/status_viewmodel.dart
+++ b/lib/ui/core/view_models/status_viewmodel.dart
@@ -7,6 +7,8 @@ import 'package:pi_hole_client/data/repositories/api/interfaces/metrics_reposito
 import 'package:pi_hole_client/data/repositories/api/interfaces/realtime_status_repository.dart';
 import 'package:pi_hole_client/domain/model/enums.dart';
 import 'package:pi_hole_client/domain/model/ftl/metrics.dart';
+import 'package:pi_hole_client/domain/model/ftl/sensor.dart';
+import 'package:pi_hole_client/domain/model/ftl/system.dart';
 import 'package:pi_hole_client/domain/model/overtime/overtime.dart';
 import 'package:pi_hole_client/domain/model/realtime_status/realtime_status.dart';
 import 'package:pi_hole_client/domain/model/server/api_versions.dart';
@@ -52,6 +54,8 @@ class StatusViewModel with ChangeNotifier {
   RealtimeStatus? _realtimeStatus;
   OverTime? _overtimeData;
   FtlDnsMetrics? _ftlDnsMetrics;
+  FtlSystem? _ftlSystem;
+  FtlSensor? _ftlSensor;
 
   // ---------------------------------------------------------------------------
   // Timer management
@@ -81,6 +85,16 @@ class StatusViewModel with ChangeNotifier {
   DnsCache? get getDnsCache => _ftlDnsMetrics?.cache;
 
   DnsReplies? get getDnsReplies => _ftlDnsMetrics?.replies;
+
+  FtlSystem? get getFtlSystem => _ftlSystem;
+
+  FtlSensor? get getFtlSensor => _ftlSensor;
+
+  double? get getQueriesPerMinute {
+    final freq = _realtimeStatus?.summary.frequency;
+    if (freq == null) return null;
+    return freq * 60;
+  }
 
   LoadStatus get getOvertimeDataLoadStatus => _overtimeDataLoading;
 
@@ -157,6 +171,8 @@ class StatusViewModel with ChangeNotifier {
       _realtimeStatus = null;
       _overtimeData = null;
       _ftlDnsMetrics = null;
+      _ftlSystem = null;
+      _ftlSensor = null;
       // When auto-refresh was already running (e.g. ServerConnectionService
       // just set serverStatus=loaded and called startAutoRefresh), preserve
       // _serverStatus to avoid a visible "disconnected" flicker.  The
@@ -305,7 +321,7 @@ class StatusViewModel with ChangeNotifier {
     // _fetchStatusData issues multiple HTTP requests, so we start it
     // immediately to give it a head start. The others are slightly delayed
     // to avoid overwhelming the connection pool.
-    final (statusOk, overtimeOk, metricsOk) = await (
+    final (statusOk, overtimeOk, metricsOk, _) = await (
       _fetchStatusData(),
       Future.delayed(
         const Duration(milliseconds: 100),
@@ -313,6 +329,9 @@ class StatusViewModel with ChangeNotifier {
       Future.delayed(
         const Duration(milliseconds: 100),
       ).then((_) => _fetchMetricsData()),
+      Future.delayed(
+        const Duration(milliseconds: 100),
+      ).then((_) => _fetchSlowSystemData()),
     ).wait;
 
     if (statusOk && overtimeOk && metricsOk) {
@@ -417,6 +436,22 @@ class StatusViewModel with ChangeNotifier {
         return false;
       },
     );
+  }
+
+  // Fetched at overtime-timer frequency (slow): system stats + temperature
+  Future<bool> _fetchSlowSystemData() async {
+    if (_selectedServerAddress == null) return false;
+    final ftlRepo = _ftlRepository;
+    if (ftlRepo == null) return false;
+
+    final (systemResult, sensorResult) = await (
+      ftlRepo.fetchInfoSystem(),
+      ftlRepo.fetchInfoSensors(),
+    ).wait;
+
+    systemResult.fold((system) => _ftlSystem = system, (_) {});
+    sensorResult.fold((sensor) => _ftlSensor = sensor, (_) {});
+    return true;
   }
 
   // ---------------------------------------------------------------------------
@@ -535,7 +570,10 @@ class StatusViewModel with ChangeNotifier {
       final metricsRepo = _metricsRepository;
       if (metricsRepo == null) return;
 
-      final result = await metricsRepo.fetchOverTime();
+      final (result, _) = await (
+        metricsRepo.fetchOverTime(),
+        _fetchSlowSystemData(),
+      ).wait;
 
       if (_selectedServerAddress != selectedUrlBefore) {
         logger.d(

--- a/lib/ui/home/widgets/home_appbar.dart
+++ b/lib/ui/home/widgets/home_appbar.dart
@@ -20,6 +20,7 @@ class HomeAppBar extends StatelessWidget implements PreferredSizeWidget {
       leading: const AdBlockStatusIcon(),
       title: const ServerLabel(),
       actions: const [ServerActionsMenu()],
+      expandedHeight: 140,
     );
   }
 }

--- a/lib/ui/home/widgets/home_screen.dart
+++ b/lib/ui/home/widgets/home_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:pi_hole_client/domain/model/enums.dart';
+import 'package:pi_hole_client/domain/model/server/api_versions.dart';
 import 'package:pi_hole_client/ui/core/actions/refresh_server_status.dart';
 import 'package:pi_hole_client/ui/core/actions/server_management.dart';
 import 'package:pi_hole_client/ui/core/ui/helpers/responsive.dart';
@@ -119,8 +120,14 @@ class _HomeScreenState extends State<HomeScreen> {
                               ),
                               SliverList.list(
                                 children: [
-                                  const ServerStatusChips(),
-                                  const SizedBox(height: 24),
+                                  // Chips data is not available for V5, so it is not displayed
+                                  if (serversViewModel
+                                          .selectedServer
+                                          ?.apiVersion !=
+                                      SupportedApiVersions.v5) ...[
+                                    const ServerStatusChips(),
+                                    const SizedBox(height: 24),
+                                  ],
                                   HomeTiles(width: width),
                                   const SizedBox(height: 24),
                                   const HomeCharts(),

--- a/lib/ui/home/widgets/home_screen.dart
+++ b/lib/ui/home/widgets/home_screen.dart
@@ -11,6 +11,7 @@ import 'package:pi_hole_client/ui/home/widgets/disable_modal.dart';
 import 'package:pi_hole_client/ui/home/widgets/home_appbar.dart';
 import 'package:pi_hole_client/ui/home/widgets/home_charts.dart';
 import 'package:pi_hole_client/ui/home/widgets/home_tiles.dart';
+import 'package:pi_hole_client/ui/home/widgets/server_status_chips.dart';
 import 'package:provider/provider.dart';
 
 class HomeScreen extends StatefulWidget {
@@ -118,6 +119,8 @@ class _HomeScreenState extends State<HomeScreen> {
                               ),
                               SliverList.list(
                                 children: [
+                                  const ServerStatusChips(),
+                                  const SizedBox(height: 24),
                                   HomeTiles(width: width),
                                   const SizedBox(height: 24),
                                   const HomeCharts(),

--- a/lib/ui/home/widgets/server_status_chips.dart
+++ b/lib/ui/home/widgets/server_status_chips.dart
@@ -1,0 +1,217 @@
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:pi_hole_client/domain/model/enums.dart';
+import 'package:pi_hole_client/ui/core/l10n/generated/app_localizations.dart';
+import 'package:pi_hole_client/ui/core/themes/theme.dart';
+import 'package:pi_hole_client/ui/core/view_models/status_viewmodel.dart';
+import 'package:pi_hole_client/utils/conversions.dart';
+import 'package:provider/provider.dart';
+import 'package:skeletonizer/skeletonizer.dart';
+
+class ServerStatusChips extends StatelessWidget {
+  const ServerStatusChips({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final statusLoading = context.select<StatusViewModel, LoadStatus>(
+      (provider) => provider.getStatusLoading,
+    );
+    final isLoading = statusLoading == LoadStatus.loading;
+
+    final locale = Platform.localeName;
+    final theme = Theme.of(context).extension<GraphColors>()!;
+    final loc = AppLocalizations.of(context)!;
+
+    return SizedBox(
+      height: 32,
+      child: Skeletonizer(
+        enabled: isLoading,
+        effect: ShimmerEffect(
+          baseColor: Theme.of(context).colorScheme.secondaryContainer,
+          highlightColor: Theme.of(context).colorScheme.surface,
+        ),
+        child: Stack(
+          children: [
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 18),
+              child: ListView.separated(
+                scrollDirection: Axis.horizontal,
+                physics: const BouncingScrollPhysics(),
+                itemCount: 6,
+                separatorBuilder: (_, __) => const SizedBox(width: 8),
+                itemBuilder: (context, index) {
+                  return switch (index) {
+                    0 => _StatusChip(
+                      icon: Icons.trending_up_rounded,
+                      iconColor: theme.getColorByTheme('blue'),
+                      labelSelector: (context) {
+                        return context.select<StatusViewModel, String>((
+                          provider,
+                        ) {
+                          // final qpm = provider.getQueriesPerMinute;
+                          final qpm = 1.6 * 60; // Fake QPM for demo purposes
+                          return '$qpm q/min';
+                        });
+                      },
+                    ),
+                    1 => _StatusChip(
+                      icon: Icons.speed_rounded,
+                      iconColor: theme.getColorByTheme('purple'),
+                      labelSelector: (context) {
+                        return context.select<StatusViewModel, String>((
+                          provider,
+                        ) {
+                          // final load = provider.getSystemStatus?.loadAverage;
+                          final load = [
+                            0.42,
+                            0.37,
+                            0.31,
+                          ]; // Fake load for demo purposes 1m, 5m, 15m
+                          return 'Load ${load[0].toStringAsFixed(2)}/${load[1].toStringAsFixed(2)}/${load[2].toStringAsFixed(2)}';
+                        });
+                      },
+                    ),
+                    2 => _StatusChip(
+                      icon: Icons.memory_rounded,
+                      iconColor: theme.getColorByTheme('green'),
+                      labelSelector: (context) {
+                        return context.select<StatusViewModel, String>((
+                          provider,
+                        ) {
+                          // final cpu = provider.getSystemStatus?.cpuUsage;
+                          final cpu = 27.3; // Fake CPU usage for demo purposes
+                          return 'CPU ${formatPercentage(cpu, locale)}%';
+                        });
+                      },
+                    ),
+                    3 => _StatusChip(
+                      icon: Icons.developer_board_rounded,
+                      iconColor: theme.getColorByTheme('teal'),
+                      labelSelector: (context) {
+                        return context.select<StatusViewModel, String>((
+                          provider,
+                        ) {
+                          // final ram = provider.getSystemStatus?.memoryUsage;
+                          final ram = 18.5; // Fake RAM usage for demo purposes
+                          return 'RAM ${formatPercentage(ram, locale)}%';
+                        });
+                      },
+                    ),
+                    4 => _StatusChip(
+                      icon: Icons.thermostat_rounded,
+                      iconColor: theme.getColorByTheme('orange'),
+                      labelSelector: (context) {
+                        return context.select<StatusViewModel, String>((
+                          provider,
+                        ) {
+                          // final temp = provider.getSystemStatus?.cpuTemperature;
+                          final temp =
+                              48.0; // Fake temperature for demo purposes
+                          return '${temp.toStringAsFixed(0)}°C';
+                        });
+                      },
+                    ),
+                    _ => _StatusChip(
+                      icon: Icons.schedule_rounded,
+                      iconColor: theme.getColorByTheme('indigo'),
+                      labelSelector: (context) {
+                        return context.select<StatusViewModel, String>((
+                          provider,
+                        ) {
+                          // final uptime = provider.getSystemStatus?.uptime;
+                          // use same serverinfo uptime func
+                          final uptime =
+                              1234567; // Fake uptime for demo purposes
+                          return 'Up ${Duration(seconds: uptime).inDays}d ${Duration(seconds: uptime).inHours % 24}h ${Duration(seconds: uptime).inMinutes % 60}m';
+                        });
+                      },
+                    ),
+                  };
+                },
+              ),
+            ),
+            const _RightFade(),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _RightFade extends StatelessWidget {
+  const _RightFade();
+
+  @override
+  Widget build(BuildContext context) {
+    final color = Theme.of(context).scaffoldBackgroundColor;
+
+    return Positioned(
+      top: 0,
+      right: 0,
+      bottom: 0,
+      child: IgnorePointer(
+        child: Container(
+          width: 64,
+          decoration: BoxDecoration(
+            gradient: LinearGradient(
+              colors: [color.withValues(alpha: 0), color],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _StatusChip extends StatelessWidget {
+  const _StatusChip({
+    required this.icon,
+    required this.iconColor,
+    required this.labelSelector,
+  });
+
+  final IconData icon;
+  final Color iconColor;
+  final String Function(BuildContext context) labelSelector;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final isDark = theme.brightness == Brightness.dark;
+    final label = labelSelector(context);
+
+    return Container(
+      height: 36,
+      padding: const EdgeInsets.symmetric(horizontal: 12),
+      decoration: BoxDecoration(
+        color: isDark
+            ? Colors.white.withValues(alpha: 0.06)
+            : Colors.black.withValues(alpha: 0.04),
+        borderRadius: BorderRadius.circular(18),
+        border: Border.all(
+          color: isDark
+              ? Colors.white.withValues(alpha: 0.12)
+              : Colors.black.withValues(alpha: 0.10),
+        ),
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Icon(icon, size: 17, color: iconColor),
+          const SizedBox(width: 6),
+          Text(
+            label,
+            style: theme.textTheme.labelMedium?.copyWith(
+              color: isDark
+                  ? Colors.white.withValues(alpha: 0.92)
+                  : Colors.black.withValues(alpha: 0.82),
+              fontWeight: FontWeight.w600,
+              letterSpacing: 0.1,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/ui/home/widgets/server_status_chips.dart
+++ b/lib/ui/home/widgets/server_status_chips.dart
@@ -84,20 +84,14 @@ class ServerStatusChips extends StatelessWidget {
         icon: Icons.thermostat_rounded,
         color: graphColors.getColorByTheme('orange'),
         tooltip: loc.chipTooltipCpuTemperature,
-        label: sensor?.cpuTemp == null
-            ? 'Temp -$tempUnitSymbol'
-            : 'Temp ${sensor!.cpuTemp!.toStringAsFixed(1)}$tempUnitSymbol',
+        label:
+            'Temp ${sensor?.cpuTemp?.toStringAsFixed(1) ?? '-'}$tempUnitSymbol',
       ),
       (
         icon: Icons.schedule_rounded,
         color: graphColors.getColorByTheme('indigo'),
         tooltip: loc.chipTooltipSystemUptime,
-        label: uptime == null
-            ? 'Up -'
-            : () {
-                final d = Duration(seconds: uptime);
-                return 'Up ${d.inDays}d ${d.inHours % 24}h ${d.inMinutes % 60}m';
-              }(),
+        label: _formatUptime(uptime),
       ),
     ];
 
@@ -135,6 +129,12 @@ class ServerStatusChips extends StatelessWidget {
       ),
     );
   }
+}
+
+String _formatUptime(int? uptime) {
+  if (uptime == null) return 'Up -';
+  final d = Duration(seconds: uptime);
+  return 'Up ${d.inDays}d ${d.inHours % 24}h ${d.inMinutes % 60}m';
 }
 
 class _RightFade extends StatelessWidget {

--- a/lib/ui/home/widgets/server_status_chips.dart
+++ b/lib/ui/home/widgets/server_status_chips.dart
@@ -2,6 +2,8 @@ import 'dart:io';
 
 import 'package:flutter/material.dart';
 import 'package:pi_hole_client/domain/model/enums.dart';
+import 'package:pi_hole_client/domain/model/ftl/sensor.dart';
+import 'package:pi_hole_client/domain/model/ftl/system.dart';
 import 'package:pi_hole_client/ui/core/l10n/generated/app_localizations.dart';
 import 'package:pi_hole_client/ui/core/themes/theme.dart';
 import 'package:pi_hole_client/ui/core/view_models/status_viewmodel.dart';
@@ -20,7 +22,84 @@ class ServerStatusChips extends StatelessWidget {
     final isLoading = statusLoading == LoadStatus.loading;
 
     final locale = Platform.localeName;
-    final theme = Theme.of(context).extension<GraphColors>()!;
+    final graphColors = Theme.of(context).extension<GraphColors>()!;
+    final loc = AppLocalizations.of(context)!;
+
+    final qpm = context.select<StatusViewModel, double?>(
+      (p) => p.getQueriesPerMinute,
+    );
+    final cpuLoad = context.select<StatusViewModel, CpuLoad?>(
+      (p) => p.getFtlSystem?.cpuLoad,
+    );
+    final cpuUsage = context.select<StatusViewModel, double?>(
+      (p) => p.getFtlSystem?.cpuUsage,
+    );
+    final ramUsage = context.select<StatusViewModel, double?>(
+      (p) => p.getFtlSystem?.ramUsage,
+    );
+    final sensor = context.select<StatusViewModel, FtlSensor?>(
+      (p) => p.getFtlSensor,
+    );
+    final uptime = context.select<StatusViewModel, int?>(
+      (p) => p.getFtlSystem?.uptime,
+    );
+
+    final tempUnitSymbol = switch (sensor?.unit) {
+      TemperatureUnit.fahrenheit => '°F',
+      TemperatureUnit.kelvin => 'K',
+      _ => '°C',
+    };
+
+    final chips = [
+      (
+        icon: Icons.trending_up_rounded,
+        color: graphColors.getColorByTheme('blue'),
+        tooltip: loc.chipTooltipQueriesPerMinute,
+        label:
+            qpm == null ? '- q/min' : '${qpm.toStringAsFixed(1)} q/min',
+      ),
+      (
+        icon: Icons.speed_rounded,
+        color: graphColors.getColorByTheme('purple'),
+        tooltip: loc.chipTooltipCpuLoadAverage,
+        label: cpuLoad == null
+            ? 'Load -/-/-'
+            : 'Load ${cpuLoad.avg1m.toStringAsFixed(2)}/${cpuLoad.avg5m.toStringAsFixed(2)}/${cpuLoad.avg15m.toStringAsFixed(2)}',
+      ),
+      (
+        icon: Icons.memory_rounded,
+        color: graphColors.getColorByTheme('green'),
+        tooltip: loc.chipTooltipCpuUsage,
+        label:
+            cpuUsage == null ? 'CPU -%' : 'CPU ${formatPercentage(cpuUsage, locale)}%',
+      ),
+      (
+        icon: Icons.developer_board_rounded,
+        color: graphColors.getColorByTheme('teal'),
+        tooltip: loc.chipTooltipRamUsage,
+        label:
+            ramUsage == null ? 'RAM -%' : 'RAM ${formatPercentage(ramUsage, locale)}%',
+      ),
+      (
+        icon: Icons.thermostat_rounded,
+        color: graphColors.getColorByTheme('orange'),
+        tooltip: loc.chipTooltipCpuTemperature,
+        label: sensor?.cpuTemp == null
+            ? 'Temp -$tempUnitSymbol'
+            : 'Temp ${sensor!.cpuTemp!.toStringAsFixed(1)}$tempUnitSymbol',
+      ),
+      (
+        icon: Icons.schedule_rounded,
+        color: graphColors.getColorByTheme('indigo'),
+        tooltip: loc.chipTooltipSystemUptime,
+        label: uptime == null
+            ? 'Up -'
+            : () {
+                final d = Duration(seconds: uptime);
+                return 'Up ${d.inDays}d ${d.inHours % 24}h ${d.inMinutes % 60}m';
+              }(),
+      ),
+    ];
 
     return SizedBox(
       height: 32,
@@ -37,103 +116,16 @@ class ServerStatusChips extends StatelessWidget {
               child: ListView.separated(
                 scrollDirection: Axis.horizontal,
                 physics: const BouncingScrollPhysics(),
-                itemCount: 6,
+                itemCount: chips.length,
                 separatorBuilder: (_, _) => const SizedBox(width: 8),
                 itemBuilder: (context, index) {
-                  final loc = AppLocalizations.of(context)!;
-                  return switch (index) {
-                    0 => _StatusChip(
-                      icon: Icons.trending_up_rounded,
-                      iconColor: theme.getColorByTheme('blue'),
-                      tooltip: loc.chipTooltipQueriesPerMinute,
-                      labelSelector: (context) {
-                        return context.select<StatusViewModel, String>((
-                          provider,
-                        ) {
-                          final qpm = provider.getQueriesPerMinute;
-                          if (qpm == null) return '- q/min';
-                          return '${qpm.toStringAsFixed(1)} q/min';
-                        });
-                      },
-                    ),
-                    1 => _StatusChip(
-                      icon: Icons.speed_rounded,
-                      iconColor: theme.getColorByTheme('purple'),
-                      tooltip: loc.chipTooltipCpuLoadAverage,
-                      labelSelector: (context) {
-                        return context.select<StatusViewModel, String>((
-                          provider,
-                        ) {
-                          final load = provider.getFtlSystem?.cpuLoad;
-                          if (load == null) return 'Load -/-/-';
-                          return 'Load ${load.avg1m.toStringAsFixed(2)}/${load.avg5m.toStringAsFixed(2)}/${load.avg15m.toStringAsFixed(2)}';
-                        });
-                      },
-                    ),
-                    2 => _StatusChip(
-                      icon: Icons.memory_rounded,
-                      iconColor: theme.getColorByTheme('green'),
-                      tooltip: loc.chipTooltipCpuUsage,
-                      labelSelector: (context) {
-                        return context.select<StatusViewModel, String>((
-                          provider,
-                        ) {
-                          final cpu = provider.getFtlSystem?.cpuUsage;
-                          if (cpu == null) return 'CPU -%';
-                          return 'CPU ${formatPercentage(cpu, locale)}%';
-                        });
-                      },
-                    ),
-                    3 => _StatusChip(
-                      icon: Icons.developer_board_rounded,
-                      iconColor: theme.getColorByTheme('teal'),
-                      tooltip: loc.chipTooltipRamUsage,
-                      labelSelector: (context) {
-                        return context.select<StatusViewModel, String>((
-                          provider,
-                        ) {
-                          final ram = provider.getFtlSystem?.ramUsage;
-                          if (ram == null) return 'RAM -%';
-                          return 'RAM ${formatPercentage(ram, locale)}%';
-                        });
-                      },
-                    ),
-                    4 => _StatusChip(
-                      icon: Icons.thermostat_rounded,
-                      iconColor: theme.getColorByTheme('orange'),
-                      tooltip: loc.chipTooltipCpuTemperature,
-                      labelSelector: (context) {
-                        return context.select<StatusViewModel, String>((
-                          provider,
-                        ) {
-                          final sensor = provider.getFtlSensor;
-                          final temp = sensor?.cpuTemp;
-                          final unitSymbol = switch (sensor?.unit) {
-                            TemperatureUnit.fahrenheit => '°F',
-                            TemperatureUnit.kelvin => 'K',
-                            _ => '°C',
-                          };
-                          if (temp == null) return 'Temp -$unitSymbol';
-                          return 'Temp ${temp.toStringAsFixed(1)}$unitSymbol';
-                        });
-                      },
-                    ),
-                    _ => _StatusChip(
-                      icon: Icons.schedule_rounded,
-                      iconColor: theme.getColorByTheme('indigo'),
-                      tooltip: loc.chipTooltipSystemUptime,
-                      labelSelector: (context) {
-                        return context.select<StatusViewModel, String>((
-                          provider,
-                        ) {
-                          final uptime = provider.getFtlSystem?.uptime;
-                          if (uptime == null) return 'Up -';
-                          final d = Duration(seconds: uptime);
-                          return 'Up ${d.inDays}d ${d.inHours % 24}h ${d.inMinutes % 60}m';
-                        });
-                      },
-                    ),
-                  };
+                  final chip = chips[index];
+                  return _StatusChip(
+                    icon: chip.icon,
+                    iconColor: chip.color,
+                    tooltip: chip.tooltip,
+                    label: chip.label,
+                  );
                 },
               ),
             ),
@@ -175,19 +167,18 @@ class _StatusChip extends StatelessWidget {
     required this.icon,
     required this.iconColor,
     required this.tooltip,
-    required this.labelSelector,
+    required this.label,
   });
 
   final IconData icon;
   final Color iconColor;
   final String tooltip;
-  final String Function(BuildContext context) labelSelector;
+  final String label;
 
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final cs = theme.colorScheme;
-    final label = labelSelector(context);
 
     return Tooltip(
       message: tooltip,

--- a/lib/ui/home/widgets/server_status_chips.dart
+++ b/lib/ui/home/widgets/server_status_chips.dart
@@ -21,7 +21,6 @@ class ServerStatusChips extends StatelessWidget {
 
     final locale = Platform.localeName;
     final theme = Theme.of(context).extension<GraphColors>()!;
-    final loc = AppLocalizations.of(context)!;
 
     return SizedBox(
       height: 32,
@@ -39,48 +38,48 @@ class ServerStatusChips extends StatelessWidget {
                 scrollDirection: Axis.horizontal,
                 physics: const BouncingScrollPhysics(),
                 itemCount: 6,
-                separatorBuilder: (_, __) => const SizedBox(width: 8),
+                separatorBuilder: (_, _) => const SizedBox(width: 8),
                 itemBuilder: (context, index) {
+                  final loc = AppLocalizations.of(context)!;
                   return switch (index) {
                     0 => _StatusChip(
                       icon: Icons.trending_up_rounded,
                       iconColor: theme.getColorByTheme('blue'),
+                      tooltip: loc.chipTooltipQueriesPerMinute,
                       labelSelector: (context) {
                         return context.select<StatusViewModel, String>((
                           provider,
                         ) {
-                          // final qpm = provider.getQueriesPerMinute;
-                          final qpm = 1.6 * 60; // Fake QPM for demo purposes
-                          return '$qpm q/min';
+                          final qpm = provider.getQueriesPerMinute;
+                          if (qpm == null) return '- q/min';
+                          return '${qpm.toStringAsFixed(1)} q/min';
                         });
                       },
                     ),
                     1 => _StatusChip(
                       icon: Icons.speed_rounded,
                       iconColor: theme.getColorByTheme('purple'),
+                      tooltip: loc.chipTooltipCpuLoadAverage,
                       labelSelector: (context) {
                         return context.select<StatusViewModel, String>((
                           provider,
                         ) {
-                          // final load = provider.getSystemStatus?.loadAverage;
-                          final load = [
-                            0.42,
-                            0.37,
-                            0.31,
-                          ]; // Fake load for demo purposes 1m, 5m, 15m
-                          return 'Load ${load[0].toStringAsFixed(2)}/${load[1].toStringAsFixed(2)}/${load[2].toStringAsFixed(2)}';
+                          final load = provider.getFtlSystem?.cpuLoad;
+                          if (load == null) return 'Load -/-/-';
+                          return 'Load ${load.avg1m.toStringAsFixed(2)}/${load.avg5m.toStringAsFixed(2)}/${load.avg15m.toStringAsFixed(2)}';
                         });
                       },
                     ),
                     2 => _StatusChip(
                       icon: Icons.memory_rounded,
                       iconColor: theme.getColorByTheme('green'),
+                      tooltip: loc.chipTooltipCpuUsage,
                       labelSelector: (context) {
                         return context.select<StatusViewModel, String>((
                           provider,
                         ) {
-                          // final cpu = provider.getSystemStatus?.cpuUsage;
-                          final cpu = 27.3; // Fake CPU usage for demo purposes
+                          final cpu = provider.getFtlSystem?.cpuUsage;
+                          if (cpu == null) return 'CPU -%';
                           return 'CPU ${formatPercentage(cpu, locale)}%';
                         });
                       },
@@ -88,12 +87,13 @@ class ServerStatusChips extends StatelessWidget {
                     3 => _StatusChip(
                       icon: Icons.developer_board_rounded,
                       iconColor: theme.getColorByTheme('teal'),
+                      tooltip: loc.chipTooltipRamUsage,
                       labelSelector: (context) {
                         return context.select<StatusViewModel, String>((
                           provider,
                         ) {
-                          // final ram = provider.getSystemStatus?.memoryUsage;
-                          final ram = 18.5; // Fake RAM usage for demo purposes
+                          final ram = provider.getFtlSystem?.ramUsage;
+                          if (ram == null) return 'RAM -%';
                           return 'RAM ${formatPercentage(ram, locale)}%';
                         });
                       },
@@ -101,29 +101,35 @@ class ServerStatusChips extends StatelessWidget {
                     4 => _StatusChip(
                       icon: Icons.thermostat_rounded,
                       iconColor: theme.getColorByTheme('orange'),
+                      tooltip: loc.chipTooltipCpuTemperature,
                       labelSelector: (context) {
                         return context.select<StatusViewModel, String>((
                           provider,
                         ) {
-                          // final temp = provider.getSystemStatus?.cpuTemperature;
-                          final temp =
-                              48.0; // Fake temperature for demo purposes
-                          return '${temp.toStringAsFixed(0)}°C';
+                          final sensor = provider.getFtlSensor;
+                          final temp = sensor?.cpuTemp;
+                          final unitSymbol = switch (sensor?.unit) {
+                            TemperatureUnit.fahrenheit => '°F',
+                            TemperatureUnit.kelvin => 'K',
+                            _ => '°C',
+                          };
+                          if (temp == null) return 'Temp -$unitSymbol';
+                          return 'Temp ${temp.toStringAsFixed(1)}$unitSymbol';
                         });
                       },
                     ),
                     _ => _StatusChip(
                       icon: Icons.schedule_rounded,
                       iconColor: theme.getColorByTheme('indigo'),
+                      tooltip: loc.chipTooltipSystemUptime,
                       labelSelector: (context) {
                         return context.select<StatusViewModel, String>((
                           provider,
                         ) {
-                          // final uptime = provider.getSystemStatus?.uptime;
-                          // use same serverinfo uptime func
-                          final uptime =
-                              1234567; // Fake uptime for demo purposes
-                          return 'Up ${Duration(seconds: uptime).inDays}d ${Duration(seconds: uptime).inHours % 24}h ${Duration(seconds: uptime).inMinutes % 60}m';
+                          final uptime = provider.getFtlSystem?.uptime;
+                          if (uptime == null) return 'Up -';
+                          final d = Duration(seconds: uptime);
+                          return 'Up ${d.inDays}d ${d.inHours % 24}h ${d.inMinutes % 60}m';
                         });
                       },
                     ),
@@ -168,49 +174,35 @@ class _StatusChip extends StatelessWidget {
   const _StatusChip({
     required this.icon,
     required this.iconColor,
+    required this.tooltip,
     required this.labelSelector,
   });
 
   final IconData icon;
   final Color iconColor;
+  final String tooltip;
   final String Function(BuildContext context) labelSelector;
 
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
-    final isDark = theme.brightness == Brightness.dark;
+    final cs = theme.colorScheme;
     final label = labelSelector(context);
 
-    return Container(
-      height: 36,
-      padding: const EdgeInsets.symmetric(horizontal: 12),
-      decoration: BoxDecoration(
-        color: isDark
-            ? Colors.white.withValues(alpha: 0.06)
-            : Colors.black.withValues(alpha: 0.04),
-        borderRadius: BorderRadius.circular(18),
-        border: Border.all(
-          color: isDark
-              ? Colors.white.withValues(alpha: 0.12)
-              : Colors.black.withValues(alpha: 0.10),
+    return Tooltip(
+      message: tooltip,
+      child: Chip(
+        avatar: Icon(icon, size: 17, color: iconColor),
+        label: Text(label),
+        visualDensity: const VisualDensity(vertical: -4),
+        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(18)),
+        side: BorderSide(color: cs.outlineVariant),
+        backgroundColor: cs.onSurfaceVariant.withValues(alpha: 0.06),
+        labelStyle: theme.textTheme.labelMedium?.copyWith(
+          color: cs.onSurface,
+          fontWeight: FontWeight.w600,
+          letterSpacing: 0.1,
         ),
-      ),
-      child: Row(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          Icon(icon, size: 17, color: iconColor),
-          const SizedBox(width: 6),
-          Text(
-            label,
-            style: theme.textTheme.labelMedium?.copyWith(
-              color: isDark
-                  ? Colors.white.withValues(alpha: 0.92)
-                  : Colors.black.withValues(alpha: 0.82),
-              fontWeight: FontWeight.w600,
-              letterSpacing: 0.1,
-            ),
-          ),
-        ],
       ),
     );
   }

--- a/test/data/mapper/v5/realtime_status_mapper_test.dart
+++ b/test/data/mapper/v5/realtime_status_mapper_test.dart
@@ -80,6 +80,7 @@ void main() {
       expect(domain.summary.clientsEverSeen, 10);
       expect(domain.summary.uniqueClients, 8);
       expect(domain.summary.dnsQueriesAllTypes, 5000);
+      expect(domain.summary.frequency, isNull);
     });
 
     test('maps reply counts correctly', () {

--- a/test/data/mapper/v6/ftl_mapper_test.dart
+++ b/test/data/mapper/v6/ftl_mapper_test.dart
@@ -336,6 +336,10 @@ void main() {
       expect(domain.uptime, 86400);
       expect(domain.ramUsage, 75.0);
       expect(domain.cpuUsage, 30.0);
+      expect(domain.cpuLoad, isNotNull);
+      expect(domain.cpuLoad!.avg1m, 1.0);
+      expect(domain.cpuLoad!.avg5m, 0.8);
+      expect(domain.cpuLoad!.avg15m, 0.6);
     });
 
     test('uses average of load.percent when percentCpu is null', () {
@@ -364,6 +368,7 @@ void main() {
       final domain = source.toDomain();
 
       expect(domain.cpuUsage, closeTo(30.0, 0.001)); // (20 + 40) / 2
+      expect(domain.cpuLoad, isNull);
     });
   });
 }

--- a/test/data/mapper/v6/metrics_mapper_test.dart
+++ b/test/data/mapper/v6/metrics_mapper_test.dart
@@ -70,6 +70,7 @@ const _queries = ss.StatsQueries(
   types: _types,
   status: _status,
   replies: _replies,
+  frequency: 1.5,
 );
 
 const _statsSummary = ss.StatsSummary(

--- a/test/data/services/api/pihole_v6_api_client_test.dart
+++ b/test/data/services/api/pihole_v6_api_client_test.dart
@@ -487,6 +487,7 @@ void main() {
             'NONE': 0,
             'BLOB': 0,
           },
+          'frequency': 1.5,
         },
         'clients': {'active': 10, 'total': 22},
         'gravity': {'domains_being_blocked': 104756, 'last_update': 1725194639},

--- a/test/ui/core/view_models/status_viewmodel_test.dart
+++ b/test/ui/core/view_models/status_viewmodel_test.dart
@@ -151,6 +151,13 @@ void main() {
       expect(vm.getFtlDnsMetrics, isNotNull);
     });
 
+    test('loading -> loaded: chip system/sensor data are populated', () async {
+      expect(vm.getServerStatus, LoadStatus.loading);
+      await vm.refreshOnce();
+      expect(vm.getFtlSystem, isNotNull);
+      expect(vm.getFtlSensor, isNotNull);
+    });
+
     test('loading -> loaded: statusLoading transitions to loaded', () async {
       expect(vm.getStatusLoading, LoadStatus.loading);
       await vm.refreshOnce();
@@ -165,6 +172,15 @@ void main() {
         // kRepoFetchRealTimeStatus has sources: '172.26.0.1' and
         // 'localhost|127.0.0.1'; split('|').first gives hostname or IP.
         expect(vm.topClientNames, containsAll(['172.26.0.1', 'localhost']));
+      },
+    );
+
+    test(
+      'loading -> loaded: getQueriesPerMinute returns frequency * 60 when available',
+      () async {
+        expect(vm.getQueriesPerMinute, isNull);
+        await vm.refreshOnce();
+        expect(vm.getQueriesPerMinute, 90.0);
       },
     );
   });

--- a/test/ui/core/view_models/status_viewmodel_test.dart
+++ b/test/ui/core/view_models/status_viewmodel_test.dart
@@ -180,7 +180,7 @@ void main() {
       () async {
         expect(vm.getQueriesPerMinute, isNull);
         await vm.refreshOnce();
-        expect(vm.getQueriesPerMinute, 90.0);
+        expect(vm.getQueriesPerMinute, isNull);
       },
     );
   });

--- a/test/ui/home/home_test.dart
+++ b/test/ui/home/home_test.dart
@@ -9,6 +9,7 @@ import 'package:pi_hole_client/ui/home/widgets/disable_modal.dart';
 import 'package:pi_hole_client/ui/home/widgets/home_appbar.dart';
 import 'package:pi_hole_client/ui/home/widgets/home_appbar/switch_server_modal.dart';
 import 'package:pi_hole_client/ui/home/widgets/home_screen.dart';
+import 'package:pi_hole_client/ui/home/widgets/server_status_chips.dart';
 import 'package:pi_hole_client/ui/servers/widgets/servers_screen.dart';
 import 'package:skeletonizer/skeletonizer.dart';
 
@@ -26,6 +27,15 @@ const _serverV6 = Server(
   alias: 'test v6',
   defaultServer: false,
   apiVersion: 'v6',
+  allowUntrustedCert: true,
+  ignoreCertificateErrors: false,
+);
+
+const _serverV5 = Server(
+  address: 'http://localhost:8080',
+  alias: 'test v5',
+  defaultServer: false,
+  apiVersion: 'v5',
   allowUntrustedCert: true,
   ignoreCertificateErrors: false,
 );
@@ -103,6 +113,54 @@ void main() async {
 
       // clients graph
       expect(find.text('Client activity last 24 hours'), findsOneWidget);
+    });
+
+    testWidgets('should show status chips for v6 server', (
+      WidgetTester tester,
+    ) async {
+      await tester.pumpWidget(
+        buildTestApp(
+          HomeScreen(
+            serversViewModel: serversViewModel,
+            appConfigViewModel: appConfigViewModel,
+            statusViewModel: statusViewModel,
+          ),
+          appConfigViewModel: appConfigViewModel,
+          serversViewModel: serversViewModel,
+          statusViewModel: statusViewModel,
+          logsViewModel: logsViewModel,
+          repositoryBundle: createFakeRepositoryBundle(),
+        ),
+      );
+
+      await tester.pumpAndSettle();
+      expect(find.byType(ServerStatusChips), findsOneWidget);
+    });
+
+    testWidgets('should hide status chips for v5 server', (
+      WidgetTester tester,
+    ) async {
+      serversViewModel
+        ..selectedServer = _serverV5
+        ..serversList = [_serverV5];
+
+      await tester.pumpWidget(
+        buildTestApp(
+          HomeScreen(
+            serversViewModel: serversViewModel,
+            appConfigViewModel: appConfigViewModel,
+            statusViewModel: statusViewModel,
+          ),
+          appConfigViewModel: appConfigViewModel,
+          serversViewModel: serversViewModel,
+          statusViewModel: statusViewModel,
+          logsViewModel: logsViewModel,
+          repositoryBundle: createFakeRepositoryBundle(apiVersion: 'v5'),
+        ),
+      );
+
+      await tester.pumpAndSettle();
+      expect(find.byType(ServerStatusChips), findsNothing);
     });
 
     testWidgets('should home screen be rendered (loading state)', (

--- a/testing/fakes/viewmodels/fake_status_viewmodel.dart
+++ b/testing/fakes/viewmodels/fake_status_viewmodel.dart
@@ -1,5 +1,7 @@
 import 'package:pi_hole_client/domain/model/enums.dart';
 import 'package:pi_hole_client/domain/model/ftl/metrics.dart';
+import 'package:pi_hole_client/domain/model/ftl/sensor.dart';
+import 'package:pi_hole_client/domain/model/ftl/system.dart';
 import 'package:pi_hole_client/domain/model/overtime/overtime.dart';
 import 'package:pi_hole_client/domain/model/realtime_status/realtime_status.dart';
 import 'package:pi_hole_client/ui/core/view_models/status_viewmodel.dart';
@@ -15,6 +17,8 @@ class FakeStatusViewModel extends StatusViewModel {
   RealtimeStatus? _realtimeStatus;
   OverTime? _overtimeData;
   FtlDnsMetrics? _ftlDnsMetrics;
+  FtlSystem? _ftlSystem;
+  FtlSensor? _ftlSensor;
 
   @override
   LoadStatus get getStatusLoading => _statusLoading;
@@ -42,6 +46,27 @@ class FakeStatusViewModel extends StatusViewModel {
 
   @override
   DnsReplies? get getDnsReplies => _ftlDnsMetrics?.replies;
+
+  @override
+  FtlSystem? get getFtlSystem => _ftlSystem;
+
+  @override
+  FtlSensor? get getFtlSensor => _ftlSensor;
+
+  @override
+  double? get getQueriesPerMinute {
+    final freq = _realtimeStatus?.summary.frequency;
+    if (freq == null) return null;
+    return freq * 60;
+  }
+
+  @override
+  List<String> get topClientNames {
+    if (_realtimeStatus == null) return [];
+    return _realtimeStatus!.topClients.topSources
+        .map((source) => source.source.split('|').first)
+        .toList();
+  }
 
   // Setters for test state
   // ignore_for_file: avoid_setters_without_getters
@@ -72,6 +97,16 @@ class FakeStatusViewModel extends StatusViewModel {
 
   set ftlDnsMetrics(FtlDnsMetrics? value) {
     _ftlDnsMetrics = value;
+    notifyListeners();
+  }
+
+  set ftlSystem(FtlSystem? value) {
+    _ftlSystem = value;
+    notifyListeners();
+  }
+
+  set ftlSensor(FtlSensor? value) {
+    _ftlSensor = value;
     notifyListeners();
   }
 

--- a/testing/models/v5/realtime_status.dart
+++ b/testing/models/v5/realtime_status.dart
@@ -128,6 +128,7 @@ final kRepoFetchRealTimeStatus = repo.RealtimeStatus(
       repo.QueryTypeStat(type: DnsRecordType.svcb, percentage: 0),
       repo.QueryTypeStat(type: DnsRecordType.https, percentage: 0),
     ],
+    frequency: 1.5,
   ),
   status: DnsBlockingStatus.enabled,
   topDomains: const repo.TopDomains(

--- a/testing/models/v5/realtime_status.dart
+++ b/testing/models/v5/realtime_status.dart
@@ -128,7 +128,6 @@ final kRepoFetchRealTimeStatus = repo.RealtimeStatus(
       repo.QueryTypeStat(type: DnsRecordType.svcb, percentage: 0),
       repo.QueryTypeStat(type: DnsRecordType.https, percentage: 0),
     ],
-    frequency: 1.5,
   ),
   status: DnsBlockingStatus.enabled,
   topDomains: const repo.TopDomains(

--- a/testing/models/v6/ftl.dart
+++ b/testing/models/v6/ftl.dart
@@ -538,12 +538,22 @@ const kRepoFetchFtlSystem = repo.FtlSystem(
   uptime: 67906,
   ramUsage: 26.854,
   cpuUsage: 3.3232043958349604,
+  cpuLoad: repo.CpuLoad(
+    avg1m: 0.58837890625,
+    avg5m: 0.64990234375,
+    avg15m: 0.66748046875,
+  ),
 );
 
 const kRepoFetchFtlSystemOld = repo.FtlSystem(
   uptime: 67906,
   ramUsage: 26.854,
   cpuUsage: 5.293782711029053,
+  cpuLoad: repo.CpuLoad(
+    avg1m: 0.58837890625,
+    avg5m: 0.64990234375,
+    avg15m: 0.66748046875,
+  ),
 );
 
 const kRepoFetchFtlVersion = repo.FtlVersion(

--- a/testing/models/v6/metrics.dart
+++ b/testing/models/v6/metrics.dart
@@ -156,6 +156,7 @@ const kSrvGetStatsSummary = srv.StatsSummary(
       none: 0,
       blob: 286,
     ),
+    frequency: 1.5,
   ),
   clients: srv.StatsClients(active: 10, total: 22),
   gravity: srv.StatsGravity(
@@ -367,6 +368,7 @@ final kRepoFetchStatsSummary = repo.Summary(
       percentage: 845 / 19663 * 100,
     ),
   ],
+  frequency: 1.5,
 );
 
 const kRepoFetchStatsUpstreams = [

--- a/testing/models/v6/realtime_status.dart
+++ b/testing/models/v6/realtime_status.dart
@@ -92,6 +92,7 @@ final kRepoFetchRealTimeStatus = repo.RealtimeStatus(
         percentage: 4.297411381783045,
       ),
     ],
+    frequency: 1.5,
   ),
   status: DnsBlockingStatus.enabled,
   topDomains: const repo.TopDomains(


### PR DESCRIPTION
## Overview
Adds a horizontally scrollable row of status chips to the home screen showing live server metrics: queries/min, CPU load, CPU usage, RAM usage, temperature, and uptime. Chips are shown only for v6 API connections. Queries/min updates on the user-configured interval (same as tiles), while system metrics (CPU, RAM, temperature, uptime) refresh every minute alongside overtime data. Chips display `"-"` gracefully when data is unavailable.

## Changes
- Add `ServerStatusChips` widget with 6 metric chips, skeleton loading state, and a fade-out scroll hint
- Fetch system/sensor data in parallel on initial load and on the 1-minute overtime timer; failures are non-fatal and do not affect overall server status
- Add `frequency`, `cpuLoad` fields to domain/data models and wire up v6 mappers
- Add `getColorByTheme` helper to `GraphColors` and chip tooltip strings for all 5 locales
- Extend tests for chip visibility, `getQueriesPerMinute`, and system/sensor data population


## Screenshot

|||
|---|---|
|<img width="1280" height="2856" alt="Screenshot_1778428926" src="https://github.com/user-attachments/assets/cbaec12e-b041-4eed-ae54-2d5fa0aeafa5" />|<img width="1280" height="2856" alt="Screenshot_1778428945" src="https://github.com/user-attachments/assets/f9023b15-930c-43b0-ba38-7c8343f73a7a" />|

