### PR TITLE
feat(adlists): navigate to adlist details from gravity update messages

### DIFF
--- a/lib/ui/core/l10n/app_de.arb
+++ b/lib/ui/core/l10n/app_de.arb
@@ -30,6 +30,7 @@
   "adlistInfo": "Adlist-Informationen",
   "adlistInvalid": "Ungültige Adlist-URL",
   "adlistNotExists": "Adlist existiert nicht",
+  "adlistNotFoundForMessage": "Keine passende Adlist gefunden",
   "adlistRemoved": "Adlist wurde erfolgreich entfernt",
   "adlistSettings": "Adlist-Einstellungen",
   "adlistStatus": "Zustand",

--- a/lib/ui/core/l10n/app_en.arb
+++ b/lib/ui/core/l10n/app_en.arb
@@ -30,6 +30,7 @@
   "adlistInfo": "Adlist Info",
   "adlistInvalid": "Invalid adlist URL",
   "adlistNotExists": "Adlist does not exist",
+  "adlistNotFoundForMessage": "No matching adlist was found",
   "adlistRemoved": "Adlist removed successfully",
   "adlistSettings": "Adlist Settings",
   "adlistStatus": "Health Status",

--- a/lib/ui/core/l10n/app_es.arb
+++ b/lib/ui/core/l10n/app_es.arb
@@ -30,6 +30,7 @@
   "adlistInfo": "Información de Adlist",
   "adlistInvalid": "URL de Adlist no válida",
   "adlistNotExists": "La Adlist no existe",
+  "adlistNotFoundForMessage": "No se encontró ninguna lista correspondiente",
   "adlistRemoved": "Adlist eliminada correctamente",
   "adlistSettings": "Configuración de Adlist",
   "adlistStatus": "Estado de salud",

--- a/lib/ui/core/l10n/app_ja.arb
+++ b/lib/ui/core/l10n/app_ja.arb
@@ -30,6 +30,7 @@
   "adlistInfo": "Adlistの情報",
   "adlistInvalid": "無効なAdlistのURLです",
   "adlistNotExists": "Adlistが存在しません",
+  "adlistNotFoundForMessage": "対応する広告リストが見つかりませんでした",
   "adlistRemoved": "Adlistを正常に削除しました",
   "adlistSettings": "Adlistの設定",
   "adlistStatus": "ヘルスステータス",

--- a/lib/ui/core/l10n/app_pl.arb
+++ b/lib/ui/core/l10n/app_pl.arb
@@ -30,6 +30,7 @@
   "adlistInfo": "Informacje o Adlist",
   "adlistInvalid": "Nieprawidłowy adres URL listy Adlist",
   "adlistNotExists": "Adlist nie istnieje",
+  "adlistNotFoundForMessage": "Nie znaleziono pasującej listy",
   "adlistRemoved": "Adlist został pomyślnie usunięty",
   "adlistSettings": "Ustawienia Adlist",
   "adlistStatus": "Stan kondycji",

