### PR TITLE
feat(add_server): improve error handling for existing connections

### DIFF
--- a/lib/ui/servers/widgets/add_server_fullscreen.dart
+++ b/lib/ui/servers/widgets/add_server_fullscreen.dart
@@ -56,7 +56,6 @@ class _AddServerFullscreenState extends State<AddServerFullscreen> {
   bool ignoreCertificateErrors = false;
   String? pinnedCertificateSha256;
 
-  String? errorUrl;
   bool allDataValid = false;
 
   String errorMessage = 'Failed';
@@ -430,12 +429,15 @@ class _AddServerFullscreenState extends State<AddServerFullscreen> {
 
       if (exists['result'] == 'success' && exists['exists'] == true) {
         setState(() {
-          errorUrl = AppLocalizations.of(context)!.connectionAlreadyExists;
           isConnecting = false;
         });
+        showErrorSnackBar(
+          context: context,
+          appConfigViewModel: appConfigViewModel,
+          label: AppLocalizations.of(context)!.connectionAlreadyExists,
+        );
       } else if (exists['result'] == 'fail') {
         setState(() {
-          errorUrl = null;
           isConnecting = false;
         });
         showErrorSnackBar(
@@ -444,9 +446,6 @@ class _AddServerFullscreenState extends State<AddServerFullscreen> {
           label: AppLocalizations.of(context)!.cannotCheckUrlSaved,
         );
       } else {
-        setState(() {
-          errorUrl = null;
-        });
         var serverObj = Server(
           address: url,
           alias: aliasFieldController.text,
@@ -541,7 +540,6 @@ class _AddServerFullscreenState extends State<AddServerFullscreen> {
       FocusManager.instance.primaryFocus?.unfocus();
       final saveCreateBundle = context.read<CreateRepositoryBundle>();
       setState(() {
-        errorUrl = null;
         isConnecting = true;
       });
 
@@ -1091,22 +1089,6 @@ class _AddServerFullscreenState extends State<AddServerFullscreen> {
               ],
             ),
           ),
-          if (errorUrl != null)
-            Padding(
-              padding: const EdgeInsets.only(top: 7),
-              child: Row(
-                mainAxisAlignment: MainAxisAlignment.center,
-                children: [
-                  Text(
-                    errorUrl!,
-                    style: const TextStyle(
-                      fontWeight: FontWeight.bold,
-                      color: Colors.red,
-                    ),
-                  ),
-                ],
-              ),
-            ),
         ],
       );
     }


### PR DESCRIPTION
## Overview
When adding a server whose connection already exists, the error was previously shown as an inline red text below the form. This replaces that inline message with a consistent error snackbar, matching how other connection errors are surfaced.

## Changes
- Show the "connection already exists" error using `showErrorSnackBar` instead of inline red text
- Remove the now-unused `errorUrl` state field and its inline error widget

## Scrrenshot

|before|after|
|---|----|
|<img width="336" height="748" alt="Screenshot_1780576748" src="https://github.com/user-attachments/assets/d1061d45-a68d-4c0c-a213-71582515bfdd" />|<img width="336" height="748" alt="Screenshot_1780576725" src="https://github.com/user-attachments/assets/65858ae4-39ac-4938-86ba-9a85b7700876" />|

## Summary by Sourcery

Unify how "connection already exists" errors are surfaced when adding a server by switching from an inline form message to the global snackbar pattern and removing the now-unused inline error state.

Bug Fixes:
- Display the "connection already exists" validation failure via the standard error snackbar instead of inline form text for consistency with other connection errors.

Enhancements:
- Remove the obsolete URL error state and its inline error widget from the add-server fullscreen UI.