### PR TITLE
feat(domains): replace full-screen spinner with stale-while-revalidate

### DIFF
--- a/lib/config/dependencies.dart
+++ b/lib/config/dependencies.dart
@@ -8,6 +8,7 @@ import 'package:pi_hole_client/domain/model/server/server.dart';
 import 'package:pi_hole_client/ui/core/view_models/app_config_viewmodel.dart';
 import 'package:pi_hole_client/ui/core/view_models/servers_viewmodel.dart';
 import 'package:pi_hole_client/ui/core/view_models/status_viewmodel.dart';
+import 'package:pi_hole_client/ui/domains/view_models/domains_viewmodel.dart';
 import 'package:pi_hole_client/ui/logs/view_models/logs_viewmodel.dart';
 import 'package:pi_hole_client/ui/settings/server_settings/adlists/view_models/gravity_update_viewmodel.dart';
 import 'package:provider/provider.dart';
@@ -30,6 +31,7 @@ List<SingleChildWidget> createProviders({
   required ServersViewModel serversViewModel,
   required StatusViewModel statusViewModel,
   required LogsViewModel logsViewModel,
+  required DomainsViewModel domainsViewModel,
   required GravityUpdateViewModel gravityUpdateViewModel,
 }) {
   return [
@@ -106,6 +108,11 @@ List<SingleChildWidget> createProviders({
           topClientNames: statusVM.topClientNames,
           onRefreshClients: statusVM.refreshOnce,
         ),
+    ),
+    ChangeNotifierProxyProvider<RepositoryBundle?, DomainsViewModel>(
+      create: (_) => domainsViewModel,
+      update: (_, bundle, previous) =>
+          previous!..update(domainRepository: bundle?.domain),
     ),
     ChangeNotifierProxyProvider2<
       RepositoryBundle?,

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -21,6 +21,7 @@ import 'package:pi_hole_client/pi_hole_client.dart';
 import 'package:pi_hole_client/ui/core/view_models/app_config_viewmodel.dart';
 import 'package:pi_hole_client/ui/core/view_models/servers_viewmodel.dart';
 import 'package:pi_hole_client/ui/core/view_models/status_viewmodel.dart';
+import 'package:pi_hole_client/ui/domains/view_models/domains_viewmodel.dart';
 import 'package:pi_hole_client/ui/logs/view_models/logs_viewmodel.dart';
 import 'package:pi_hole_client/ui/settings/server_settings/adlists/view_models/gravity_update_viewmodel.dart';
 import 'package:pi_hole_client/utils/logger.dart';
@@ -195,6 +196,7 @@ void main() async {
   final configProvider = AppConfigViewModel(appConfigRepository);
   final statusViewModel = StatusViewModel();
   final logsViewModel = LogsViewModel();
+  final domainsViewModel = DomainsViewModel();
   final gravityUpdateViewModel = GravityUpdateViewModel(
     repository: gravityRepository,
   );
@@ -243,6 +245,7 @@ void main() async {
         serversViewModel: serversViewModel,
         statusViewModel: statusViewModel,
         logsViewModel: logsViewModel,
+        domainsViewModel: domainsViewModel,
         gravityUpdateViewModel: gravityUpdateViewModel,
       ),
       child: SentryWidget(child: Phoenix(child: const PiHoleClient())),

--- a/lib/ui/domains/view_models/domains_viewmodel.dart
+++ b/lib/ui/domains/view_models/domains_viewmodel.dart
@@ -1,6 +1,5 @@
 import 'package:command_it/command_it.dart';
 import 'package:flutter/foundation.dart';
-import 'package:flutter/scheduler.dart';
 import 'package:pi_hole_client/data/repositories/api/interfaces/domain_repository.dart';
 import 'package:pi_hole_client/domain/model/domain/domain.dart';
 import 'package:pi_hole_client/domain/model/enums.dart';
@@ -50,18 +49,12 @@ class DomainsViewModel extends ChangeNotifier {
   LoadStatus _loadingStatus = LoadStatus.loading;
   bool _disposed = false;
   bool _isRevalidating = false;
-  bool _screenActive = false;
   int _serverEpoch = 0;
 
   /// Bumped on every locally-confirmed add/delete/update. Used to detect a
   /// mutation that raced an in-flight revalidation, so its stale snapshot is
   /// not applied over the user's change.
   int _mutationSeq = 0;
-
-  /// Server epoch currently being loaded, or -1 when idle. Guards against two
-  /// concurrent loads for the same server (the eager reload from [update] and
-  /// the remount-driven `loadDomains.run()` would otherwise both fetch).
-  int _loadingEpoch = -1;
 
   // --- Getters ---
   List<Domain> get whitelistDomains => _whitelistDomains;
@@ -80,22 +73,14 @@ class DomainsViewModel extends ChangeNotifier {
 
   bool get isRevalidating => _isRevalidating;
 
-  /// Marks whether the Domains screen is currently visible.
-  ///
-  /// Only while the screen is active does a server switch ([update]) trigger an
-  /// eager background reload. When inactive, the load is deferred until the
-  /// screen mounts and calls `loadDomains.run()`, so the first view after a
-  /// server switch shows the full-screen spinner rather than the SWR bar.
-  void setScreenActive(bool active) {
-    _screenActive = active;
-  }
-
   /// Called by the app-level `ChangeNotifierProxyProvider` whenever the active
   /// [DomainRepository] changes (i.e. the selected server changed).
   ///
-  /// On a repository change the cached domain data is reset **immediately** and
-  /// a fresh load is scheduled, so the previous server's domains never leak
-  /// into the new server's screen — even if the new server is slow to respond.
+  /// The cached domain data is reset **immediately** so the previous server's
+  /// domains never leak into the new server's screen. The reload itself is left
+  /// to the next screen mount (`loadDomains.run()`): switching servers always
+  /// navigates away from the Domains tab, so the screen is unmounted here and
+  /// remounts — and reloads against the cleared cache — on return.
   void update({DomainRepository? domainRepository}) {
     if (domainRepository == null) return;
     final changed = domainRepository != _domainRepository;
@@ -107,31 +92,6 @@ class DomainsViewModel extends ChangeNotifier {
     _loadingStatus = LoadStatus.loading;
     _isRevalidating = false;
     _safeNotifyListeners();
-
-    // Only eagerly reload when the screen is visible. Otherwise the reset cache
-    // is loaded lazily on the next mount, so the first view after a server
-    // switch shows the full-screen spinner instead of the SWR bar.
-    if (!_screenActive) return;
-
-    // Defer to after the current frame to avoid notifyListeners() during build.
-    // Re-check visibility: the user may have left the tab before the frame ran,
-    // in which case the next mount will load lazily instead.
-    SchedulerBinding.instance.addPostFrameCallback((_) {
-      if (_disposed || !_screenActive) return;
-      _reload();
-    });
-  }
-
-  /// Reloads outside the [loadDomains] Command so that a server switch can
-  /// always trigger a fresh load even if a previous load is still in flight
-  /// (Commands ignore re-entrant runs). Errors are swallowed here because
-  /// [_loadDomains] already records the error state.
-  Future<void> _reload() async {
-    try {
-      await _loadDomains();
-    } catch (_) {
-      // Error state is handled inside _loadDomains.
-    }
   }
 
   /// Clears the loaded and filtered domain lists (e.g. on a server switch or
@@ -150,63 +110,52 @@ class DomainsViewModel extends ChangeNotifier {
 
     final serverEpoch = _serverEpoch;
 
-    // A load for this server is already in flight (e.g. the screen remount
-    // called loadDomains.run() and update() also scheduled an eager reload).
-    // Let the first one win instead of fetching twice.
-    if (_loadingEpoch == serverEpoch) return;
-    _loadingEpoch = serverEpoch;
+    // Stale-While-Revalidate: when a list is already loaded, keep it visible
+    // and show a thin progress bar while fresh data is fetched in the
+    // background. The full-screen spinner is only shown on the very first load
+    // (and after a server switch, where the cache was just cleared), so
+    // returning to the Domains tab no longer flashes a spinner.
+    final hasCache =
+        _whitelistDomains.isNotEmpty || _blacklistDomains.isNotEmpty;
 
-    try {
-      // Stale-While-Revalidate: when a list is already loaded, keep it visible
-      // and show a thin progress bar while fresh data is fetched in the
-      // background. The full-screen spinner is only shown on the very first load
-      // (and after a server switch, where the cache was just cleared), so
-      // returning to the Domains tab no longer flashes a spinner.
-      final hasCache =
-          _whitelistDomains.isNotEmpty || _blacklistDomains.isNotEmpty;
+    if (hasCache) {
+      _isRevalidating = true;
+      _safeNotifyListeners();
+    } else {
+      _loadingStatus = LoadStatus.loading;
+      _resetCache();
+      _safeNotifyListeners();
+    }
 
-      if (hasCache) {
-        _isRevalidating = true;
+    final mutationSeq = _mutationSeq;
+    final result = await repository.fetchAllDomains();
+    if (_disposed || serverEpoch != _serverEpoch) return;
+
+    switch (result) {
+      case Success():
+        // A local add/delete/update was confirmed by the server while this
+        // fetch was in flight; its snapshot predates that change, so applying
+        // it would drop the user's mutation. Skip the assignment and keep the
+        // locally-updated list (already correct: previous data plus the
+        // confirmed change). External edits are picked up on the next reload.
+        if (mutationSeq == _mutationSeq) {
+          final lists = result.getOrNull();
+          _whitelistDomains = [...lists.allowExact, ...lists.allowRegex];
+          _blacklistDomains = [...lists.denyExact, ...lists.denyRegex];
+          _applyFilters();
+        }
+        _loadingStatus = LoadStatus.loaded;
+        _isRevalidating = false;
         _safeNotifyListeners();
-      } else {
-        _loadingStatus = LoadStatus.loading;
-        _resetCache();
+      case Failure():
+        _isRevalidating = false;
+        // Keep the cached list visible when a background refresh fails; only
+        // surface the error screen when there is nothing to show.
+        if (!hasCache) {
+          _loadingStatus = LoadStatus.error;
+        }
         _safeNotifyListeners();
-      }
-
-      final mutationSeq = _mutationSeq;
-      final result = await repository.fetchAllDomains();
-      if (_disposed || serverEpoch != _serverEpoch) return;
-
-      switch (result) {
-        case Success():
-          // A local add/delete/update was confirmed by the server while this
-          // fetch was in flight; its snapshot predates that change, so applying
-          // it would drop the user's mutation. Skip the assignment and keep the
-          // locally-updated list (already correct: previous data plus the
-          // confirmed change). External edits are picked up on the next reload.
-          if (mutationSeq == _mutationSeq) {
-            final lists = result.getOrNull();
-            _whitelistDomains = [...lists.allowExact, ...lists.allowRegex];
-            _blacklistDomains = [...lists.denyExact, ...lists.denyRegex];
-            _applyFilters();
-          }
-          _loadingStatus = LoadStatus.loaded;
-          _isRevalidating = false;
-          _safeNotifyListeners();
-        case Failure():
-          _isRevalidating = false;
-          // Keep the cached list visible when a background refresh fails; only
-          // surface the error screen when there is nothing to show.
-          if (!hasCache) {
-            _loadingStatus = LoadStatus.error;
-          }
-          _safeNotifyListeners();
-          throw result.exceptionOrNull();
-      }
-    } finally {
-      // Release ownership only if a newer server switch hasn't taken over.
-      if (_loadingEpoch == serverEpoch) _loadingEpoch = -1;
+        throw result.exceptionOrNull();
     }
   }
 

--- a/lib/ui/domains/view_models/domains_viewmodel.dart
+++ b/lib/ui/domains/view_models/domains_viewmodel.dart
@@ -1,12 +1,13 @@
 import 'package:command_it/command_it.dart';
 import 'package:flutter/foundation.dart';
+import 'package:flutter/scheduler.dart';
 import 'package:pi_hole_client/data/repositories/api/interfaces/domain_repository.dart';
 import 'package:pi_hole_client/domain/model/domain/domain.dart';
 import 'package:pi_hole_client/domain/model/enums.dart';
 import 'package:result_dart/result_dart.dart';
 
 class DomainsViewModel extends ChangeNotifier {
-  DomainsViewModel({required DomainRepository domainRepository})
+  DomainsViewModel({DomainRepository? domainRepository})
     : _domainRepository = domainRepository {
     loadDomains = Command.createAsyncNoParam<void>(
       _loadDomains,
@@ -27,7 +28,7 @@ class DomainsViewModel extends ChangeNotifier {
     updateDomain.errors.addListener(notifyListeners);
   }
 
-  final DomainRepository _domainRepository;
+  DomainRepository? _domainRepository;
 
   // --- Commands ---
   late final Command<void, void> loadDomains;
@@ -48,6 +49,9 @@ class DomainsViewModel extends ChangeNotifier {
   int? _groupFilter;
   LoadStatus _loadingStatus = LoadStatus.loading;
   bool _disposed = false;
+  bool _isRevalidating = false;
+  bool _screenActive = false;
+  int _serverEpoch = 0;
 
   // --- Getters ---
   List<Domain> get whitelistDomains => _whitelistDomains;
@@ -64,17 +68,92 @@ class DomainsViewModel extends ChangeNotifier {
     return _loadingStatus;
   }
 
-  // --- Command implementations ---
-  Future<void> _loadDomains() async {
-    _loadingStatus = LoadStatus.loading;
+  bool get isRevalidating => _isRevalidating;
+
+  /// Marks whether the Domains screen is currently visible.
+  ///
+  /// Only while the screen is active does a server switch ([update]) trigger an
+  /// eager background reload. When inactive, the load is deferred until the
+  /// screen mounts and calls `loadDomains.run()`, so the first view after a
+  /// server switch shows the full-screen spinner rather than the SWR bar.
+  void setScreenActive(bool active) {
+    _screenActive = active;
+  }
+
+  /// Called by the app-level `ChangeNotifierProxyProvider` whenever the active
+  /// [DomainRepository] changes (i.e. the selected server changed).
+  ///
+  /// On a repository change the cached domain data is reset **immediately** and
+  /// a fresh load is scheduled, so the previous server's domains never leak
+  /// into the new server's screen — even if the new server is slow to respond.
+  void update({DomainRepository? domainRepository}) {
+    if (domainRepository == null) return;
+    final changed = domainRepository != _domainRepository;
+    _domainRepository = domainRepository;
+    if (!changed) return;
+
+    _serverEpoch++;
     _whitelistDomains = [];
     _blacklistDomains = [];
     _filteredWhitelistDomains = [];
     _filteredBlacklistDomains = [];
+    _loadingStatus = LoadStatus.loading;
+    _isRevalidating = false;
     _safeNotifyListeners();
 
-    final result = await _domainRepository.fetchAllDomains();
-    if (_disposed) return;
+    // Only eagerly reload when the screen is visible. Otherwise the reset cache
+    // is loaded lazily on the next mount, so the first view after a server
+    // switch shows the full-screen spinner instead of the SWR bar.
+    if (!_screenActive) return;
+
+    // Defer to after the current frame to avoid notifyListeners() during build.
+    SchedulerBinding.instance.addPostFrameCallback((_) {
+      if (_disposed) return;
+      _reload();
+    });
+  }
+
+  /// Reloads outside the [loadDomains] Command so that a server switch can
+  /// always trigger a fresh load even if a previous load is still in flight
+  /// (Commands ignore re-entrant runs). Errors are swallowed here because
+  /// [_loadDomains] already records the error state.
+  Future<void> _reload() async {
+    try {
+      await _loadDomains();
+    } catch (_) {
+      // Error state is handled inside _loadDomains.
+    }
+  }
+
+  // --- Command implementations ---
+  Future<void> _loadDomains() async {
+    final repository = _domainRepository;
+    if (repository == null) return;
+
+    final serverEpoch = _serverEpoch;
+
+    // Stale-While-Revalidate: when a list is already loaded, keep it visible
+    // and show a thin progress bar while fresh data is fetched in the
+    // background. The full-screen spinner is only shown on the very first load
+    // (and after a server switch, where the cache was just cleared), so
+    // returning to the Domains tab no longer flashes a spinner.
+    final hasCache =
+        _whitelistDomains.isNotEmpty || _blacklistDomains.isNotEmpty;
+
+    if (hasCache) {
+      _isRevalidating = true;
+      _safeNotifyListeners();
+    } else {
+      _loadingStatus = LoadStatus.loading;
+      _whitelistDomains = [];
+      _blacklistDomains = [];
+      _filteredWhitelistDomains = [];
+      _filteredBlacklistDomains = [];
+      _safeNotifyListeners();
+    }
+
+    final result = await repository.fetchAllDomains();
+    if (_disposed || serverEpoch != _serverEpoch) return;
     switch (result) {
       case Success():
         final lists = result.getOrNull();
@@ -82,16 +161,22 @@ class DomainsViewModel extends ChangeNotifier {
         _blacklistDomains = [...lists.denyExact, ...lists.denyRegex];
         _applyFilters();
         _loadingStatus = LoadStatus.loaded;
+        _isRevalidating = false;
         _safeNotifyListeners();
       case Failure():
-        _loadingStatus = LoadStatus.error;
+        _isRevalidating = false;
+        // Keep the cached list visible when a background refresh fails; only
+        // surface the error screen when there is nothing to show.
+        if (!hasCache) {
+          _loadingStatus = LoadStatus.error;
+        }
         _safeNotifyListeners();
         throw result.exceptionOrNull();
     }
   }
 
   Future<void> _deleteDomain(Domain domain) async {
-    final result = await _domainRepository.deleteDomain(
+    final result = await _domainRepository!.deleteDomain(
       domain.type,
       domain.kind,
       domain.punyCode,
@@ -108,7 +193,7 @@ class DomainsViewModel extends ChangeNotifier {
   Future<void> _addDomain(
     ({DomainType type, DomainKind kind, String domain}) params,
   ) async {
-    final result = await _domainRepository.addDomain(
+    final result = await _domainRepository!.addDomain(
       params.type,
       params.kind,
       params.domain,
@@ -130,7 +215,7 @@ class DomainsViewModel extends ChangeNotifier {
   }
 
   Future<void> _updateDomain(Domain domain) async {
-    final result = await _domainRepository.updateDomain(
+    final result = await _domainRepository!.updateDomain(
       domain.type,
       domain.kind,
       domain.punyCode,

--- a/lib/ui/domains/view_models/domains_viewmodel.dart
+++ b/lib/ui/domains/view_models/domains_viewmodel.dart
@@ -176,7 +176,11 @@ class DomainsViewModel extends ChangeNotifier {
   }
 
   Future<void> _deleteDomain(Domain domain) async {
-    final result = await _domainRepository!.deleteDomain(
+    final repository = _domainRepository;
+    if (repository == null) {
+      throw Exception('DomainRepository not available');
+    }
+    final result = await repository.deleteDomain(
       domain.type,
       domain.kind,
       domain.punyCode,
@@ -193,7 +197,11 @@ class DomainsViewModel extends ChangeNotifier {
   Future<void> _addDomain(
     ({DomainType type, DomainKind kind, String domain}) params,
   ) async {
-    final result = await _domainRepository!.addDomain(
+    final repository = _domainRepository;
+    if (repository == null) {
+      throw Exception('DomainRepository not available');
+    }
+    final result = await repository.addDomain(
       params.type,
       params.kind,
       params.domain,
@@ -215,7 +223,11 @@ class DomainsViewModel extends ChangeNotifier {
   }
 
   Future<void> _updateDomain(Domain domain) async {
-    final result = await _domainRepository!.updateDomain(
+    final repository = _domainRepository;
+    if (repository == null) {
+      throw Exception('DomainRepository not available');
+    }
+    final result = await repository.updateDomain(
       domain.type,
       domain.kind,
       domain.punyCode,

--- a/lib/ui/domains/view_models/domains_viewmodel.dart
+++ b/lib/ui/domains/view_models/domains_viewmodel.dart
@@ -53,6 +53,16 @@ class DomainsViewModel extends ChangeNotifier {
   bool _screenActive = false;
   int _serverEpoch = 0;
 
+  /// Bumped on every locally-confirmed add/delete/update. Used to detect a
+  /// mutation that raced an in-flight revalidation, so its stale snapshot is
+  /// not applied over the user's change.
+  int _mutationSeq = 0;
+
+  /// Server epoch currently being loaded, or -1 when idle. Guards against two
+  /// concurrent loads for the same server (the eager reload from [update] and
+  /// the remount-driven `loadDomains.run()` would otherwise both fetch).
+  int _loadingEpoch = -1;
+
   // --- Getters ---
   List<Domain> get whitelistDomains => _whitelistDomains;
   List<Domain> get blacklistDomains => _blacklistDomains;
@@ -93,10 +103,7 @@ class DomainsViewModel extends ChangeNotifier {
     if (!changed) return;
 
     _serverEpoch++;
-    _whitelistDomains = [];
-    _blacklistDomains = [];
-    _filteredWhitelistDomains = [];
-    _filteredBlacklistDomains = [];
+    _resetCache();
     _loadingStatus = LoadStatus.loading;
     _isRevalidating = false;
     _safeNotifyListeners();
@@ -107,8 +114,10 @@ class DomainsViewModel extends ChangeNotifier {
     if (!_screenActive) return;
 
     // Defer to after the current frame to avoid notifyListeners() during build.
+    // Re-check visibility: the user may have left the tab before the frame ran,
+    // in which case the next mount will load lazily instead.
     SchedulerBinding.instance.addPostFrameCallback((_) {
-      if (_disposed) return;
+      if (_disposed || !_screenActive) return;
       _reload();
     });
   }
@@ -125,6 +134,15 @@ class DomainsViewModel extends ChangeNotifier {
     }
   }
 
+  /// Clears the loaded and filtered domain lists (e.g. on a server switch or
+  /// before the first load of a server).
+  void _resetCache() {
+    _whitelistDomains = [];
+    _blacklistDomains = [];
+    _filteredWhitelistDomains = [];
+    _filteredBlacklistDomains = [];
+  }
+
   // --- Command implementations ---
   Future<void> _loadDomains() async {
     final repository = _domainRepository;
@@ -132,46 +150,63 @@ class DomainsViewModel extends ChangeNotifier {
 
     final serverEpoch = _serverEpoch;
 
-    // Stale-While-Revalidate: when a list is already loaded, keep it visible
-    // and show a thin progress bar while fresh data is fetched in the
-    // background. The full-screen spinner is only shown on the very first load
-    // (and after a server switch, where the cache was just cleared), so
-    // returning to the Domains tab no longer flashes a spinner.
-    final hasCache =
-        _whitelistDomains.isNotEmpty || _blacklistDomains.isNotEmpty;
+    // A load for this server is already in flight (e.g. the screen remount
+    // called loadDomains.run() and update() also scheduled an eager reload).
+    // Let the first one win instead of fetching twice.
+    if (_loadingEpoch == serverEpoch) return;
+    _loadingEpoch = serverEpoch;
 
-    if (hasCache) {
-      _isRevalidating = true;
-      _safeNotifyListeners();
-    } else {
-      _loadingStatus = LoadStatus.loading;
-      _whitelistDomains = [];
-      _blacklistDomains = [];
-      _filteredWhitelistDomains = [];
-      _filteredBlacklistDomains = [];
-      _safeNotifyListeners();
-    }
+    try {
+      // Stale-While-Revalidate: when a list is already loaded, keep it visible
+      // and show a thin progress bar while fresh data is fetched in the
+      // background. The full-screen spinner is only shown on the very first load
+      // (and after a server switch, where the cache was just cleared), so
+      // returning to the Domains tab no longer flashes a spinner.
+      final hasCache =
+          _whitelistDomains.isNotEmpty || _blacklistDomains.isNotEmpty;
 
-    final result = await repository.fetchAllDomains();
-    if (_disposed || serverEpoch != _serverEpoch) return;
-    switch (result) {
-      case Success():
-        final lists = result.getOrNull();
-        _whitelistDomains = [...lists.allowExact, ...lists.allowRegex];
-        _blacklistDomains = [...lists.denyExact, ...lists.denyRegex];
-        _applyFilters();
-        _loadingStatus = LoadStatus.loaded;
-        _isRevalidating = false;
+      if (hasCache) {
+        _isRevalidating = true;
         _safeNotifyListeners();
-      case Failure():
-        _isRevalidating = false;
-        // Keep the cached list visible when a background refresh fails; only
-        // surface the error screen when there is nothing to show.
-        if (!hasCache) {
-          _loadingStatus = LoadStatus.error;
-        }
+      } else {
+        _loadingStatus = LoadStatus.loading;
+        _resetCache();
         _safeNotifyListeners();
-        throw result.exceptionOrNull();
+      }
+
+      final mutationSeq = _mutationSeq;
+      final result = await repository.fetchAllDomains();
+      if (_disposed || serverEpoch != _serverEpoch) return;
+
+      switch (result) {
+        case Success():
+          // A local add/delete/update was confirmed by the server while this
+          // fetch was in flight; its snapshot predates that change, so applying
+          // it would drop the user's mutation. Skip the assignment and keep the
+          // locally-updated list (already correct: previous data plus the
+          // confirmed change). External edits are picked up on the next reload.
+          if (mutationSeq == _mutationSeq) {
+            final lists = result.getOrNull();
+            _whitelistDomains = [...lists.allowExact, ...lists.allowRegex];
+            _blacklistDomains = [...lists.denyExact, ...lists.denyRegex];
+            _applyFilters();
+          }
+          _loadingStatus = LoadStatus.loaded;
+          _isRevalidating = false;
+          _safeNotifyListeners();
+        case Failure():
+          _isRevalidating = false;
+          // Keep the cached list visible when a background refresh fails; only
+          // surface the error screen when there is nothing to show.
+          if (!hasCache) {
+            _loadingStatus = LoadStatus.error;
+          }
+          _safeNotifyListeners();
+          throw result.exceptionOrNull();
+      }
+    } finally {
+      // Release ownership only if a newer server switch hasn't taken over.
+      if (_loadingEpoch == serverEpoch) _loadingEpoch = -1;
     }
   }
 
@@ -210,6 +245,7 @@ class DomainsViewModel extends ChangeNotifier {
     switch (result) {
       case Success():
         final domain = result.getOrNull();
+        _mutationSeq++;
         if (domain.type == DomainType.allow) {
           _whitelistDomains = [..._whitelistDomains, domain];
         } else {
@@ -239,6 +275,7 @@ class DomainsViewModel extends ChangeNotifier {
     switch (result) {
       case Success():
         final updated = result.getOrNull();
+        _mutationSeq++;
         // Replace in-place and remove from the other list (handles type changes).
         if (updated.type == DomainType.allow) {
           _whitelistDomains = [
@@ -313,6 +350,7 @@ class DomainsViewModel extends ChangeNotifier {
   }
 
   void _removeDomainFromList(Domain domain) {
+    _mutationSeq++;
     if (domain.type == DomainType.allow) {
       _whitelistDomains = _whitelistDomains
           .where((d) => d.id != domain.id)

--- a/lib/ui/domains/view_models/domains_viewmodel.dart
+++ b/lib/ui/domains/view_models/domains_viewmodel.dart
@@ -123,7 +123,6 @@ class DomainsViewModel extends ChangeNotifier {
       _safeNotifyListeners();
     } else {
       _loadingStatus = LoadStatus.loading;
-      _resetCache();
       _safeNotifyListeners();
     }
 

--- a/lib/ui/domains/widgets/domains_list.dart
+++ b/lib/ui/domains/widgets/domains_list.dart
@@ -275,6 +275,15 @@ class _DomainsListState extends State<DomainsList> {
           onRefresh: () async => viewModel.loadDomains.runAsync(),
           bottomSpaceHeight: 80,
         ),
+        // Stale-While-Revalidate: a thin bar at the top while a background
+        // refresh runs over an already-visible list.
+        if (viewModel.isRevalidating)
+          const Positioned(
+            top: 0,
+            left: 0,
+            right: 0,
+            child: LinearProgressIndicator(),
+          ),
         SafeArea(
           child: Stack(
             children: [

--- a/lib/ui/domains/widgets/domains_screen.dart
+++ b/lib/ui/domains/widgets/domains_screen.dart
@@ -12,7 +12,6 @@ import 'package:pi_hole_client/ui/domains/widgets/domain_actions.dart';
 import 'package:pi_hole_client/ui/domains/widgets/domain_details_screen.dart';
 import 'package:pi_hole_client/ui/domains/widgets/domains_list.dart';
 import 'package:pi_hole_client/ui/domains/widgets/domains_scaffold.dart';
-import 'package:pi_hole_client/ui/logs/view_models/logs_viewmodel.dart';
 import 'package:pi_hole_client/ui/settings/server_settings/group_client/view_models/groups_viewmodel.dart';
 import 'package:pi_hole_client/ui/shell/app_shell.dart';
 import 'package:provider/provider.dart';
@@ -32,6 +31,7 @@ class _DomainsScreenState extends State<DomainsScreen>
   final TextEditingController searchController = TextEditingController();
 
   late final AppConfigViewModel _appConfigViewModel;
+  DomainsViewModel? _domainsViewModel;
   int _lastKnownTab = AppShell.domainsIndex;
 
   @override
@@ -51,15 +51,9 @@ class _DomainsScreenState extends State<DomainsScreen>
     final previousTab = _lastKnownTab;
     _lastKnownTab = currentTab;
 
-    if (currentTab == AppShell.domainsIndex) {
-      // Returning to domains tab — refresh only if a domain was added
-      final logsVm = context.read<LogsViewModel>();
-      if (logsVm.domainListDirty) {
-        logsVm.clearDomainListDirty();
-        context.read<DomainsViewModel>().loadDomains.run();
-      }
-    } else if (previousTab == AppShell.domainsIndex) {
-      // Leaving domains tab — reset while hidden (no flash)
+    if (previousTab == AppShell.domainsIndex &&
+        currentTab != AppShell.domainsIndex) {
+      // Leaving domains tab — reset selection while hidden (no flash).
       context.read<DomainsViewModel>().setSelectedDomain(null);
       tabController.index = 0;
     }
@@ -68,15 +62,20 @@ class _DomainsScreenState extends State<DomainsScreen>
   @override
   void didChangeDependencies() {
     super.didChangeDependencies();
+    final viewModel = context.read<DomainsViewModel>();
+    _domainsViewModel = viewModel;
+    viewModel.setScreenActive(true);
     if (!_initialized) {
       _initialized = true;
-      Provider.of<DomainsViewModel>(context, listen: false).setSelectedTab(0);
+      viewModel.setSelectedTab(0);
+      viewModel.loadDomains.run();
     }
   }
 
   @override
   void dispose() {
     _appConfigViewModel.removeListener(_onAppConfigChanged);
+    _domainsViewModel?.setScreenActive(false);
     tabController.dispose();
     scrollController.dispose();
     searchController.dispose();

--- a/lib/ui/domains/widgets/domains_screen.dart
+++ b/lib/ui/domains/widgets/domains_screen.dart
@@ -31,7 +31,6 @@ class _DomainsScreenState extends State<DomainsScreen>
   final TextEditingController searchController = TextEditingController();
 
   late final AppConfigViewModel _appConfigViewModel;
-  DomainsViewModel? _domainsViewModel;
   int _lastKnownTab = AppShell.domainsIndex;
 
   @override
@@ -62,11 +61,9 @@ class _DomainsScreenState extends State<DomainsScreen>
   @override
   void didChangeDependencies() {
     super.didChangeDependencies();
-    final viewModel = context.read<DomainsViewModel>();
-    _domainsViewModel = viewModel;
-    viewModel.setScreenActive(true);
     if (!_initialized) {
       _initialized = true;
+      final viewModel = context.read<DomainsViewModel>();
       viewModel.setSelectedTab(0);
       viewModel.loadDomains.run();
     }
@@ -75,7 +72,6 @@ class _DomainsScreenState extends State<DomainsScreen>
   @override
   void dispose() {
     _appConfigViewModel.removeListener(_onAppConfigChanged);
-    _domainsViewModel?.setScreenActive(false);
     tabController.dispose();
     scrollController.dispose();
     searchController.dispose();

--- a/lib/ui/domains/widgets/domains_screen_factory.dart
+++ b/lib/ui/domains/widgets/domains_screen_factory.dart
@@ -1,23 +1,20 @@
 import 'package:flutter/material.dart';
 import 'package:pi_hole_client/data/repositories/api/interfaces/repository_bundle.dart';
-import 'package:pi_hole_client/ui/domains/view_models/domains_viewmodel.dart';
 import 'package:pi_hole_client/ui/domains/widgets/domains_screen.dart';
 import 'package:pi_hole_client/ui/settings/server_settings/group_client/view_models/groups_viewmodel.dart';
 import 'package:provider/provider.dart';
 
+/// Builds the Domains tab.
+///
+/// The `DomainsViewModel` is provided app-wide (see `createProviders` in
+/// `lib/config/dependencies.dart`) so that its cached list survives bottom-tab
+/// switches — returning to the Domains tab shows the previous list immediately
+/// instead of a full-screen spinner. Only [GroupsViewModel] is scoped to this
+/// route.
 Widget createDomainsScreen(RepositoryBundle bundle) {
-  return MultiProvider(
-    providers: [
-      ChangeNotifierProvider(
-        create: (_) =>
-            DomainsViewModel(domainRepository: bundle.domain)
-              ..loadDomains.run(),
-      ),
-      ChangeNotifierProvider(
-        create: (_) =>
-            GroupsViewModel(groupRepository: bundle.group)..loadGroups.run(),
-      ),
-    ],
+  return ChangeNotifierProvider(
+    create: (_) =>
+        GroupsViewModel(groupRepository: bundle.group)..loadGroups.run(),
     child: const DomainsScreen(),
   );
 }

--- a/lib/ui/logs/view_models/logs_viewmodel.dart
+++ b/lib/ui/logs/view_models/logs_viewmodel.dart
@@ -77,12 +77,6 @@ class LogsViewModel extends ChangeNotifier {
     }
   }
 
-  /// Whether a domain was added via [addDomainToList] since the last time
-  /// the domains screen consumed this flag.
-  bool _domainListDirty = false;
-  bool get domainListDirty => _domainListDirty;
-  void clearDomainListDirty() => _domainListDirty = false;
-
   /// Adds [domain] to the allow or deny list via [DomainRepository].
   ///
   /// [list] should be `'white'` for allow-list or `'black'` for deny-list.
@@ -104,7 +98,6 @@ class LogsViewModel extends ChangeNotifier {
       DomainKind.exact,
       domain,
     );
-    if (result.isSuccess()) _domainListDirty = true;
     return result;
   }
 

--- a/test/ui/domains/view_models/domains_viewmodel_test.dart
+++ b/test/ui/domains/view_models/domains_viewmodel_test.dart
@@ -1,9 +1,93 @@
+import 'dart:async';
+
 import 'package:command_it/command_it.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:pi_hole_client/data/repositories/api/interfaces/domain_repository.dart';
+import 'package:pi_hole_client/domain/model/domain/domain.dart';
 import 'package:pi_hole_client/domain/model/enums.dart';
 import 'package:pi_hole_client/ui/domains/view_models/domains_viewmodel.dart';
+import 'package:result_dart/result_dart.dart';
 
 import '../../../../testing/fakes/repositories/api/fake_domain_repository.dart';
+
+/// A [DomainRepository] whose [fetchAllDomains] result and timing can be
+/// controlled per test: swap the returned dataset, gate the response on a
+/// [Completer], force failures, and count how often it was hit.
+class _ControllableDomainRepository implements DomainRepository {
+  _ControllableDomainRepository(this._lists);
+
+  DomainLists _lists;
+  Completer<void>? gate;
+  bool shouldFail = false;
+  int fetchCount = 0;
+
+  void setLists(DomainLists lists) => _lists = lists;
+
+  @override
+  Future<Result<DomainLists>> fetchAllDomains() async {
+    fetchCount++;
+    final gate = this.gate;
+    if (gate != null) await gate.future;
+    if (shouldFail) {
+      return Failure(Exception('Force fetchAllDomains failure'));
+    }
+    return Success(_lists);
+  }
+
+  @override
+  Future<Result<Domain>> addDomain(
+    DomainType type,
+    DomainKind kind,
+    String domain, {
+    String? comment,
+    List<int>? groups = const [0],
+    bool? enabled = true,
+  }) async => Failure(Exception('not used'));
+
+  @override
+  Future<Result<Domain>> updateDomain(
+    DomainType type,
+    DomainKind kind,
+    String domain, {
+    String? comment,
+    List<int>? groups = const [0],
+    bool? enabled = true,
+  }) async => Failure(Exception('not used'));
+
+  @override
+  Future<Result<Unit>> deleteDomain(
+    DomainType type,
+    DomainKind kind,
+    String domain,
+  ) async => const Success(unit);
+}
+
+DateTime _ts = DateTime(2025, 1, 1);
+
+/// Builds a [DomainLists] holding a single allow-exact domain named [allowName]
+/// so tests can assert which server's dataset ended up in the view model.
+///
+/// [allowName] is optional: omit it when the dataset content is irrelevant and
+/// only a distinct repository instance is needed (e.g. server-switch resets).
+DomainLists _listsWith([String allowName = 'placeholder.com']) => DomainLists(
+  allowExact: [
+    Domain(
+      id: 1,
+      name: allowName,
+      punyCode: allowName,
+      type: DomainType.allow,
+      kind: DomainKind.exact,
+      comment: null,
+      groups: const [0],
+      enabled: true,
+      dateAdded: _ts,
+      dateModified: _ts,
+    ),
+  ],
+  allowRegex: const [],
+  denyExact: const [],
+  denyRegex: const [],
+);
 
 void main() {
   group('DomainsViewModel', () {
@@ -204,6 +288,187 @@ void main() {
           expect(viewModel.filteredBlacklistDomains.length, 0);
         },
       );
+    });
+  });
+
+  group('DomainsViewModel - stale-while-revalidate', () {
+    setUp(() => Command.globalExceptionHandler = (_, _) {});
+    tearDown(() => Command.globalExceptionHandler = null);
+
+    test(
+      'keeps cached list visible and sets isRevalidating during a background reload',
+      () async {
+        final repo = _ControllableDomainRepository(_listsWith('cached.com'));
+        final vm = DomainsViewModel(domainRepository: repo);
+        addTearDown(vm.dispose);
+
+        // First load populates the cache.
+        await vm.loadDomains.runAsync();
+        expect(vm.isRevalidating, isFalse);
+        expect(vm.whitelistDomains.single.name, 'cached.com');
+        expect(vm.loadingStatus, LoadStatus.loaded);
+
+        // Gate the next fetch so the reload stays in flight.
+        repo.setLists(_listsWith('fresh.com'));
+        repo.gate = Completer<void>();
+        final pending = vm.loadDomains.runAsync();
+        await Future<void>.delayed(Duration.zero);
+
+        // SWR: stale list stays visible, status stays loaded, bar is shown.
+        expect(vm.isRevalidating, isTrue);
+        expect(vm.loadingStatus, LoadStatus.loaded);
+        expect(vm.whitelistDomains.single.name, 'cached.com');
+
+        // Completing the reload swaps in the fresh data and clears the bar.
+        repo.gate!.complete();
+        await pending;
+        expect(vm.isRevalidating, isFalse);
+        expect(vm.loadingStatus, LoadStatus.loaded);
+        expect(vm.whitelistDomains.single.name, 'fresh.com');
+      },
+    );
+
+    test('failed background reload keeps the cached list', () async {
+      final repo = _ControllableDomainRepository(_listsWith('cached.com'));
+      final vm = DomainsViewModel(domainRepository: repo);
+      addTearDown(vm.dispose);
+
+      await vm.loadDomains.runAsync();
+      expect(vm.whitelistDomains.single.name, 'cached.com');
+
+      repo.shouldFail = true;
+      try {
+        await vm.loadDomains.runAsync();
+      } catch (_) {}
+
+      // Cache is preserved; no error screen because there is data to show.
+      expect(vm.loadingStatus, LoadStatus.loaded);
+      expect(vm.isRevalidating, isFalse);
+      expect(vm.whitelistDomains.single.name, 'cached.com');
+    });
+  });
+
+  group('DomainsViewModel - server switch (update)', () {
+    setUp(() => Command.globalExceptionHandler = (_, _) {});
+    tearDown(() => Command.globalExceptionHandler = null);
+
+    test('update() with a new repository resets cached state', () async {
+      final repoA = _ControllableDomainRepository(_listsWith('a.com'));
+      final vm = DomainsViewModel(domainRepository: repoA);
+      addTearDown(vm.dispose);
+
+      await vm.loadDomains.runAsync();
+      expect(vm.whitelistDomains, isNotEmpty);
+      expect(vm.loadingStatus, LoadStatus.loaded);
+
+      // Change server
+      vm.update(domainRepository: _ControllableDomainRepository(_listsWith()));
+
+      expect(vm.whitelistDomains, isEmpty);
+      expect(vm.blacklistDomains, isEmpty);
+      expect(vm.filteredWhitelistDomains, isEmpty);
+      expect(vm.filteredBlacklistDomains, isEmpty);
+      expect(vm.loadingStatus, LoadStatus.loading);
+      expect(vm.isRevalidating, isFalse);
+    });
+
+    test('update() with the same repository instance is a no-op', () async {
+      final repo = _ControllableDomainRepository(_listsWith('a.com'));
+      final vm = DomainsViewModel(domainRepository: repo);
+      addTearDown(vm.dispose);
+
+      await vm.loadDomains.runAsync();
+      expect(vm.whitelistDomains, isNotEmpty);
+
+      vm.update(domainRepository: repo);
+
+      // No reset: the loaded list is preserved.
+      expect(vm.whitelistDomains, isNotEmpty);
+      expect(vm.loadingStatus, LoadStatus.loaded);
+      expect(vm.whitelistDomains.single.name, 'a.com');
+    });
+
+    test(
+      'discards an in-flight load from the previous server (epoch guard)',
+      () async {
+        final repoA = _ControllableDomainRepository(_listsWith('a.com'));
+        repoA.gate = Completer<void>();
+        final repoB = _ControllableDomainRepository(_listsWith('b.com'));
+        final vm = DomainsViewModel(domainRepository: repoA);
+        addTearDown(vm.dispose);
+
+        // Start a load against server A that stays in flight.
+        final pendingOld = vm.loadDomains.runAsync();
+        await Future<void>.delayed(Duration.zero);
+        expect(repoA.fetchCount, 1);
+
+        // Switch to server B (screen inactive -> reset only, no eager reload).
+        vm.update(domainRepository: repoB);
+        expect(vm.whitelistDomains, isEmpty);
+
+        // The delayed server-A response must be discarded, not applied.
+        repoA.gate!.complete();
+        await pendingOld;
+        expect(vm.whitelistDomains, isEmpty);
+        expect(vm.loadingStatus, LoadStatus.loading);
+
+        // A fresh load now resolves against server B.
+        await vm.loadDomains.runAsync();
+        expect(vm.whitelistDomains.single.name, 'b.com');
+      },
+    );
+  });
+
+  group('DomainsViewModel - screen-active eager reload', () {
+    late TestWidgetsFlutterBinding binding;
+
+    setUpAll(() => binding = TestWidgetsFlutterBinding.ensureInitialized());
+    setUp(() => Command.globalExceptionHandler = (_, _) {});
+    tearDown(() => Command.globalExceptionHandler = null);
+
+    // Drives one frame so any post-frame callback scheduled by update() runs,
+    // then drains the (microtask-only) fetch.
+    Future<void> pumpFrame() async {
+      binding.handleBeginFrame(Duration.zero);
+      binding.handleDrawFrame();
+      await Future<void>.delayed(Duration.zero);
+    }
+
+    test(
+      'server switch while the screen is inactive does not eagerly reload',
+      () async {
+        final repoA = _ControllableDomainRepository(_listsWith('a.com'));
+        final repoB = _ControllableDomainRepository(_listsWith('b.com'));
+        final vm = DomainsViewModel(domainRepository: repoA);
+        addTearDown(vm.dispose);
+
+        // screenActive defaults to false: the switch resets state but must not
+        // schedule a background reload.
+        vm.update(domainRepository: repoB);
+        await pumpFrame();
+
+        expect(repoB.fetchCount, 0);
+        expect(vm.whitelistDomains, isEmpty);
+        expect(vm.loadingStatus, LoadStatus.loading);
+      },
+    );
+
+    test('server switch while the screen is active eagerly reloads', () async {
+      final repoA = _ControllableDomainRepository(_listsWith('a.com'));
+      final repoB = _ControllableDomainRepository(_listsWith('b.com'));
+      final vm = DomainsViewModel(domainRepository: repoA);
+      addTearDown(vm.dispose);
+
+      vm.setScreenActive(true);
+
+      // The switch schedules a background reload via a post-frame callback;
+      // running a frame fires it and drains the fetch (microtask-only, no gate).
+      vm.update(domainRepository: repoB);
+      await pumpFrame();
+
+      expect(repoB.fetchCount, 1);
+      expect(vm.whitelistDomains.single.name, 'b.com');
+      expect(vm.loadingStatus, LoadStatus.loaded);
     });
   });
 }

--- a/test/ui/domains/view_models/domains_viewmodel_test.dart
+++ b/test/ui/domains/view_models/domains_viewmodel_test.dart
@@ -59,17 +59,6 @@ class _ControllableDomainRepository implements DomainRepository {
       dateAdded: _ts,
       dateModified: _ts,
     );
-    // Simulate server persistence so a fetch issued after this reflects it.
-    _lists = DomainLists(
-      allowExact: type == DomainType.allow
-          ? [..._lists.allowExact, added]
-          : _lists.allowExact,
-      allowRegex: _lists.allowRegex,
-      denyExact: type == DomainType.deny
-          ? [..._lists.denyExact, added]
-          : _lists.denyExact,
-      denyRegex: _lists.denyRegex,
-    );
     return Success(added);
   }
 

--- a/test/ui/domains/view_models/domains_viewmodel_test.dart
+++ b/test/ui/domains/view_models/domains_viewmodel_test.dart
@@ -492,58 +492,24 @@ void main() {
         expect(vm.whitelistDomains.single.name, 'b.com');
       },
     );
-  });
 
-  group('DomainsViewModel - screen-active eager reload', () {
-    late TestWidgetsFlutterBinding binding;
-
-    setUpAll(() => binding = TestWidgetsFlutterBinding.ensureInitialized());
-    setUp(() => Command.globalExceptionHandler = (_, _) {});
-    tearDown(() => Command.globalExceptionHandler = null);
-
-    // Drives one frame so any post-frame callback scheduled by update() runs,
-    // then drains the (microtask-only) fetch.
-    Future<void> pumpFrame() async {
-      binding.handleBeginFrame(Duration.zero);
-      binding.handleDrawFrame();
-      await Future<void>.delayed(Duration.zero);
-    }
-
-    test(
-      'server switch while the screen is inactive does not eagerly reload',
-      () async {
-        final repoA = _ControllableDomainRepository(_listsWith('a.com'));
-        final repoB = _ControllableDomainRepository(_listsWith('b.com'));
-        final vm = DomainsViewModel(domainRepository: repoA);
-        addTearDown(vm.dispose);
-
-        // screenActive defaults to false: the switch resets state but must not
-        // schedule a background reload.
-        vm.update(domainRepository: repoB);
-        await pumpFrame();
-
-        expect(repoB.fetchCount, 0);
-        expect(vm.whitelistDomains, isEmpty);
-        expect(vm.loadingStatus, LoadStatus.loading);
-      },
-    );
-
-    test('server switch while the screen is active eagerly reloads', () async {
+    test('update() resets cached state but does not load on its own', () async {
       final repoA = _ControllableDomainRepository(_listsWith('a.com'));
       final repoB = _ControllableDomainRepository(_listsWith('b.com'));
       final vm = DomainsViewModel(domainRepository: repoA);
       addTearDown(vm.dispose);
 
-      vm.setScreenActive(true);
+      await vm.loadDomains.runAsync();
+      expect(vm.whitelistDomains.single.name, 'a.com');
 
-      // The switch schedules a background reload via a post-frame callback;
-      // running a frame fires it and drains the fetch (microtask-only, no gate).
+      // Switching servers clears the cache and marks loading, but the reload is
+      // deferred to the next screen mount — update() itself never fetches.
       vm.update(domainRepository: repoB);
-      await pumpFrame();
+      await Future<void>.delayed(Duration.zero);
 
-      expect(repoB.fetchCount, 1);
-      expect(vm.whitelistDomains.single.name, 'b.com');
-      expect(vm.loadingStatus, LoadStatus.loaded);
+      expect(repoB.fetchCount, 0);
+      expect(vm.whitelistDomains, isEmpty);
+      expect(vm.loadingStatus, LoadStatus.loading);
     });
   });
 }

--- a/test/ui/domains/view_models/domains_viewmodel_test.dart
+++ b/test/ui/domains/view_models/domains_viewmodel_test.dart
@@ -26,12 +26,16 @@ class _ControllableDomainRepository implements DomainRepository {
   @override
   Future<Result<DomainLists>> fetchAllDomains() async {
     fetchCount++;
+    // Capture the dataset at call time: a response that resolves later must
+    // reflect the data as it was when the query was issued, so a mutation that
+    // lands during an in-flight fetch is not retroactively included.
+    final snapshot = _lists;
     final gate = this.gate;
     if (gate != null) await gate.future;
     if (shouldFail) {
       return Failure(Exception('Force fetchAllDomains failure'));
     }
-    return Success(_lists);
+    return Success(snapshot);
   }
 
   @override
@@ -42,7 +46,32 @@ class _ControllableDomainRepository implements DomainRepository {
     String? comment,
     List<int>? groups = const [0],
     bool? enabled = true,
-  }) async => Failure(Exception('not used'));
+  }) async {
+    final added = Domain(
+      id: _lists.allowExact.length + _lists.denyExact.length + 100,
+      name: domain,
+      punyCode: domain,
+      type: type,
+      kind: kind,
+      comment: comment,
+      groups: groups ?? const [0],
+      enabled: enabled ?? true,
+      dateAdded: _ts,
+      dateModified: _ts,
+    );
+    // Simulate server persistence so a fetch issued after this reflects it.
+    _lists = DomainLists(
+      allowExact: type == DomainType.allow
+          ? [..._lists.allowExact, added]
+          : _lists.allowExact,
+      allowRegex: _lists.allowRegex,
+      denyExact: type == DomainType.deny
+          ? [..._lists.denyExact, added]
+          : _lists.denyExact,
+      denyRegex: _lists.denyRegex,
+    );
+    return Success(added);
+  }
 
   @override
   Future<Result<Domain>> updateDomain(
@@ -346,6 +375,52 @@ void main() {
       expect(vm.isRevalidating, isFalse);
       expect(vm.whitelistDomains.single.name, 'cached.com');
     });
+
+    test(
+      'a mutation during revalidation is not overwritten by the stale fetch',
+      () async {
+        final repo = _ControllableDomainRepository(_listsWith('cached.com'));
+        final vm = DomainsViewModel(domainRepository: repo);
+        addTearDown(vm.dispose);
+
+        // First load populates the cache.
+        await vm.loadDomains.runAsync();
+        expect(vm.whitelistDomains.map((d) => d.name), ['cached.com']);
+
+        // Start a revalidation and gate it so it stays in flight. Its snapshot
+        // is captured now (just {cached.com}), before the upcoming add.
+        repo.gate = Completer<void>();
+        final pending = vm.loadDomains.runAsync();
+        await Future<void>.delayed(Duration.zero);
+        expect(vm.isRevalidating, isTrue);
+
+        // While the revalidation is in flight, the user adds a domain; the
+        // server confirms it and the local list updates optimistically.
+        await vm.addDomain.runAsync((
+          type: DomainType.allow,
+          kind: DomainKind.exact,
+          domain: 'added.com',
+        ));
+        expect(vm.whitelistDomains.map((d) => d.name), [
+          'cached.com',
+          'added.com',
+        ]);
+
+        // The in-flight fetch resolves with its pre-add snapshot. It must be
+        // discarded, not applied over the user's confirmed addition.
+        repo.gate!.complete();
+        await pending;
+
+        expect(vm.whitelistDomains.map((d) => d.name), [
+          'cached.com',
+          'added.com',
+        ]);
+        expect(vm.isRevalidating, isFalse);
+        expect(vm.loadingStatus, LoadStatus.loaded);
+        // Only the single gated fetch ran; the discard does not re-fetch.
+        expect(repo.fetchCount, 2);
+      },
+    );
   });
 
   group('DomainsViewModel - server switch (update)', () {

--- a/test/widgets/helpers.mocks.dart
+++ b/test/widgets/helpers.mocks.dart
@@ -842,14 +842,6 @@ class MockLogsViewModel extends _i1.Mock implements _i18.LogsViewModel {
   }
 
   @override
-  bool get domainListDirty =>
-      (super.noSuchMethod(
-            Invocation.getter(#domainListDirty),
-            returnValue: false,
-          )
-          as bool);
-
-  @override
   String get apiVersion =>
       (super.noSuchMethod(
             Invocation.getter(#apiVersion),
@@ -1038,12 +1030,6 @@ class MockLogsViewModel extends _i1.Mock implements _i18.LogsViewModel {
   @override
   void refreshClients() => super.noSuchMethod(
     Invocation.method(#refreshClients, []),
-    returnValueForMissingStub: null,
-  );
-
-  @override
-  void clearDomainListDirty() => super.noSuchMethod(
-    Invocation.method(#clearDomainListDirty, []),
     returnValueForMissingStub: null,
   );
 


### PR DESCRIPTION
## Overview

Returning to the Domains tab previously recreated the view model and showed a full-screen spinner on every visit, re-fetching from scratch. This change makes DomainsViewModel app-wide so its cached lists survive bottom-tab switches, and adopts a stale-while-revalidate (SWR) pattern: the cached list stays visible with a thin progress bar while fresh data loads in the background.

## Changes

- Make DomainsViewModel app-wide so its cache survives tab switches, reloading on remount instead of recreating per route.
- Keep the cached list visible with a thin progress bar during background revalidation; full-screen spinner only on first load and server switch.
- Reset the cache and guard against stale responses on server switch and against local edits being overwritten by an in-flight revalidation.
- Remove the now-unused domainListDirty flag from LogsViewModel and add tests for the SWR, epoch-guard, and mutation-race paths.