### PR TITLE
refactor(tls): make TLS certificate fetcher injectable

### DIFF
--- a/lib/ui/core/services/server_connection_service.dart
+++ b/lib/ui/core/services/server_connection_service.dart
@@ -65,6 +65,7 @@ class ServerConnectionService {
     required this.createBundle,
     this.useRootContextOnFailure = false,
     this.showModal = false,
+    this.fetchTlsCertificate = fetchTlsCertificateInfo,
   });
 
   final BuildContext context;
@@ -75,6 +76,7 @@ class ServerConnectionService {
   final CreateRepositoryBundle createBundle;
   final bool useRootContextOnFailure;
   final bool showModal;
+  final TlsCertificateFetcher fetchTlsCertificate;
 
   Future<void> connect() async {
     // Prevent a second concurrent connection attempt to the same server.
@@ -256,7 +258,7 @@ class ServerConnectionService {
     // If the platform TLS validation succeeds, treat the connection as verified
     // and do not require pin setup (user may still choose to pin manually).
     try {
-      await fetchTlsCertificateInfo(
+      await fetchTlsCertificate(
         uri,
         allowBadCertificates: false,
         timeout: const Duration(seconds: 3),
@@ -398,6 +400,7 @@ class ServerConnectionService {
             createBundle: createBundle,
             useRootContextOnFailure: useRootContextOnFailure,
             showModal: showModal,
+            fetchTlsCertificate: fetchTlsCertificate,
           ).connect();
         }
       } else {
@@ -422,7 +425,7 @@ class ServerConnectionService {
 
     TlsCertificateInfo? certificateInfo;
     try {
-      certificateInfo = await fetchTlsCertificateInfo(
+      certificateInfo = await fetchTlsCertificate(
         uri,
         allowBadCertificates: true,
       );
@@ -536,7 +539,7 @@ class ServerConnectionService {
     if (!server.allowUntrustedCert) return false;
 
     try {
-      final info = await fetchTlsCertificateInfo(
+      final info = await fetchTlsCertificate(
         uri,
         allowBadCertificates: true,
         timeout: const Duration(seconds: 3),

--- a/lib/ui/servers/widgets/add_server_fullscreen.dart
+++ b/lib/ui/servers/widgets/add_server_fullscreen.dart
@@ -27,11 +27,13 @@ class AddServerFullscreen extends StatefulWidget {
     required this.title,
     super.key,
     this.server,
+    this.fetchTlsCertificate = fetchTlsCertificateInfo,
   });
 
   final Server? server;
   final bool window;
   final String title;
+  final TlsCertificateFetcher fetchTlsCertificate;
 
   @override
   State<AddServerFullscreen> createState() => _AddServerFullscreenState();
@@ -293,7 +295,7 @@ class _AddServerFullscreenState extends State<AddServerFullscreen> {
 
       try {
         // If the certificate is trusted by the platform, pin it automatically.
-        final info = await fetchTlsCertificateInfo(
+        final info = await widget.fetchTlsCertificate(
           uri,
           allowBadCertificates: false,
         );
@@ -310,7 +312,7 @@ class _AddServerFullscreenState extends State<AddServerFullscreen> {
 
       TlsCertificateInfo? certificateInfo;
       try {
-        certificateInfo = await fetchTlsCertificateInfo(
+        certificateInfo = await widget.fetchTlsCertificate(
           uri,
           allowBadCertificates: true,
         );
@@ -388,7 +390,7 @@ class _AddServerFullscreenState extends State<AddServerFullscreen> {
       } else {
         // Strict mode: verify certificate is trusted by the platform
         try {
-          await fetchTlsCertificateInfo(uri, allowBadCertificates: false);
+          await widget.fetchTlsCertificate(uri, allowBadCertificates: false);
           // Certificate is trusted, proceed without pin
           // ignore: avoid_redundant_argument_values
           return serverObj.copyWith(pinnedCertificateSha256: null);

--- a/lib/ui/servers/widgets/server_tile_actions.dart
+++ b/lib/ui/servers/widgets/server_tile_actions.dart
@@ -31,6 +31,7 @@ class ServerTileActions extends StatelessWidget {
     required this.onDelete,
     required this.onSetDefault,
     super.key,
+    this.fetchTlsCertificate = fetchTlsCertificateInfo,
   });
 
   final Server server;
@@ -38,6 +39,7 @@ class ServerTileActions extends StatelessWidget {
   final VoidCallback onEdit;
   final VoidCallback onDelete;
   final VoidCallback onSetDefault;
+  final TlsCertificateFetcher fetchTlsCertificate;
 
   @override
   Widget build(BuildContext context) {
@@ -162,7 +164,7 @@ class ServerTileActions extends StatelessWidget {
 
     TlsCertificateInfo? certificateInfo;
     try {
-      certificateInfo = await fetchTlsCertificateInfo(
+      certificateInfo = await fetchTlsCertificate(
         uri,
         allowBadCertificates: true,
       );

--- a/lib/ui/servers/widgets/transport_security_indicator.dart
+++ b/lib/ui/servers/widgets/transport_security_indicator.dart
@@ -33,9 +33,14 @@ class _TransportSecurityViewData {
 }
 
 class TransportSecurityIndicator extends StatefulWidget {
-  const TransportSecurityIndicator({required this.server, super.key});
+  const TransportSecurityIndicator({
+    required this.server,
+    super.key,
+    this.fetchTlsCertificate = fetchTlsCertificateInfo,
+  });
 
   final Server server;
+  final TlsCertificateFetcher fetchTlsCertificate;
 
   @override
   State<TransportSecurityIndicator> createState() =>
@@ -114,7 +119,7 @@ class _TransportSecurityIndicatorState
     required Duration timeout,
   }) async {
     try {
-      await fetchTlsCertificateInfo(
+      await widget.fetchTlsCertificate(
         uri,
         allowBadCertificates: false,
         timeout: timeout,
@@ -163,7 +168,7 @@ class _TransportSecurityIndicatorState
     required Duration timeout,
   }) async {
     try {
-      return await fetchTlsCertificateInfo(
+      return await widget.fetchTlsCertificate(
         uri,
         allowBadCertificates: true,
         timeout: timeout,

--- a/lib/utils/tls_certificate.dart
+++ b/lib/utils/tls_certificate.dart
@@ -18,6 +18,17 @@ class TlsCertificateInfo {
   final DateTime endValidity;
 }
 
+/// Function signature for fetching TLS certificate information.
+///
+/// Matches [fetchTlsCertificateInfo] so the real implementation can be used as
+/// the default value, while tests inject a fake to avoid a real TLS handshake.
+typedef TlsCertificateFetcher =
+    Future<TlsCertificateInfo?> Function(
+      Uri uri, {
+      required bool allowBadCertificates,
+      Duration timeout,
+    });
+
 /// Fetches the server TLS certificate SHA-256 fingerprint (if available).
 ///
 /// This function performs a TLS handshake using [SecureSocket.connect] and returns


### PR DESCRIPTION
## Overview
The TLS certificate flow called the top-level `fetchTlsCertificateInfo` directly, which performs a real `SecureSocket.connect` handshake and cannot be reliably exercised in widget tests. This PR makes the fetcher injectable so the certificate dialog / pin-reset / retry flows can be tested with a fake, with no change to production behavior.

## Changes
- No behavior change: production callers rely on the default real implementation, so existing call sites and tests remain untouched.

## Summary by Sourcery

Make TLS certificate fetching injectable across UI and connection services to enable testing with fake implementations while preserving existing behavior.

Enhancements:
- Introduce a TlsCertificateFetcher typedef that matches the existing TLS certificate fetch function signature.
- Inject the TLS certificate fetcher into server connection service and related widgets, defaulting to the real implementation for production use.