### PR TITLE
feat(open-url): open links in the user's default external browser

### DIFF
--- a/lib/ui/settings/about/widgets/app_detail_screen.dart
+++ b/lib/ui/settings/about/widgets/app_detail_screen.dart
@@ -126,9 +126,9 @@ class AppDetailScreen extends StatelessWidget {
                   colorScheme: colorScheme,
                 ),
                 subtitle: Text(loc.supportDeveloperSubtitle),
-                onTap: () => openUrl(Urls.buyMeACoffee, externalBrowser: true),
+                onTap: () => openUrl(Urls.buyMeACoffee),
                 trailing: Icon(
-                  Icons.open_in_browser_rounded,
+                  Icons.open_in_new_rounded,
                   color: colorScheme.onSurfaceVariant.withValues(alpha: 0.8),
                 ),
               ),

--- a/lib/utils/open_url.dart
+++ b/lib/utils/open_url.dart
@@ -1,9 +1,12 @@
 import 'package:sentry_flutter/sentry_flutter.dart';
 import 'package:url_launcher/url_launcher.dart' as url_launcher;
 
+/// Opens the given [url] in the user's default external browser.
+///
+/// Any exceptions thrown during the process are captured and reported to Sentry.
 Future<void> openUrl(String url) async {
-  final uri = Uri.parse(url);
   try {
+    final uri = Uri.parse(url);
     await url_launcher.launchUrl(
       uri,
       mode: url_launcher.LaunchMode.externalApplication,

--- a/lib/utils/open_url.dart
+++ b/lib/utils/open_url.dart
@@ -1,54 +1,13 @@
-import 'dart:io';
-
-import 'package:flutter_custom_tabs/flutter_custom_tabs.dart'
-    as flutter_custom_tabs;
 import 'package:sentry_flutter/sentry_flutter.dart';
 import 'package:url_launcher/url_launcher.dart' as url_launcher;
 
-/// Opens the given [url] using the appropriate method based on the platform and [externalBrowser] flag.
-///
-/// If [externalBrowser] is `true`, the URL is opened in the device's external browser using `url_launcher`.
-/// Otherwise, on Android and iOS, the URL is opened using custom tabs (Android) or Safari View Controller (iOS)
-/// with specific options for sharing, title display, and bar collapsing. On other platforms, the URL is opened
-/// using `url_launcher`.
-///
-/// Any exceptions thrown during the process are captured and reported to Sentry.
-///
-/// - [url]: The URL to open.
-/// - [externalBrowser]: If `true`, forces opening the URL in an external browser. Defaults to `false`.
-///
-/// Example:
-/// ```dart
-/// await openUrl('https://example.com', externalBrowser: true);
-/// ```
-Future<void> openUrl(String url, {bool externalBrowser = false}) async {
+Future<void> openUrl(String url) async {
   final uri = Uri.parse(url);
   try {
-    if (externalBrowser) {
-      await url_launcher.launchUrl(
-        uri,
-        mode: url_launcher.LaunchMode.externalApplication,
-      );
-      return;
-    }
-
-    if (Platform.isAndroid || Platform.isIOS) {
-      await flutter_custom_tabs.launchUrl(
-        uri,
-        customTabsOptions: const flutter_custom_tabs.CustomTabsOptions(
-          shareState: flutter_custom_tabs.CustomTabsShareState.browserDefault,
-          urlBarHidingEnabled: true,
-          showTitle: true,
-        ),
-        safariVCOptions: const flutter_custom_tabs.SafariViewControllerOptions(
-          barCollapsingEnabled: true,
-          dismissButtonStyle:
-              flutter_custom_tabs.SafariViewControllerDismissButtonStyle.close,
-        ),
-      );
-    } else {
-      await url_launcher.launchUrl(uri);
-    }
+    await url_launcher.launchUrl(
+      uri,
+      mode: url_launcher.LaunchMode.externalApplication,
+    );
   } catch (e, stackTrace) {
     await Sentry.captureException(e, stackTrace: stackTrace);
   }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -350,46 +350,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.3.0"
-  flutter_custom_tabs:
-    dependency: "direct main"
-    description:
-      name: flutter_custom_tabs
-      sha256: "8c3d92b074a8109f1dc76333c5ff8f87ea5896c118264c4b6b6e7d880058e820"
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.5.0"
-  flutter_custom_tabs_android:
-    dependency: transitive
-    description:
-      name: flutter_custom_tabs_android
-      sha256: "84e6b856fae8ca347bf47156f2106aac5671441fd6b3c531d1b793d22d29dece"
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.4.0"
-  flutter_custom_tabs_ios:
-    dependency: transitive
-    description:
-      name: flutter_custom_tabs_ios
-      sha256: "5f8bbfedad7ff60da4875d888085c05b1d0fd90acbfa4a624ae71b78c5cc6e37"
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.5.0"
-  flutter_custom_tabs_platform_interface:
-    dependency: transitive
-    description:
-      name: flutter_custom_tabs_platform_interface
-      sha256: "2b66c541f3ca87fbf3e63808dbd41b28cb76f512acce5940f2468b33abe69031"
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.4.0"
-  flutter_custom_tabs_web:
-    dependency: transitive
-    description:
-      name: flutter_custom_tabs_web
-      sha256: d606b231859c79679c78dbf05293528a543e3e067c2893a3a5bed1ab9a8300bb
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.4.0"
   flutter_dotenv:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -66,7 +66,6 @@ dependencies:
       url: https://github.com/google/flutter-desktop-embedding
       path: plugins/window_size
   local_auth: ^3.0.1
-  flutter_custom_tabs: ^2.5.0
   mobile_scanner: ^7.2.0
   logger: ^2.7.0
   freezed_annotation: ^3.0.0


### PR DESCRIPTION
## Overview
Previously, all links opened via Chrome Custom Tabs on Android, which always rendered Chrome's UI as an in-app overlay regardless of the user's default browser setting. This caused confusion for users whose default browser is Firefox, Brave, or another browser. Links now open in the user's actual default external browser using `url_launcher`'s `externalApplication` mode.

## Changes
- Replaced `flutter_custom_tabs` with `url_launcher`'s `LaunchMode.externalApplication` for all link openings on Android
- Removed the now-redundant `externalBrowser` parameter from `openUrl()`
- Removed the `flutter_custom_tabs` dependency (and 4 transitive packages) from `pubspec.yaml`