--- a/lib/ui/core/l10n/generated/app_localizations.dart
+++ b/lib/ui/core/l10n/generated/app_localizations.dart
@@ -284,6 +284,12 @@ abstract class AppLocalizations {
   /// **'Adlist does not exist'**
   String get adlistNotExists;
 
+  /// No description provided for @adlistNotFoundForMessage.
+  ///
+  /// In en, this message translates to:
+  /// **'No matching adlist was found'**
+  String get adlistNotFoundForMessage;
+
   /// No description provided for @adlistRemoved.
   ///
   /// In en, this message translates to:

--- a/lib/ui/core/l10n/generated/app_localizations_de.dart
+++ b/lib/ui/core/l10n/generated/app_localizations_de.dart
@@ -100,6 +100,9 @@ class AppLocalizationsDe extends AppLocalizations {
   String get adlistNotExists => 'Adlist existiert nicht';
 
   @override
+  String get adlistNotFoundForMessage => 'Keine passende Adlist gefunden';
+
+  @override
   String get adlistRemoved => 'Adlist wurde erfolgreich entfernt';
 
   @override

--- a/lib/ui/core/l10n/generated/app_localizations_en.dart
+++ b/lib/ui/core/l10n/generated/app_localizations_en.dart
@@ -100,6 +100,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get adlistNotExists => 'Adlist does not exist';
 
   @override
+  String get adlistNotFoundForMessage => 'No matching adlist was found';
+
+  @override
   String get adlistRemoved => 'Adlist removed successfully';
 
   @override

--- a/lib/ui/core/l10n/generated/app_localizations_es.dart
+++ b/lib/ui/core/l10n/generated/app_localizations_es.dart
@@ -100,6 +100,10 @@ class AppLocalizationsEs extends AppLocalizations {
   String get adlistNotExists => 'La Adlist no existe';
 
   @override
+  String get adlistNotFoundForMessage =>
+      'No se encontró ninguna lista correspondiente';
+
+  @override
   String get adlistRemoved => 'Adlist eliminada correctamente';
 
   @override

--- a/lib/ui/core/l10n/generated/app_localizations_ja.dart
+++ b/lib/ui/core/l10n/generated/app_localizations_ja.dart
@@ -99,6 +99,9 @@ class AppLocalizationsJa extends AppLocalizations {
   String get adlistNotExists => 'Adlistが存在しません';
 
   @override
+  String get adlistNotFoundForMessage => '対応する広告リストが見つかりませんでした';
+
+  @override
   String get adlistRemoved => 'Adlistを正常に削除しました';
 
   @override

--- a/lib/ui/core/l10n/generated/app_localizations_pl.dart
+++ b/lib/ui/core/l10n/generated/app_localizations_pl.dart
@@ -99,6 +99,9 @@ class AppLocalizationsPl extends AppLocalizations {
   String get adlistNotExists => 'Adlist nie istnieje';
 
   @override
+  String get adlistNotFoundForMessage => 'Nie znaleziono pasującej listy';
+
+  @override
   String get adlistRemoved => 'Adlist został pomyślnie usunięty';
 
   @override

--- a/lib/ui/settings/server_settings/adlists/widgets/gravity_update.dart
+++ b/lib/ui/settings/server_settings/adlists/widgets/gravity_update.dart
@@ -106,9 +106,7 @@ class _GravityUpdateState extends State<GravityUpdate> {
         shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
         clipBehavior: Clip.antiAlias,
         child: InkWell(
-          onTap: () {
-            onTap();
-          },
+          onTap: onTap,
           child: Padding(
             padding: const EdgeInsets.symmetric(vertical: 12, horizontal: 16),
             child: Row(

--- a/lib/ui/settings/server_settings/adlists/widgets/gravity_update.dart
+++ b/lib/ui/settings/server_settings/adlists/widgets/gravity_update.dart
@@ -1,11 +1,20 @@
+import 'package:collection/collection.dart';
 import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
 import 'package:pi_hole_client/domain/model/enums.dart';
+import 'package:pi_hole_client/domain/model/ftl/message.dart';
+import 'package:pi_hole_client/domain/model/list/adlist.dart';
+import 'package:pi_hole_client/routing/route_extra.dart';
+import 'package:pi_hole_client/routing/routes.dart';
 import 'package:pi_hole_client/ui/core/l10n/generated/app_localizations.dart';
 import 'package:pi_hole_client/ui/core/themes/theme.dart';
 import 'package:pi_hole_client/ui/core/ui/components/section_label.dart';
 import 'package:pi_hole_client/ui/core/ui/helpers/snackbar.dart';
 import 'package:pi_hole_client/ui/core/view_models/app_config_viewmodel.dart';
+import 'package:pi_hole_client/ui/settings/server_settings/adlists/view_models/adlists_viewmodel.dart';
 import 'package:pi_hole_client/ui/settings/server_settings/adlists/view_models/gravity_update_viewmodel.dart';
+import 'package:pi_hole_client/ui/settings/server_settings/adlists/widgets/adlist_actions.dart';
+import 'package:pi_hole_client/ui/settings/server_settings/group_client/view_models/groups_viewmodel.dart';
 import 'package:pi_hole_client/utils/format.dart';
 import 'package:pi_hole_client/utils/logger.dart';
 import 'package:provider/provider.dart';
@@ -78,6 +87,7 @@ class _GravityUpdateState extends State<GravityUpdate> {
     required String title,
     required String subtitle,
     required Future<bool> Function() onDelete,
+    required void Function() onTap,
     required Icon icon,
     Key? key,
   }) {
@@ -94,38 +104,44 @@ class _GravityUpdateState extends State<GravityUpdate> {
       child: Card(
         margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
         shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
-        child: Padding(
-          padding: const EdgeInsets.symmetric(vertical: 12, horizontal: 16),
-          child: Row(
-            children: [
-              Padding(padding: const EdgeInsets.only(right: 12), child: icon),
-              Expanded(
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    Text(
-                      title,
-                      style: const TextStyle(
-                        fontSize: 12,
-                        fontWeight: FontWeight.w500,
+        clipBehavior: Clip.antiAlias,
+        child: InkWell(
+          onTap: () {
+            onTap();
+          },
+          child: Padding(
+            padding: const EdgeInsets.symmetric(vertical: 12, horizontal: 16),
+            child: Row(
+              children: [
+                Padding(padding: const EdgeInsets.only(right: 12), child: icon),
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        title,
+                        style: const TextStyle(
+                          fontSize: 12,
+                          fontWeight: FontWeight.w500,
+                        ),
                       ),
-                    ),
-                    const SizedBox(height: 2),
-                    Text(
-                      subtitle,
-                      style: TextStyle(
-                        fontSize: 12,
-                        color: Theme.of(context).colorScheme.onSurfaceVariant,
+                      const SizedBox(height: 2),
+                      Text(
+                        subtitle,
+                        style: TextStyle(
+                          fontSize: 12,
+                          color: Theme.of(context).colorScheme.onSurfaceVariant,
+                        ),
                       ),
-                    ),
-                  ],
+                    ],
+                  ),
                 ),
-              ),
-              Icon(
-                Icons.swipe_left_alt_rounded,
-                color: Theme.of(context).colorScheme.outlineVariant,
-              ),
-            ],
+                Icon(
+                  Icons.swipe_left_alt_rounded,
+                  color: Theme.of(context).colorScheme.outlineVariant,
+                ),
+              ],
+            ),
           ),
         ),
       ),
@@ -153,6 +169,7 @@ class _GravityUpdateState extends State<GravityUpdate> {
                 appConfigViewModel: context.read<AppConfigViewModel>(),
                 messageId: message.id,
               ),
+              onTap: () => handleMessageTap(context: context, message: message),
             );
           }).toList(),
         );
@@ -214,6 +231,44 @@ class _GravityUpdateState extends State<GravityUpdate> {
       }
     }
     return success;
+  }
+
+  void handleMessageTap({
+    required BuildContext context,
+    required FtlMessage message,
+  }) {
+    final viewModel = context.read<AdlistsViewModel>();
+    final appConfigViewModel = context.read<AppConfigViewModel>();
+
+    final adlist = [
+      ...viewModel.whitelistAdlists,
+      ...viewModel.blacklistAdlists,
+    ].firstWhereOrNull((a) => a.address == message.url);
+
+    if (adlist == null) {
+      showErrorSnackBar(
+        context: context,
+        appConfigViewModel: appConfigViewModel,
+        label: AppLocalizations.of(context)!.adlistNotFoundForMessage,
+      );
+      return;
+    }
+
+    context.pushNamed(
+      Routes.settingsServerAdlistsDetails,
+      extra: AdlistDetailsExtra(
+        adlist: adlist,
+        remove: (Adlist a) => deleteAdlist(
+          context: context,
+          viewModel: viewModel,
+          appConfigViewModel: appConfigViewModel,
+          adlist: a,
+        ),
+        groups: context.read<GroupsViewModel>().groupItems,
+        colors: appConfigViewModel.colors,
+        viewModel: viewModel,
+      ),
+    );
   }
 
   @override

--- a/mock_api_server/lib/handlers/info_handler.dart
+++ b/mock_api_server/lib/handlers/info_handler.dart
@@ -241,6 +241,24 @@ class InfoHandler {
             "html":
                 "Connection error (<strong>127.0.0.1#5335</strong>): TCP connection failed while receiving payload length from upstream (<strong>Connection prematurely closed by remote server</strong>)",
           },
+          {
+            "id": 201,
+            "timestamp": 1744481762,
+            "type": "LIST",
+            "plain":
+                "List with ID 30 (https://blocklistproject.github.io/Lists/malware.txt) was inaccessible during last gravity run",
+            "html":
+                "List with ID <strong>30</strong> (<a href=\"https://blocklistproject.github.io/Lists/malware.txt\">https://blocklistproject.github.io/Lists/malware.txt</a>) was inaccessible during last gravity run",
+          },
+          {
+            "id": 202,
+            "timestamp": 1744481763,
+            "type": "LIST",
+            "plain":
+                "List with ID 333 (https://raw.githubusercontent.com/Perflyst/PiHoleBlocklist/master/SmartTV-notfound.txt) was inaccessible during last gravity run",
+            "html":
+                "List with ID <strong>333</strong> (<a href=\"https://raw.githubusercontent.com/Perflyst/PiHoleBlocklist/master/SmartTV-notfound.txt\">https://raw.githubusercontent.com/Perflyst/PiHoleBlocklist/master/SmartTV-notfound.txt</a>) was inaccessible during last gravity run",
+          },
         ],
         "took": 0.003072500228881836,
       };

--- a/test/ui/settings/server_settings/adlists/adlists_test.dart
+++ b/test/ui/settings/server_settings/adlists/adlists_test.dart
@@ -902,5 +902,89 @@ void main() async {
       );
       expect(find.text('http://localhost:8989/test.txt'), findsNothing);
     });
