### PR TITLE
feat(domains): add Internationalized Domain Name (IDN) support

### DIFF
--- a/lib/ui/domains/widgets/add_domain_modal.dart
+++ b/lib/ui/domains/widgets/add_domain_modal.dart
@@ -48,7 +48,7 @@ class _AddDomainModalState extends State<AddDomainModal> {
       // - With leading dot: .example.com, .co.jp
       // Uses Unicode letters (\p{L}), digits (\p{N}), '.' and '-'.
       final domainLikeRegexp = RegExp(
-        r'^\.?-?[\p{L}\p{N}]+([-.][\p{L}\p{N}]+)*$',
+        r'^\.?-?[\p{L}\p{N}-]+(\.[\p{L}\p{N}-]+)*$',
         unicode: true,
         caseSensitive: false,
       );

--- a/lib/ui/domains/widgets/add_domain_modal.dart
+++ b/lib/ui/domains/widgets/add_domain_modal.dart
@@ -42,13 +42,14 @@ class _AddDomainModalState extends State<AddDomainModal> {
 
   void validateDomain(String? value) {
     if (value != null && value != '') {
-      // Matches "domain-like" strings such as:
-      // - Single labels: example, local, com, jp
-      // - With dots: example.com, sub.domain.co.jp
+      // Matches "domain-like" strings including IDN (Internationalized Domain Names):
+      // - Single labels: example, local, てすと
+      // - With dots: example.com, sub.domain.co.jp, てすと.com
       // - With leading dot: .example.com, .co.jp
-      // Uses only letters, digits, '.' and '-' (case-insensitive).
+      // Uses Unicode letters (\p{L}), digits (\p{N}), '.' and '-'.
       final domainLikeRegexp = RegExp(
-        r'^\.?\-?[a-z0-9]+([.-][a-z0-9]+)*$',
+        r'^\.?-?[\p{L}\p{N}]+([-.][\p{L}\p{N}]+)*$',
+        unicode: true,
         caseSensitive: false,
       );
       if (domainLikeRegexp.hasMatch(value)) {

--- a/lib/ui/domains/widgets/domain_details_screen.dart
+++ b/lib/ui/domains/widgets/domain_details_screen.dart
@@ -102,7 +102,11 @@ class _DomainDetailsScreenState extends State<DomainDetailsScreen> {
             ListTile(
               leading: const Icon(Icons.domain),
               title: Text(AppLocalizations.of(context)!.domain),
-              subtitle: Text(_domain.name),
+              subtitle: Text(
+                _domain.punyCode != _domain.name
+                    ? '${_domain.name} (${_domain.punyCode})'
+                    : _domain.name,
+              ),
             ),
             ListTile(
               leading: const Icon(Icons.category_rounded),

--- a/lib/ui/domains/widgets/domain_tile.dart
+++ b/lib/ui/domains/widgets/domain_tile.dart
@@ -88,7 +88,9 @@ class DomainTile extends StatelessWidget {
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
               Text(
-                domain.name,
+                domain.punyCode != domain.name
+                    ? '${domain.name} (${domain.punyCode})'
+                    : domain.name,
                 overflow: TextOverflow.ellipsis,
                 style: const TextStyle(
                   fontWeight: FontWeight.w400,

--- a/mock_api_server/lib/handlers/domains_handler.dart
+++ b/mock_api_server/lib/handlers/domains_handler.dart
@@ -201,6 +201,18 @@ class DomainsHandler {
             "date_added": 1742822968,
             "date_modified": 1742822968,
           },
+          {
+            "domain": "xn--88jzah.com",
+            "unicode": "てすと.COM",
+            "type": "allow",
+            "kind": "exact",
+            "comment": null,
+            "groups": [0],
+            "enabled": true,
+            "id": 145,
+            "date_added": 1742822968,
+            "date_modified": 1742822968,
+          },
         ],
         "took": 0.004214763641357422,
       };


### PR DESCRIPTION
## Overview
The domain add modal previously rejected non-ASCII input, making it impossible to register Internationalized Domain Names (IDN) such as `てすと.com` even though Pi-hole supports them natively. This change relaxes the validation and improves the display for IDN entries in the domain list and details screen.

## Changes
- Replace ASCII-only regex in the domain add modal with a Unicode-aware pattern using `\p{L}` and `\p{N}` property escapes, allowing any Unicode letter or digit in domain labels
- When a domain's punycode and unicode representations differ, display both in the format `てすと.com (xn--88jzah.com)` in the domain list tile and details screen
- Add a non-ASCII sample domain (`xn--88jzah.com` / `てすと.COM`) to the mock API server for development testing

## ScreenShot

<img width="336" height="748" alt="Screenshot_1780151278" src="https://github.com/user-attachments/assets/ea8e426a-e6b4-46ec-8cb8-54c40f85804a" />