+
+    testWidgets(
+      'should navigate to adlist details when message card is tapped',
+      (WidgetTester tester) async {
+        tester.view.physicalSize = const Size(1080, 2400);
+        tester.view.devicePixelRatio = 2.0;
+
+        fakeGravityUpdateViewModel.logs = ['Log1', 'Log2', 'Done'];
+        fakeGravityUpdateViewModel.status = GravityStatus.success;
+        fakeGravityUpdateViewModel.isLoaded = true;
+        fakeGravityUpdateViewModel.completedAtTime =
+            DateTime.fromMillisecondsSinceEpoch(1733465701 * 1000);
+        fakeGravityUpdateViewModel.messages = [
+          FtlMessage(
+            id: 5,
+            timestamp: DateTime.fromMillisecondsSinceEpoch(1743936482 * 1000),
+            message:
+                'List with ID 106 was inaccessible during last gravity run',
+            url: 'https://hosts-file.net/ad_servers.txt',
+          ),
+        ];
+
+        addTearDown(() {
+          tester.view.resetPhysicalSize();
+          tester.view.resetDevicePixelRatio();
+        });
+
+        await tester.pumpWidget(buildAdlistWidgetWithRouter());
+
+        expect(find.byType(AdlistScreen), findsOneWidget);
+        await tester.pump();
+
+        await tester.tap(find.text('Update Gravity'));
+        await tester.pumpAndSettle();
+
+        await tester.tap(
+          find.text(
+            'List with ID 106 was inaccessible during last gravity run',
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        expect(find.byType(AdlistDetailsScreen), findsOneWidget);
+        expect(find.text('Adlist Details'), findsOneWidget);
+      },
+    );
+
+    testWidgets(
+      'should show snackbar when no matching adlist for tapped message',
+      (WidgetTester tester) async {
+        tester.view.physicalSize = const Size(1080, 2400);
+        tester.view.devicePixelRatio = 2.0;
+
+        fakeGravityUpdateViewModel.logs = ['Log1', 'Log2', 'Done'];
+        fakeGravityUpdateViewModel.status = GravityStatus.success;
+        fakeGravityUpdateViewModel.isLoaded = true;
+        fakeGravityUpdateViewModel.completedAtTime =
+            DateTime.fromMillisecondsSinceEpoch(1733465701 * 1000);
+        // The default message url ('http://localhost:8989/test.txt') does not
+        // match any adlist, so a "not found" snackbar should be shown instead.
+
+        addTearDown(() {
+          tester.view.resetPhysicalSize();
+          tester.view.resetDevicePixelRatio();
+        });
+
+        await tester.pumpWidget(buildAdlistWidgetWithRouter());
+
+        expect(find.byType(AdlistScreen), findsOneWidget);
+        await tester.pump();
+
+        await tester.tap(find.text('Update Gravity'));
+        await tester.pumpAndSettle();
+
+        await tester.tap(
+          find.text('List with ID 10 was inaccessible during last gravity run'),
+        );
+        await tester.pumpAndSettle();
+
+        expect(find.byType(AdlistDetailsScreen), findsNothing);
+        expect(find.byType(SnackBar), findsOneWidget);
+        expect(find.text('No matching adlist was found'), findsWidgets);
+      },
+    );
   });
 }


### PR DESCRIPTION
## Overview
Gravity update message cards in server settings are now tappable, navigating the user to the details of the adlist referenced by the message. When no matching adlist can be found for a message, an error snackbar is shown instead.

## Changes
- Make gravity update message cards tappable, opening the corresponding adlist details screen
- Match a tapped message to its adlist by URL across whitelist and blacklist adlists, with deletion wired through the existing flow
- Show an error snackbar with a localized message when no matching adlist is found
- Add the adlistNotFoundForMessage string across all supported locales (en, de, es, ja, pl)
- Add inaccessible-list (LIST type) sample messages to the mock API server response
- Add widget tests covering tap navigation and the not-found case