### PR TITLE
feat(servers): allow editing connection fields of an existing server

### DIFF
--- a/lib/data/repositories/local/interfaces/server_repository.dart
+++ b/lib/data/repositories/local/interfaces/server_repository.dart
@@ -17,13 +17,7 @@ abstract interface class ServerRepository {
   });
   Future<Result<int>> updateDefaultServer(String url);
 
-  Future<Result<int>> replaceServer(
-    String oldAddress,
-    Server newServer, {
-    String? token,
-    String? password,
-    String? sid,
-  });
+  Future<Result<int>> replaceServer(String oldAddress, Server newServer);
 
   Future<Result<int>> deleteServer(String address);
   Future<Result<int>> deleteAllServers();

--- a/lib/data/repositories/local/interfaces/server_repository.dart
+++ b/lib/data/repositories/local/interfaces/server_repository.dart
@@ -44,4 +44,5 @@ abstract interface class ServerRepository {
   Future<Result<void>> saveToken(String address, String token);
   Future<Result<void>> deletePassword(String address);
   Future<Result<void>> deleteToken(String address);
+  Future<Result<void>> deleteSid(String address);
 }

--- a/lib/data/repositories/local/interfaces/server_repository.dart
+++ b/lib/data/repositories/local/interfaces/server_repository.dart
@@ -16,6 +16,15 @@ abstract interface class ServerRepository {
     String? sid,
   });
   Future<Result<int>> updateDefaultServer(String url);
+
+  Future<Result<int>> replaceServer(
+    String oldAddress,
+    Server newServer, {
+    String? token,
+    String? password,
+    String? sid,
+  });
+
   Future<Result<int>> deleteServer(String address);
   Future<Result<int>> deleteAllServers();
   Future<Result<bool>> doesServerExist(String url);

--- a/lib/data/repositories/local/server_repository.dart
+++ b/lib/data/repositories/local/server_repository.dart
@@ -4,7 +4,6 @@ import 'package:pi_hole_client/data/services/local/database_service.dart';
 import 'package:pi_hole_client/data/services/local/secure_storage_service.dart';
 import 'package:pi_hole_client/data/services/utils/database_utils.dart';
 import 'package:pi_hole_client/domain/model/server/server.dart';
-import 'package:pi_hole_client/utils/conversions.dart';
 import 'package:pi_hole_client/utils/logger.dart';
 import 'package:result_dart/result_dart.dart';
 
@@ -96,14 +95,20 @@ class LocalServerRepository implements ServerRepository {
         await _secureStorage.saveValue('${server.address}_sid', sid);
       }
 
-      return await _database.insert('servers', {
-        'address': server.address,
-        'alias': server.alias,
-        'isDefaultServer': server.defaultServer ? 1 : 0,
-        'apiVersion': server.apiVersion,
-        'allowUntrustedCert': server.allowUntrustedCert ? 1 : 0,
-        'ignoreCertificateErrors': server.ignoreCertificateErrors ? 1 : 0,
-        'pinnedCertificateSha256': server.pinnedCertificateSha256,
+      return await _database.transaction<int>((txn) async {
+        // Keep "only one default" invariant atomic with the insert.
+        if (server.defaultServer) {
+          await txn.update('servers', {'isDefaultServer': 0});
+        }
+        return txn.insert('servers', {
+          'address': server.address,
+          'alias': server.alias,
+          'isDefaultServer': server.defaultServer ? 1 : 0,
+          'apiVersion': server.apiVersion,
+          'allowUntrustedCert': server.allowUntrustedCert ? 1 : 0,
+          'ignoreCertificateErrors': server.ignoreCertificateErrors ? 1 : 0,
+          'pinnedCertificateSha256': server.pinnedCertificateSha256,
+        });
       });
     } catch (e, st) {
       logger.e('Failed to save server: $e\n$st');
@@ -141,19 +146,25 @@ class LocalServerRepository implements ServerRepository {
         await _secureStorage.saveValue('${server.address}_sid', sid);
       }
 
-      return await _database.update(
-        'servers',
-        {
-          'alias': server.alias,
-          'isDefaultServer': convertFromBoolToInt(server.defaultServer),
-          'apiVersion': server.apiVersion,
-          'allowUntrustedCert': server.allowUntrustedCert ? 1 : 0,
-          'ignoreCertificateErrors': server.ignoreCertificateErrors ? 1 : 0,
-          'pinnedCertificateSha256': server.pinnedCertificateSha256,
-        },
-        where: 'address = ?',
-        whereArgs: [server.address],
-      );
+      return await _database.transaction<int>((txn) async {
+        // Keep "only one default" invariant atomic with the update
+        if (server.defaultServer) {
+          await txn.update('servers', {'isDefaultServer': 0});
+        }
+        return txn.update(
+          'servers',
+          {
+            'alias': server.alias,
+            'isDefaultServer': server.defaultServer ? 1 : 0,
+            'apiVersion': server.apiVersion,
+            'allowUntrustedCert': server.allowUntrustedCert ? 1 : 0,
+            'ignoreCertificateErrors': server.ignoreCertificateErrors ? 1 : 0,
+            'pinnedCertificateSha256': server.pinnedCertificateSha256,
+          },
+          where: 'address = ?',
+          whereArgs: [server.address],
+        );
+      });
     } catch (e, st) {
       logger.e('Failed to edit server: $e\n$st');
       return Failure(Exception('Failed to edit server: $e\n$st'));
@@ -192,28 +203,21 @@ class LocalServerRepository implements ServerRepository {
     }
   }
 
-  /// Replaces the server identified by [oldAddress] with [newServer].
+  /// Replaces the server identified by [oldAddress] with [newServer] at the
+  /// database level only.
   ///
-  /// Deletes the old secrets, stores any provided new secrets under the new
-  /// server address, then in a single transaction removes the old row and
-  /// inserts the new one. Gravity child rows referencing [oldAddress] are
-  /// removed automatically by the `ON DELETE CASCADE` foreign keys.
+  /// In a single transaction this removes the old row, clears the default flag
+  /// on the other servers when [newServer] is the default, and inserts the new
+  /// row. Gravity child rows referencing [oldAddress] are removed automatically
+  /// by the `ON DELETE CASCADE` foreign keys.
   ///
   /// Returns the inserted row id on success, or a [Failure] if it fails.
   @override
-  Future<Result<int>> replaceServer(
-    String oldAddress,
-    Server newServer, {
-    String? token,
-    String? password,
-    String? sid,
-  }) async {
+  Future<Result<int>> replaceServer(String oldAddress, Server newServer) async {
     try {
       await openDbIfNeeded(_database);
 
-      // DB first: a failed transaction must not wipe the old server's
-      // credentials, or it becomes unrecoverable.
-      final result = await _database.transaction<int>((txn) async {
+      return await _database.transaction<int>((txn) async {
         final deleted = await txn.delete(
           'servers',
           where: 'address = ?',
@@ -239,28 +243,6 @@ class LocalServerRepository implements ServerRepository {
           'pinnedCertificateSha256': newServer.pinnedCertificateSha256,
         });
       });
-
-      if (result.isError()) return result;
-
-      // Committed: now safe to migrate credentials.
-      await _secureStorage.deleteValue('${oldAddress}_token');
-      await _secureStorage.deleteValue('${oldAddress}_password');
-      await _secureStorage.deleteValue('${oldAddress}_sid');
-
-      if (token != null && token.isNotEmpty) {
-        await _secureStorage.saveValue('${newServer.address}_token', token);
-      }
-      if (password != null && password.isNotEmpty) {
-        await _secureStorage.saveValue(
-          '${newServer.address}_password',
-          password,
-        );
-      }
-      if (sid != null && sid.isNotEmpty) {
-        await _secureStorage.saveValue('${newServer.address}_sid', sid);
-      }
-
-      return result;
     } catch (e, st) {
       logger.e('Failed to replace server: $e\n$st');
       return Failure(Exception('Failed to replace server: $e\n$st'));

--- a/lib/data/repositories/local/server_repository.dart
+++ b/lib/data/repositories/local/server_repository.dart
@@ -211,6 +211,38 @@ class LocalServerRepository implements ServerRepository {
     try {
       await openDbIfNeeded(_database);
 
+      // DB first: a failed transaction must not wipe the old server's
+      // credentials, or it becomes unrecoverable.
+      final result = await _database.transaction<int>((txn) async {
+        final deleted = await txn.delete(
+          'servers',
+          where: 'address = ?',
+          whereArgs: [oldAddress],
+        );
+        if (deleted == 0) {
+          logger.w(
+            'replaceServer: no existing row found for $oldAddress; '
+            'inserting the new server without removing a previous one',
+          );
+        }
+        // Keep "only one default" invariant atomic with the insert.
+        if (newServer.defaultServer) {
+          await txn.update('servers', {'isDefaultServer': 0});
+        }
+        return txn.insert('servers', {
+          'address': newServer.address,
+          'alias': newServer.alias,
+          'isDefaultServer': newServer.defaultServer ? 1 : 0,
+          'apiVersion': newServer.apiVersion,
+          'allowUntrustedCert': newServer.allowUntrustedCert ? 1 : 0,
+          'ignoreCertificateErrors': newServer.ignoreCertificateErrors ? 1 : 0,
+          'pinnedCertificateSha256': newServer.pinnedCertificateSha256,
+        });
+      });
+
+      if (result.isError()) return result;
+
+      // Committed: now safe to migrate credentials.
       await _secureStorage.deleteValue('${oldAddress}_token');
       await _secureStorage.deleteValue('${oldAddress}_password');
       await _secureStorage.deleteValue('${oldAddress}_sid');
@@ -228,22 +260,7 @@ class LocalServerRepository implements ServerRepository {
         await _secureStorage.saveValue('${newServer.address}_sid', sid);
       }
 
-      return await _database.transaction<int>((txn) async {
-        await txn.delete(
-          'servers',
-          where: 'address = ?',
-          whereArgs: [oldAddress],
-        );
-        return txn.insert('servers', {
-          'address': newServer.address,
-          'alias': newServer.alias,
-          'isDefaultServer': newServer.defaultServer ? 1 : 0,
-          'apiVersion': newServer.apiVersion,
-          'allowUntrustedCert': newServer.allowUntrustedCert ? 1 : 0,
-          'ignoreCertificateErrors': newServer.ignoreCertificateErrors ? 1 : 0,
-          'pinnedCertificateSha256': newServer.pinnedCertificateSha256,
-        });
-      });
+      return result;
     } catch (e, st) {
       logger.e('Failed to replace server: $e\n$st');
       return Failure(Exception('Failed to replace server: $e\n$st'));
@@ -350,13 +367,11 @@ class LocalServerRepository implements ServerRepository {
       final keysToDelete = <String>[];
 
       for (final key in keys.getOrThrow().keys) {
-        if (key.endsWith('_token') ||
-            key.endsWith('_password') ||
-            key.endsWith('_sid')) {
-          final address = key.split('_').first;
-          if (!serverAddresses.contains(address)) {
-            keysToDelete.add(key);
-          }
+        final address = _serverAddressFromSecretKey(key);
+        if (address == null) continue;
+
+        if (!serverAddresses.contains(address)) {
+          keysToDelete.add(key);
         }
       }
 
@@ -444,5 +459,28 @@ class LocalServerRepository implements ServerRepository {
       logger.e('Failed to delete token: $e\n$st');
       return Failure(Exception('Failed to delete token: $e\n$st'));
     }
+  }
+
+  @override
+  Future<Result<void>> deleteSid(String address) async {
+    try {
+      await _secureStorage.deleteValue('${address}_sid');
+      return Success.unit();
+    } catch (e, st) {
+      logger.e('Failed to delete sid: $e\n$st');
+      return Failure(Exception('Failed to delete sid: $e\n$st'));
+    }
+  }
+
+  String? _serverAddressFromSecretKey(String key) {
+    const suffixes = ['_token', '_password', '_sid'];
+
+    for (final suffix in suffixes) {
+      if (key.endsWith(suffix)) {
+        return key.substring(0, key.length - suffix.length);
+      }
+    }
+
+    return null;
   }
 }

--- a/lib/data/repositories/local/server_repository.dart
+++ b/lib/data/repositories/local/server_repository.dart
@@ -192,6 +192,64 @@ class LocalServerRepository implements ServerRepository {
     }
   }
 
+  /// Replaces the server identified by [oldAddress] with [newServer].
+  ///
+  /// Deletes the old secrets, stores any provided new secrets under the new
+  /// server address, then in a single transaction removes the old row and
+  /// inserts the new one. Gravity child rows referencing [oldAddress] are
+  /// removed automatically by the `ON DELETE CASCADE` foreign keys.
+  ///
+  /// Returns the inserted row id on success, or a [Failure] if it fails.
+  @override
+  Future<Result<int>> replaceServer(
+    String oldAddress,
+    Server newServer, {
+    String? token,
+    String? password,
+    String? sid,
+  }) async {
+    try {
+      await openDbIfNeeded(_database);
+
+      await _secureStorage.deleteValue('${oldAddress}_token');
+      await _secureStorage.deleteValue('${oldAddress}_password');
+      await _secureStorage.deleteValue('${oldAddress}_sid');
+
+      if (token != null && token.isNotEmpty) {
+        await _secureStorage.saveValue('${newServer.address}_token', token);
+      }
+      if (password != null && password.isNotEmpty) {
+        await _secureStorage.saveValue(
+          '${newServer.address}_password',
+          password,
+        );
+      }
+      if (sid != null && sid.isNotEmpty) {
+        await _secureStorage.saveValue('${newServer.address}_sid', sid);
+      }
+
+      return await _database.transaction<int>((txn) async {
+        await txn.delete(
+          'servers',
+          where: 'address = ?',
+          whereArgs: [oldAddress],
+        );
+        return txn.insert('servers', {
+          'address': newServer.address,
+          'alias': newServer.alias,
+          'isDefaultServer': newServer.defaultServer ? 1 : 0,
+          'apiVersion': newServer.apiVersion,
+          'allowUntrustedCert': newServer.allowUntrustedCert ? 1 : 0,
+          'ignoreCertificateErrors': newServer.ignoreCertificateErrors ? 1 : 0,
+          'pinnedCertificateSha256': newServer.pinnedCertificateSha256,
+        });
+      });
+    } catch (e, st) {
+      logger.e('Failed to replace server: $e\n$st');
+      return Failure(Exception('Failed to replace server: $e\n$st'));
+    }
+  }
+
   /// Deletes a specific server entry and its associated secrets.
   ///
   /// This method removes token, password, and session ID from secure storage

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -220,6 +220,16 @@ void main() async {
   }
   await WidgetChannel.sendServersUpdated(serversViewModel.getServersList);
 
+  // Reclaim secure-storage entries (token/password/sid) orphaned by servers
+  // that no longer exist (e.g. after a failed edit). Best-effort.
+  final secretCleanup = await serverRepository.deleteUnusedServerSecrets();
+  if (secretCleanup.isError()) {
+    logger.w(
+      'Failed to reclaim orphaned server secrets: '
+      '${secretCleanup.exceptionOrNull()}',
+    );
+  }
+
   // 5. Platform-specific setup
   await initializeBiometrics(configProvider, appConfigRepository);
   await initializeVibration(configProvider);

--- a/lib/ui/core/view_models/servers_viewmodel.dart
+++ b/lib/ui/core/view_models/servers_viewmodel.dart
@@ -184,10 +184,16 @@ class ServersViewModel with ChangeNotifier {
     if (saved.isError()) {
       throw saved.exceptionOrNull()!;
     }
-    if (server.defaultServer == true) {
-      await _setDefaultServer(server);
-    }
     _serversList = [..._serversList, server];
+
+    // insertServer already cleared the other defaults inside its transaction;
+    // mirror that in memory without a second DB write.
+    if (server.defaultServer == true) {
+      _serversList = _serversList
+          .map((s) => s.copyWith(defaultServer: s.address == server.address))
+          .toList();
+    }
+
     await WidgetChannel.sendServersUpdated(_serversList);
     notifyListeners();
   }
@@ -206,8 +212,12 @@ class ServersViewModel with ChangeNotifier {
       _selectedServer = server;
     }
 
+    // updateServer already cleared the other defaults inside its transaction;
+    // mirror that in memory without a second DB write.
     if (server.defaultServer == true) {
-      await _setDefaultServer(server);
+      _serversList = _serversList
+          .map((s) => s.copyWith(defaultServer: s.address == server.address))
+          .toList();
     }
 
     await WidgetChannel.sendServersUpdated(_serversList);

--- a/lib/ui/core/view_models/servers_viewmodel.dart
+++ b/lib/ui/core/view_models/servers_viewmodel.dart
@@ -14,10 +14,17 @@ import 'package:pi_hole_client/utils/logger.dart';
 import 'package:pi_hole_client/utils/widget_channel.dart';
 import 'package:result_dart/result_dart.dart';
 
+/// Parameters for [ServersViewModel.replaceServer]: the address of the server
+/// being replaced and the new server that takes its place.
+typedef ReplaceServerParams = ({String oldAddress, Server newServer});
+
 class ServersViewModel with ChangeNotifier {
   ServersViewModel(this._repository) {
     addServer = Command.createAsyncNoResult<Server>(_addServer);
     editServer = Command.createAsyncNoResult<Server>(_editServer);
+    replaceServer = Command.createAsyncNoResult<ReplaceServerParams>(
+      _replaceServer,
+    );
     removeServer = Command.createAsyncNoResult<String>(_removeServer);
     setDefaultServer = Command.createAsyncNoResult<Server>(_setDefaultServer);
 
@@ -25,6 +32,8 @@ class ServersViewModel with ChangeNotifier {
     addServer.errors.addListener(notifyListeners);
     editServer.addListener(notifyListeners);
     editServer.errors.addListener(notifyListeners);
+    replaceServer.addListener(notifyListeners);
+    replaceServer.errors.addListener(notifyListeners);
     removeServer.addListener(notifyListeners);
     removeServer.errors.addListener(notifyListeners);
     setDefaultServer.addListener(notifyListeners);
@@ -49,6 +58,7 @@ class ServersViewModel with ChangeNotifier {
   // --- Commands ---
   late final Command<Server, void> addServer;
   late final Command<Server, void> editServer;
+  late final Command<ReplaceServerParams, void> replaceServer;
   late final Command<String, void> removeServer;
   late final Command<Server, void> setDefaultServer;
 
@@ -204,6 +214,37 @@ class ServersViewModel with ChangeNotifier {
     notifyListeners();
   }
 
+  /// Replaces an existing server when its address (primary key) changes.
+  ///
+  /// Deletes the old row (and its cascaded data) and inserts the new one. The
+  /// new server's credentials/session are expected to already be stored under
+  /// the new address by the caller (the edit screen) before this runs.
+  Future<void> _replaceServer(ReplaceServerParams params) async {
+    final result = await _repository.replaceServer(
+      params.oldAddress,
+      params.newServer,
+    );
+    if (result.isError()) {
+      throw result.exceptionOrNull()!;
+    }
+
+    _serversList = _serversList
+        .map((s) => s.address == params.oldAddress ? params.newServer : s)
+        .toList();
+
+    if (_selectedServer?.address == params.oldAddress) {
+      _selectedServer = params.newServer;
+    }
+
+    if (params.newServer.defaultServer == true) {
+      await _setDefaultServer(params.newServer);
+    }
+
+    await WidgetChannel.sendServerRemoved(params.oldAddress);
+    await WidgetChannel.sendServersUpdated(_serversList);
+    notifyListeners();
+  }
+
   Future<void> _removeServer(String serverAddress) async {
     final result = await _repository.deleteServer(serverAddress);
     if (result.isError()) {
@@ -340,12 +381,15 @@ class ServersViewModel with ChangeNotifier {
     addServer.errors.removeListener(notifyListeners);
     editServer.removeListener(notifyListeners);
     editServer.errors.removeListener(notifyListeners);
+    replaceServer.removeListener(notifyListeners);
+    replaceServer.errors.removeListener(notifyListeners);
     removeServer.removeListener(notifyListeners);
     removeServer.errors.removeListener(notifyListeners);
     setDefaultServer.removeListener(notifyListeners);
     setDefaultServer.errors.removeListener(notifyListeners);
     addServer.dispose();
     editServer.dispose();
+    replaceServer.dispose();
     removeServer.dispose();
     setDefaultServer.dispose();
     super.dispose();

--- a/lib/ui/core/view_models/servers_viewmodel.dart
+++ b/lib/ui/core/view_models/servers_viewmodel.dart
@@ -236,8 +236,16 @@ class ServersViewModel with ChangeNotifier {
       _selectedServer = params.newServer;
     }
 
+    // The repository already cleared other defaults inside the replace
+    // transaction; mirror that in memory without a second DB write.
     if (params.newServer.defaultServer == true) {
-      await _setDefaultServer(params.newServer);
+      _serversList = _serversList
+          .map(
+            (s) => s.copyWith(
+              defaultServer: s.address == params.newServer.address,
+            ),
+          )
+          .toList();
     }
 
     await WidgetChannel.sendServerRemoved(params.oldAddress);
@@ -374,6 +382,9 @@ class ServersViewModel with ChangeNotifier {
 
   Future<Result<void>> deleteToken(String address) =>
       _repository.deleteToken(address);
+
+  Future<Result<void>> deleteSid(String address) =>
+      _repository.deleteSid(address);
 
   @override
   void dispose() {

--- a/lib/ui/servers/widgets/add_server_fullscreen.dart
+++ b/lib/ui/servers/widgets/add_server_fullscreen.dart
@@ -19,6 +19,7 @@ import 'package:pi_hole_client/utils/exceptions.dart';
 import 'package:pi_hole_client/utils/logger.dart';
 import 'package:pi_hole_client/utils/open_url.dart';
 import 'package:pi_hole_client/utils/tls_certificate.dart';
+import 'package:pi_hole_client/utils/url.dart';
 import 'package:provider/provider.dart';
 
 class AddServerFullscreen extends StatefulWidget {
@@ -70,21 +71,31 @@ class _AddServerFullscreenState extends State<AddServerFullscreen> {
   String? initPassword;
   bool _advancedOptionsExpanded = false;
 
+  /// Whether the edit screen has finished loading the stored secrets. Always
+  /// true in add mode; false until [_loadSecrets] completes in edit mode so the
+  /// Save button can't fire (and overwrite credentials) before they are ready.
+  bool _secretsLoaded = true;
+
+  /// Whether [_loadSecrets] actually read the stored secrets. Stays false when
+  /// the secure-storage read fails, so [_restoreSecrets] won't write back the
+  /// empty placeholders and wipe a credential that is still present.
+  bool _secretsLoadSucceeded = false;
+
   @override
   void initState() {
     super.initState();
     if (widget.server != null) {
-      final splitted = widget.server!.address.split(':');
-      addressFieldController.text = splitted[1].split('/')[2];
-      portFieldController.text = splitted.length > 2
-          ? splitted[2].split('/')[0]
-          : '';
-      subrouteFieldController.text =
-          widget.server!.address.split('/').length > 3
-          ? '/${widget.server!.address.split('/')[3]}'
-          : '';
+      // Parse the stored URL with Uri so multi-segment subroutes (e.g.
+      // `/api/v1`) survive and the host/port are extracted reliably instead of
+      // via fragile manual `split` calls.
+      final uri = Uri.parse(widget.server!.address);
+      addressFieldController.text = uri.host;
+      portFieldController.text = uri.hasPort ? '${uri.port}' : '';
+      // A bare '/' carries no routing info and trips the subroute validator, so
+      // normalise it to empty; otherwise keep the full path.
+      subrouteFieldController.text = uri.path == '/' ? '' : uri.path;
       aliasFieldController.text = widget.server!.alias;
-      connectionType = widget.server!.address.split(':')[0] == 'https'
+      connectionType = uri.scheme == 'https'
           ? ConnectionType.https
           : ConnectionType.http;
       piHoleVersion = widget.server!.apiVersion;
@@ -94,6 +105,7 @@ class _AddServerFullscreenState extends State<AddServerFullscreen> {
       pinnedCertificateSha256 = widget.server!.pinnedCertificateSha256;
       // For edit mode, expand Advanced Options if HTTPS
       _advancedOptionsExpanded = connectionType == ConnectionType.https;
+      _secretsLoaded = false;
       _loadSecrets();
     }
   }
@@ -181,6 +193,9 @@ class _AddServerFullscreenState extends State<AddServerFullscreen> {
   }
 
   Future<void> _loadSecrets() async {
+    var password = '';
+    var token = '';
+    var loaded = false;
     if (widget.server != null) {
       try {
         final serversViewModel = context.read<ServersViewModel>();
@@ -188,45 +203,41 @@ class _AddServerFullscreenState extends State<AddServerFullscreen> {
           widget.server!.address,
         );
         final creds = result.getOrNull();
-
-        if (mounted) {
-          setState(() {
-            passwordFieldController.text = creds?.password ?? '';
-            tokenFieldController.text = creds?.token ?? '';
-            initToken = creds?.token ?? '';
-            initPassword = creds?.password ?? '';
-          });
+        if (creds != null) {
+          password = creds.password;
+          token = creds.token;
+          loaded = true;
         }
       } catch (e) {
-        if (mounted) {
-          setState(() {
-            passwordFieldController.text = '';
-            tokenFieldController.text = '';
-            initToken = '';
-            initPassword = '';
-          });
-        }
+        password = '';
+        token = '';
       }
-    } else {
-      if (mounted) {
-        setState(() {
-          passwordFieldController.text = '';
-          tokenFieldController.text = '';
-          initToken = '';
-          initPassword = '';
-        });
-      }
+    }
+    // Mark loaded on both the success and failure paths so the Save button is
+    // never permanently disabled if the credential read throws.
+    if (mounted) {
+      setState(() {
+        passwordFieldController.text = password;
+        tokenFieldController.text = token;
+        initToken = token;
+        initPassword = password;
+        _secretsLoadSucceeded = loaded;
+        _secretsLoaded = true;
+      });
     }
   }
 
   Future<void> _restoreSecrets() async {
-    if (widget.server != null) {
+    // Only restore when the original secrets were actually read. If the initial
+    // load failed, initPassword/initToken are empty placeholders and writing
+    // them back would wipe a credential that is still in secure storage.
+    if (widget.server != null && _secretsLoadSucceeded) {
       final serversViewModel = context.read<ServersViewModel>();
       await serversViewModel.savePassword(
         widget.server!.address,
-        initPassword!,
+        initPassword ?? '',
       );
-      await serversViewModel.saveToken(widget.server!.address, initToken!);
+      await serversViewModel.saveToken(widget.server!.address, initToken ?? '');
     }
   }
 
@@ -479,8 +490,8 @@ class _AddServerFullscreenState extends State<AddServerFullscreen> {
             if (mounted) {
               setState(() {
                 isConnecting = false;
-                _restoreSecrets();
               });
+              await _restoreSecrets();
               await serversViewModel.deletePassword(url);
               await serversViewModel.deleteToken(url);
               if (!context.mounted) return;
@@ -518,8 +529,8 @@ class _AddServerFullscreenState extends State<AddServerFullscreen> {
           if (mounted) {
             setState(() {
               isConnecting = false;
-              _restoreSecrets();
             });
+            await _restoreSecrets();
 
             await serversViewModel.deletePassword(url);
             await serversViewModel.deleteToken(url);
@@ -553,7 +564,9 @@ class _AddServerFullscreenState extends State<AddServerFullscreen> {
       final oldAddress = oldServer.address;
       final newUrl =
           '${connectionType.name}://${addressFieldController.text}${portFieldController.text != '' ? ':${portFieldController.text}' : ''}${subrouteFieldController.text}';
-      final isAddressChanged = newUrl != oldAddress;
+      // Normalised comparison: a host-case-only or trailing-slash difference is
+      // NOT an address change and must stay on the in-place editServer path.
+      final isAddressChanged = !isSameEndpoint(oldAddress, newUrl);
 
       // When the address (primary key) changes, make sure the new URL is not
       // already used by another server before doing anything destructive.
@@ -633,18 +646,19 @@ class _AddServerFullscreenState extends State<AddServerFullscreen> {
         tokenFieldController.text,
       );
 
-      // Rolls back everything written under the new address on a failed
-      // address-changing save: credentials, SID, and the freshly created remote
-      // session. Same-address edits keep their secrets (handled by the caller).
-      Future<void> discardNewAddressArtifacts({
+      // Rolls back everything written for THIS save attempt on failure, always
+      // leaving the old server (row, credentials, session) untouched.
+      //
+      // - Address change: remove the credentials and SID written under the new
+      //   address plus the freshly created remote session.
+      // - Same address: restore the old credentials and, when a new session was
+      //   created during this attempt, tear it down so it does not leak.
+      Future<void> rollbackFailedSave({
         required RepositoryBundle bundle,
         required bool sessionCreated,
       }) async {
-        if (!isAddressChanged) return;
-        await serversViewModel.deletePassword(targetAddress);
-        await serversViewModel.deleteToken(targetAddress);
-        await serversViewModel.deleteSid(targetAddress);
-        if (sessionCreated) {
+        Future<void> deleteNewSession() async {
+          if (!sessionCreated) return;
           try {
             await bundle.auth.deleteCurrentSession();
           } catch (e, s) {
@@ -655,20 +669,32 @@ class _AddServerFullscreenState extends State<AddServerFullscreen> {
             );
           }
         }
+
+        if (isAddressChanged) {
+          await serversViewModel.deletePassword(targetAddress);
+          await serversViewModel.deleteToken(targetAddress);
+          await serversViewModel.deleteSid(targetAddress);
+          await deleteNewSession();
+        } else {
+          await deleteNewSession();
+          await _restoreSecrets();
+        }
       }
 
-      void handleSaveError(Exception e) {
+      Future<void> handleSaveError(Exception e) async {
         if (context.mounted) {
           setState(() {
             isConnecting = false;
-            _restoreSecrets();
           });
-          handleApiErrorResult(
-            context: context,
-            appConfigViewModel: appConfigViewModel,
-            error: e,
-            version: piHoleVersion,
-          );
+          await _restoreSecrets();
+          if (context.mounted) {
+            handleApiErrorResult(
+              context: context,
+              appConfigViewModel: appConfigViewModel,
+              error: e,
+              version: piHoleVersion,
+            );
+          }
         }
         if (serversViewModel.selectedServer != null) {
           statusViewModel.startAutoRefresh();
@@ -684,18 +710,28 @@ class _AddServerFullscreenState extends State<AddServerFullscreen> {
             passwordFieldController.text,
           );
           if (authResult.isError()) {
-            await discardNewAddressArtifacts(
-              bundle: bundle,
-              sessionCreated: false,
-            );
-            handleSaveError(authResult.exceptionOrNull()!);
+            await rollbackFailedSave(bundle: bundle, sessionCreated: false);
+            await handleSaveError(authResult.exceptionOrNull()!);
+            return;
+          }
+          sessionJustCreated = true;
+        } else if (passwordFieldController.text != (initPassword ?? '')) {
+          // Same address but the password was edited. Validate it now by
+          // creating a session: an unverified (possibly wrong) password would
+          // otherwise silently overwrite the known-good one and lock the user
+          // out the moment the current SID is invalidated.
+          final authResult = await bundle.auth.createSession(
+            passwordFieldController.text,
+          );
+          if (authResult.isError()) {
+            await handleSaveError(authResult.exceptionOrNull()!);
             return;
           }
           sessionJustCreated = true;
         } else {
-          // Same address: check if the existing session is still valid before
-          // creating a new one. Only re-authenticate on 401/SidNotFoundException
-          // to avoid session multiplication when the server is temporarily
+          // Same address, unchanged password: reuse the existing session if it
+          // is still valid. Only re-authenticate on 401/SidNotFoundException to
+          // avoid session multiplication when the server is temporarily
           // unreachable (503/504/timeout).
           final preCheck = await bundle.dns.fetchBlockingStatus(
             skipRenewal: true,
@@ -703,14 +739,14 @@ class _AddServerFullscreenState extends State<AddServerFullscreen> {
           if (preCheck.isError()) {
             final err = preCheck.exceptionOrNull();
             if (!isReauthRequired(err)) {
-              handleSaveError(err!);
+              await handleSaveError(err!);
               return;
             }
             final authResult = await bundle.auth.createSession(
               passwordFieldController.text,
             );
             if (authResult.isError()) {
-              handleSaveError(authResult.exceptionOrNull()!);
+              await handleSaveError(authResult.exceptionOrNull()!);
               return;
             }
             sessionJustCreated = true;
@@ -745,11 +781,12 @@ class _AddServerFullscreenState extends State<AddServerFullscreen> {
 
         if (cmdError == null) {
           // The old v6 session is orphaned on an address change or a switch
-          // away from v6 (e.g. v6 -> v5). Tear it down and drop the unused SID.
-          // Run only after the DB commit so a failed save can't kill a live
-          // session; best-effort since the old host is often unreachable.
+          // away from v6 (e.g. v6 -> v5). Run only after the DB commit so a
+          // failed save can't kill a live session.
           final oldWasV6 = oldServer.apiVersion == SupportedApiVersions.v6;
           final newIsV6 = serverObj.apiVersion == SupportedApiVersions.v6;
+
+          // 1. Log out the old v6 session.
           if (oldWasV6 && (isAddressChanged || !newIsV6)) {
             try {
               final oldBundle = saveCreateBundle(server: oldServer);
@@ -761,9 +798,18 @@ class _AddServerFullscreenState extends State<AddServerFullscreen> {
                 stackTrace: s,
               );
             }
-            if (!isAddressChanged) {
-              await serversViewModel.deleteSid(targetAddress);
-            }
+          }
+
+          // 2. Now safe to drop the old server's credentials.
+          if (isAddressChanged) {
+            // New credentials already live under the new address; remove the
+            // stale ones left behind under the old address.
+            await serversViewModel.deleteToken(oldAddress);
+            await serversViewModel.deletePassword(oldAddress);
+            await serversViewModel.deleteSid(oldAddress);
+          } else if (oldWasV6 && !newIsV6) {
+            // Same address, v6 -> v5: the SID is now unused.
+            await serversViewModel.deleteSid(targetAddress);
           }
           if (context.mounted) {
             await Navigator.maybePop(context);
@@ -776,13 +822,12 @@ class _AddServerFullscreenState extends State<AddServerFullscreen> {
             );
           }
         } else {
-          // DB write failed: roll back the new-address artifacts; the old
+          // DB write failed: roll back this attempt's artifacts; the old
           // server (row, credentials, session) is left fully intact.
-          await discardNewAddressArtifacts(
+          await rollbackFailedSave(
             bundle: bundle,
             sessionCreated: sessionJustCreated,
           );
-          if (!isAddressChanged) await _restoreSecrets();
           if (context.mounted) {
             setState(() {
               isConnecting = false;
@@ -795,11 +840,10 @@ class _AddServerFullscreenState extends State<AddServerFullscreen> {
           }
         }
       } else {
-        await discardNewAddressArtifacts(
+        await rollbackFailedSave(
           bundle: bundle,
           sessionCreated: sessionJustCreated,
         );
-        if (!isAddressChanged) await _restoreSecrets();
         if (context.mounted) {
           setState(() {
             isConnecting = false;
@@ -825,7 +869,15 @@ class _AddServerFullscreenState extends State<AddServerFullscreen> {
       if (addressFieldController.text != '' &&
           subrouteFieldError == null &&
           addressFieldError == null &&
+          portFieldError == null &&
           aliasFieldController.text != '') {
+        if (widget.server != null) {
+          if (!_secretsLoaded) return false;
+          final hasCredential = piHoleVersion == SupportedApiVersions.v6
+              ? passwordFieldController.text != ''
+              : tokenFieldController.text != '';
+          if (!hasCredential) return false;
+        }
         return true;
       } else {
         return false;

--- a/lib/ui/servers/widgets/add_server_fullscreen.dart
+++ b/lib/ui/servers/widgets/add_server_fullscreen.dart
@@ -549,8 +549,52 @@ class _AddServerFullscreenState extends State<AddServerFullscreen> {
         pinnedCertificateSha256 = null;
       }
 
+      final oldServer = widget.server!;
+      final oldAddress = oldServer.address;
+      final newUrl =
+          '${connectionType.name}://${addressFieldController.text}${portFieldController.text != '' ? ':${portFieldController.text}' : ''}${subrouteFieldController.text}';
+      final isAddressChanged = newUrl != oldAddress;
+
+      // When the address (primary key) changes, make sure the new URL is not
+      // already used by another server before doing anything destructive.
+      if (isAddressChanged) {
+        final exists = await serversViewModel.checkUrlExists(newUrl);
+        if (!context.mounted) return;
+        if (exists['result'] == 'success' && exists['exists'] == true) {
+          setState(() {
+            isConnecting = false;
+          });
+          showErrorSnackBar(
+            context: context,
+            appConfigViewModel: appConfigViewModel,
+            label: AppLocalizations.of(context)!.connectionAlreadyExists,
+          );
+          return;
+        } else if (exists['result'] == 'fail') {
+          setState(() {
+            isConnecting = false;
+          });
+          showErrorSnackBar(
+            context: context,
+            appConfigViewModel: appConfigViewModel,
+            label: AppLocalizations.of(context)!.cannotCheckUrlSaved,
+          );
+          return;
+        }
+      }
+
+      final targetAddress = isAddressChanged ? newUrl : oldAddress;
+
+      // When the address changes the target is effectively a different host, so
+      // any pinned certificate carried over from the old server is stale. Reset
+      // it to null so the certificate check re-runs against the new host
+      // instead of silently reusing the old fingerprint.
+      if (isAddressChanged) {
+        pinnedCertificateSha256 = null;
+      }
+
       var serverObj = Server(
-        address: widget.server!.address,
+        address: targetAddress,
         alias: aliasFieldController.text,
         apiVersion: piHoleVersion,
         allowUntrustedCert: allowUntrustedCert,
@@ -558,11 +602,11 @@ class _AddServerFullscreenState extends State<AddServerFullscreen> {
         pinnedCertificateSha256: pinnedCertificateSha256,
       );
       await serversViewModel.savePassword(
-        widget.server!.address,
+        targetAddress,
         passwordFieldController.text,
       );
       await serversViewModel.saveToken(
-        widget.server!.address,
+        targetAddress,
         tokenFieldController.text,
       );
       if (serversViewModel.selectedServer != null) {
@@ -588,6 +632,15 @@ class _AddServerFullscreenState extends State<AddServerFullscreen> {
 
       serverObj = updatedServer;
 
+      // Removes secrets written under the new address so a failed
+      // address-changing edit leaves no orphaned credentials behind.
+      Future<void> discardNewAddressSecrets() async {
+        if (isAddressChanged) {
+          await serversViewModel.deletePassword(targetAddress);
+          await serversViewModel.deleteToken(targetAddress);
+        }
+      }
+
       void handleSaveError(Exception e) {
         if (context.mounted) {
           setState(() {
@@ -609,26 +662,40 @@ class _AddServerFullscreenState extends State<AddServerFullscreen> {
       final bundle = saveCreateBundle(server: serverObj);
       var sessionJustCreated = false;
       if (serverObj.apiVersion == SupportedApiVersions.v6) {
-        // Check if the existing session is still valid before creating a new one.
-        // Only re-authenticate on 401/SidNotFoundException to avoid session
-        // multiplication when the server is temporarily unreachable (503/504/timeout).
-        final preCheck = await bundle.dns.fetchBlockingStatus(
-          skipRenewal: true,
-        );
-        if (preCheck.isError()) {
-          final err = preCheck.exceptionOrNull();
-          if (!isReauthRequired(err)) {
-            handleSaveError(err!);
-            return;
-          }
+        if (isAddressChanged) {
+          // The new address has no existing session, so always create one.
           final authResult = await bundle.auth.createSession(
             passwordFieldController.text,
           );
           if (authResult.isError()) {
+            await discardNewAddressSecrets();
             handleSaveError(authResult.exceptionOrNull()!);
             return;
           }
           sessionJustCreated = true;
+        } else {
+          // Same address: check if the existing session is still valid before
+          // creating a new one. Only re-authenticate on 401/SidNotFoundException
+          // to avoid session multiplication when the server is temporarily
+          // unreachable (503/504/timeout).
+          final preCheck = await bundle.dns.fetchBlockingStatus(
+            skipRenewal: true,
+          );
+          if (preCheck.isError()) {
+            final err = preCheck.exceptionOrNull();
+            if (!isReauthRequired(err)) {
+              handleSaveError(err!);
+              return;
+            }
+            final authResult = await bundle.auth.createSession(
+              passwordFieldController.text,
+            );
+            if (authResult.isError()) {
+              handleSaveError(authResult.exceptionOrNull()!);
+              return;
+            }
+            sessionJustCreated = true;
+          }
         }
       }
       // skipRenewal: true only when a new session was just created above to
@@ -639,13 +706,43 @@ class _AddServerFullscreenState extends State<AddServerFullscreen> {
 
       if (result.isSuccess()) {
         final server = serverObj.copyWith(defaultServer: defaultCheckbox);
+
+        // The new connection is confirmed working. When the address changed,
+        // terminate the old session on the Pi-hole server before deleting the
+        // local data. Best-effort: the old address is often unreachable (e.g.
+        // the user is fixing a wrong IP), so failures are logged and ignored.
+        if (isAddressChanged &&
+            oldServer.apiVersion == SupportedApiVersions.v6) {
+          try {
+            final oldBundle = saveCreateBundle(server: oldServer);
+            await oldBundle.auth.deleteCurrentSession();
+          } catch (e, s) {
+            logger.w(
+              'Failed to delete old session on server',
+              error: e,
+              stackTrace: s,
+            );
+          }
+        }
+
+        Object? cmdError;
         try {
-          await serversViewModel.editServer.runAsync(server);
+          if (isAddressChanged) {
+            await serversViewModel.replaceServer.runAsync((
+              oldAddress: oldAddress,
+              newServer: server,
+            ));
+            cmdError = serversViewModel.replaceServer.errors.value;
+          } else {
+            await serversViewModel.editServer.runAsync(server);
+            cmdError = serversViewModel.editServer.errors.value;
+          }
         } catch (e, s) {
           logger.e('Failed to save server', error: e, stackTrace: s);
+          cmdError = e;
         }
         if (context.mounted) {
-          if (serversViewModel.editServer.errors.value == null) {
+          if (cmdError == null) {
             await Navigator.maybePop(context);
             if (!context.mounted) return;
 
@@ -666,6 +763,7 @@ class _AddServerFullscreenState extends State<AddServerFullscreen> {
           }
         }
       } else {
+        await discardNewAddressSecrets();
         if (context.mounted) {
           setState(() {
             isConnecting = false;
@@ -857,16 +955,14 @@ class _AddServerFullscreenState extends State<AddServerFullscreen> {
                   padding: const EdgeInsets.symmetric(vertical: 10),
                   width: double.maxFinite,
                   child: SegmentedButton<ConnectionType>(
-                    segments: [
+                    segments: const [
                       ButtonSegment(
                         value: ConnectionType.http,
-                        label: const Text('HTTP'),
-                        enabled: widget.server != null ? false : true,
+                        label: Text('HTTP'),
                       ),
                       ButtonSegment(
                         value: ConnectionType.https,
-                        label: const Text('HTTPS'),
-                        enabled: widget.server != null ? false : true,
+                        label: Text('HTTPS'),
                       ),
                     ],
                     selected: <ConnectionType>{connectionType},
@@ -883,7 +979,6 @@ class _AddServerFullscreenState extends State<AddServerFullscreen> {
                   child: TextFormField(
                     onChanged: validateAddress,
                     controller: addressFieldController,
-                    enabled: widget.server != null ? false : true,
                     decoration: InputDecoration(
                       errorText: addressFieldError,
                       prefixIcon: const Icon(Icons.link),
@@ -899,7 +994,6 @@ class _AddServerFullscreenState extends State<AddServerFullscreen> {
                   child: TextFormField(
                     onChanged: validatePort,
                     controller: portFieldController,
-                    enabled: widget.server != null ? false : true,
                     keyboardType: TextInputType.number,
                     decoration: InputDecoration(
                       errorText: portFieldError,
@@ -935,7 +1029,6 @@ class _AddServerFullscreenState extends State<AddServerFullscreen> {
                       TextFormField(
                         onChanged: validateSubroute,
                         controller: subrouteFieldController,
-                        enabled: widget.server != null ? false : true,
                         decoration: InputDecoration(
                           errorText: subrouteFieldError,
                           prefixIcon: const Icon(Icons.route_rounded),
@@ -1039,16 +1132,14 @@ class _AddServerFullscreenState extends State<AddServerFullscreen> {
                   padding: const EdgeInsets.symmetric(vertical: 10),
                   width: double.maxFinite,
                   child: SegmentedButton<String>(
-                    segments: [
+                    segments: const [
                       ButtonSegment(
                         value: SupportedApiVersions.v5,
-                        label: const Text(SupportedApiVersions.v5),
-                        enabled: widget.server != null ? false : true,
+                        label: Text(SupportedApiVersions.v5),
                       ),
                       ButtonSegment(
                         value: SupportedApiVersions.v6,
-                        label: const Text(SupportedApiVersions.v6),
-                        enabled: widget.server != null ? false : true,
+                        label: Text(SupportedApiVersions.v6),
                       ),
                     ],
                     selected: <String>{piHoleVersion},

--- a/lib/ui/servers/widgets/add_server_fullscreen.dart
+++ b/lib/ui/servers/widgets/add_server_fullscreen.dart
@@ -601,14 +601,6 @@ class _AddServerFullscreenState extends State<AddServerFullscreen> {
         ignoreCertificateErrors: ignoreCertificateErrors,
         pinnedCertificateSha256: pinnedCertificateSha256,
       );
-      await serversViewModel.savePassword(
-        targetAddress,
-        passwordFieldController.text,
-      );
-      await serversViewModel.saveToken(
-        targetAddress,
-        tokenFieldController.text,
-      );
       if (serversViewModel.selectedServer != null) {
         statusViewModel.stopAutoRefresh();
       }
@@ -632,12 +624,36 @@ class _AddServerFullscreenState extends State<AddServerFullscreen> {
 
       serverObj = updatedServer;
 
-      // Removes secrets written under the new address so a failed
-      // address-changing edit leaves no orphaned credentials behind.
-      Future<void> discardNewAddressSecrets() async {
-        if (isAddressChanged) {
-          await serversViewModel.deletePassword(targetAddress);
-          await serversViewModel.deleteToken(targetAddress);
+      await serversViewModel.savePassword(
+        targetAddress,
+        passwordFieldController.text,
+      );
+      await serversViewModel.saveToken(
+        targetAddress,
+        tokenFieldController.text,
+      );
+
+      // Rolls back everything written under the new address on a failed
+      // address-changing save: credentials, SID, and the freshly created remote
+      // session. Same-address edits keep their secrets (handled by the caller).
+      Future<void> discardNewAddressArtifacts({
+        required RepositoryBundle bundle,
+        required bool sessionCreated,
+      }) async {
+        if (!isAddressChanged) return;
+        await serversViewModel.deletePassword(targetAddress);
+        await serversViewModel.deleteToken(targetAddress);
+        await serversViewModel.deleteSid(targetAddress);
+        if (sessionCreated) {
+          try {
+            await bundle.auth.deleteCurrentSession();
+          } catch (e, s) {
+            logger.w(
+              'Failed to delete new session on server',
+              error: e,
+              stackTrace: s,
+            );
+          }
         }
       }
 
@@ -668,7 +684,10 @@ class _AddServerFullscreenState extends State<AddServerFullscreen> {
             passwordFieldController.text,
           );
           if (authResult.isError()) {
-            await discardNewAddressSecrets();
+            await discardNewAddressArtifacts(
+              bundle: bundle,
+              sessionCreated: false,
+            );
             handleSaveError(authResult.exceptionOrNull()!);
             return;
           }
@@ -707,24 +726,6 @@ class _AddServerFullscreenState extends State<AddServerFullscreen> {
       if (result.isSuccess()) {
         final server = serverObj.copyWith(defaultServer: defaultCheckbox);
 
-        // The new connection is confirmed working. When the address changed,
-        // terminate the old session on the Pi-hole server before deleting the
-        // local data. Best-effort: the old address is often unreachable (e.g.
-        // the user is fixing a wrong IP), so failures are logged and ignored.
-        if (isAddressChanged &&
-            oldServer.apiVersion == SupportedApiVersions.v6) {
-          try {
-            final oldBundle = saveCreateBundle(server: oldServer);
-            await oldBundle.auth.deleteCurrentSession();
-          } catch (e, s) {
-            logger.w(
-              'Failed to delete old session on server',
-              error: e,
-              stackTrace: s,
-            );
-          }
-        }
-
         Object? cmdError;
         try {
           if (isAddressChanged) {
@@ -741,8 +742,30 @@ class _AddServerFullscreenState extends State<AddServerFullscreen> {
           logger.e('Failed to save server', error: e, stackTrace: s);
           cmdError = e;
         }
-        if (context.mounted) {
-          if (cmdError == null) {
+
+        if (cmdError == null) {
+          // The old v6 session is orphaned on an address change or a switch
+          // away from v6 (e.g. v6 -> v5). Tear it down and drop the unused SID.
+          // Run only after the DB commit so a failed save can't kill a live
+          // session; best-effort since the old host is often unreachable.
+          final oldWasV6 = oldServer.apiVersion == SupportedApiVersions.v6;
+          final newIsV6 = serverObj.apiVersion == SupportedApiVersions.v6;
+          if (oldWasV6 && (isAddressChanged || !newIsV6)) {
+            try {
+              final oldBundle = saveCreateBundle(server: oldServer);
+              await oldBundle.auth.deleteCurrentSession();
+            } catch (e, s) {
+              logger.w(
+                'Failed to delete old session on server',
+                error: e,
+                stackTrace: s,
+              );
+            }
+            if (!isAddressChanged) {
+              await serversViewModel.deleteSid(targetAddress);
+            }
+          }
+          if (context.mounted) {
             await Navigator.maybePop(context);
             if (!context.mounted) return;
 
@@ -751,7 +774,16 @@ class _AddServerFullscreenState extends State<AddServerFullscreen> {
               appConfigViewModel: appConfigViewModel,
               label: AppLocalizations.of(context)!.editServerSuccessfully,
             );
-          } else {
+          }
+        } else {
+          // DB write failed: roll back the new-address artifacts; the old
+          // server (row, credentials, session) is left fully intact.
+          await discardNewAddressArtifacts(
+            bundle: bundle,
+            sessionCreated: sessionJustCreated,
+          );
+          if (!isAddressChanged) await _restoreSecrets();
+          if (context.mounted) {
             setState(() {
               isConnecting = false;
             });
@@ -763,11 +795,14 @@ class _AddServerFullscreenState extends State<AddServerFullscreen> {
           }
         }
       } else {
-        await discardNewAddressSecrets();
+        await discardNewAddressArtifacts(
+          bundle: bundle,
+          sessionCreated: sessionJustCreated,
+        );
+        if (!isAddressChanged) await _restoreSecrets();
         if (context.mounted) {
           setState(() {
             isConnecting = false;
-            _restoreSecrets();
           });
 
           handleApiErrorResult(

--- a/lib/utils/url.dart
+++ b/lib/utils/url.dart
@@ -1,0 +1,27 @@
+/// Compares two server URLs ignoring scheme/host case, a trailing slash and a
+/// scheme's default port.
+///
+/// Re-deriving the URL from the form fields lower-cases the host (via
+/// [Uri.parse]), so a plain string compare against the stored address would
+/// report a false "address changed" for an alias-only edit and wrongly take the
+/// destructive replace path. This normalises both sides.
+bool isSameEndpoint(String a, String b) {
+  String normalize(String url) {
+    final uri = Uri.parse(url);
+    var path = uri.path == '/' ? '' : uri.path;
+    if (path.endsWith('/')) {
+      path = path.substring(0, path.length - 1);
+    }
+    // [Uri.port] resolves the scheme's default (80/443), so an explicit default
+    // port and an omitted one normalise to the same endpoint.
+    // (e.g. https://pi.hole == https://pi.hole:443).
+    final port = uri.port != 0 ? ':${uri.port}' : '';
+    return '${uri.scheme.toLowerCase()}://${uri.host.toLowerCase()}$port$path';
+  }
+
+  try {
+    return normalize(a) == normalize(b);
+  } catch (_) {
+    return a == b;
+  }
+}

--- a/test/data/repositories/local/server_repository_test.dart
+++ b/test/data/repositories/local/server_repository_test.dart
@@ -374,6 +374,115 @@ void main() {
     });
   });
 
+  group('ServerRepository.replaceServer', () {
+    late LocalServerRepository repository;
+    late FakeDatabaseService dbService;
+    late FakeSecureStorageService ssSerivce;
+
+    const newServerV6 = Server(
+      address: 'http://192.168.1.50',
+      alias: 'test6-moved',
+      defaultServer: true,
+      apiVersion: 'v6',
+      allowUntrustedCert: true,
+      ignoreCertificateErrors: false,
+    );
+
+    setUp(() async {
+      dbService = FakeDatabaseService(path: dbName);
+      ssSerivce = FakeSecureStorageService();
+      repository = LocalServerRepository(dbService, ssSerivce);
+      await dbService.open();
+    });
+
+    tearDown(() async {
+      await dbService.close();
+      if (await databaseExists(dbName)) {
+        await deleteDatabase(dbName);
+      }
+    });
+
+    test('moves the row and swaps secret keys', () async {
+      await repository.insertServer(
+        serverV6,
+        password: 'pass-old',
+        sid: 'sid-old',
+      );
+
+      final result = await repository.replaceServer(
+        serverV6.address,
+        newServerV6,
+        password: 'pass-new',
+        sid: 'sid-new',
+      );
+      expect(result.isSuccess(), true);
+
+      final servers = await repository.fetchServers();
+      final addresses = servers.getOrNull()!.map((s) => s.address).toList();
+      expect(addresses.contains(serverV6.address), false);
+      expect(addresses.contains(newServerV6.address), true);
+
+      // Old secrets are removed.
+      expect(
+        (await ssSerivce.getValue('${serverV6.address}_password')).isError(),
+        true,
+      );
+      expect(
+        (await ssSerivce.getValue('${serverV6.address}_sid')).isError(),
+        true,
+      );
+      // New secrets are stored under the new address.
+      expect(
+        (await ssSerivce.getValue('${newServerV6.address}_password'))
+            .getOrNull(),
+        'pass-new',
+      );
+      expect(
+        (await ssSerivce.getValue('${newServerV6.address}_sid')).getOrNull(),
+        'sid-new',
+      );
+    });
+
+    test('removes cascade data for the old address', () async {
+      await repository.insertServer(serverV6);
+      await dbService.insert('gravity_updates', gravityUpdateDataJson);
+      await dbService.insert('gravity_messages', gravityMessagesDataJson);
+      await dbService.insert('gravity_logs', gravityLogsDataJson);
+
+      final result = await repository.replaceServer(
+        serverV6.address,
+        newServerV6,
+      );
+      expect(result.isSuccess(), true);
+
+      final gu = await dbService.query('gravity_updates');
+      expect(gu.getOrNull()?.length, 0);
+      final gm = await dbService.query('gravity_messages');
+      expect(gm.getOrNull()?.length, 0);
+      final gl = await dbService.query('gravity_logs');
+      expect(gl.getOrNull()?.length, 0);
+    });
+
+    test('returns Failure and keeps the old row on transaction error', () async {
+      await repository.insertServer(serverV6);
+      dbService.shouldThrowOnTransaction = true;
+
+      final result = await repository.replaceServer(
+        serverV6.address,
+        newServerV6,
+      );
+      expect(result.isError(), true);
+      expect(
+        result.exceptionOrNull()?.toString(),
+        contains('Failed to replace server'),
+      );
+
+      final servers = await repository.fetchServers();
+      final addresses = servers.getOrNull()!.map((s) => s.address).toList();
+      expect(addresses.contains(serverV6.address), true);
+    });
+  });
+
   group('ServerRepository.deleteAllServer', () {
     late LocalServerRepository repository;
     late FakeDatabaseService dbService;

--- a/test/data/repositories/local/server_repository_test.dart
+++ b/test/data/repositories/local/server_repository_test.dart
@@ -161,8 +161,9 @@ void main() {
     });
 
     test('returns Failure when unexpexted error', () async {
-      dbService.shouldThrowOnInsert = true;
-      await repository.insertServer(serverV6);
+      // insertServer now wraps the write in a transaction (atomic default
+      // clearing), so the transaction is what throws.
+      dbService.shouldThrowOnTransaction = true;
 
       final result = await repository.insertServer(serverV6);
       expect(result.isError(), true);
@@ -171,6 +172,21 @@ void main() {
         contains('Exception: Failed to save server'),
       );
     });
+
+    test(
+      'clears the previous default when inserting a new default server',
+      () async {
+        await repository.insertServer(serverV5.copyWith(defaultServer: true));
+        await repository.insertServer(serverV6); // defaultServer: true
+
+        final servers = (await repository.fetchServers()).getOrNull()!;
+        final defaults = servers
+            .where((s) => s.defaultServer)
+            .map((s) => s.address)
+            .toList();
+        expect(defaults, [serverV6.address]);
+      },
+    );
   });
 
   group('ServerRepository.updateServer', () {
@@ -231,8 +247,10 @@ void main() {
     });
 
     test('returns Failure when unexpected error', () async {
-      dbService.shouldThrowOnUpdate = true;
       await repository.insertServer(serverV6);
+      // updateServer now wraps the write in a transaction (atomic default
+      // clearing), so the transaction is what throws.
+      dbService.shouldThrowOnTransaction = true;
 
       final updatedServer = serverV6.copyWith(alias: 'updated6');
       final result = await repository.updateServer(updatedServer);
@@ -242,6 +260,26 @@ void main() {
         contains('Exception: Failed to edit server'),
       );
     });
+
+    test(
+      'clears the default flag on other servers when updating into a default server',
+      () async {
+        await repository.insertServer(serverV5.copyWith(defaultServer: true));
+        await repository.insertServer(serverV6.copyWith(defaultServer: false));
+
+        final result = await repository.updateServer(
+          serverV6.copyWith(defaultServer: true),
+        );
+        expect(result.isSuccess(), true);
+
+        final servers = (await repository.fetchServers()).getOrNull()!;
+        final defaults = servers
+            .where((s) => s.defaultServer)
+            .map((s) => s.address)
+            .toList();
+        expect(defaults, [serverV6.address]);
+      },
+    );
   });
 
   group('ServerRepository.updateDefaultServer', () {
@@ -402,7 +440,7 @@ void main() {
       }
     });
 
-    test('moves the row and swaps secret keys', () async {
+    test('moves the row and leaves secrets untouched (DB only)', () async {
       await repository.insertServer(
         serverV6,
         password: 'pass-old',
@@ -412,8 +450,6 @@ void main() {
       final result = await repository.replaceServer(
         serverV6.address,
         newServerV6,
-        password: 'pass-new',
-        sid: 'sid-new',
       );
       expect(result.isSuccess(), true);
 
@@ -422,25 +458,24 @@ void main() {
       expect(addresses.contains(serverV6.address), false);
       expect(addresses.contains(newServerV6.address), true);
 
-      // Old secrets are removed.
+      // replaceServer is DB-only: secret migration is owned by the caller so a
+      // failed transaction can leave the old session/credentials recoverable.
+      // The old secrets remain and no new-address secrets are created here.
       expect(
-        (await ssSerivce.getValue('${serverV6.address}_password')).isError(),
+        (await ssSerivce.getValue('${serverV6.address}_password')).getOrNull(),
+        'pass-old',
+      );
+      expect(
+        (await ssSerivce.getValue('${serverV6.address}_sid')).getOrNull(),
+        'sid-old',
+      );
+      expect(
+        (await ssSerivce.getValue('${newServerV6.address}_password')).isError(),
         true,
       );
       expect(
-        (await ssSerivce.getValue('${serverV6.address}_sid')).isError(),
+        (await ssSerivce.getValue('${newServerV6.address}_sid')).isError(),
         true,
-      );
-      // New secrets are stored under the new address.
-      expect(
-        (await ssSerivce.getValue(
-          '${newServerV6.address}_password',
-        )).getOrNull(),
-        'pass-new',
-      );
-      expect(
-        (await ssSerivce.getValue('${newServerV6.address}_sid')).getOrNull(),
-        'sid-new',
       );
     });
 

--- a/test/data/repositories/local/server_repository_test.dart
+++ b/test/data/repositories/local/server_repository_test.dart
@@ -433,8 +433,9 @@ void main() {
       );
       // New secrets are stored under the new address.
       expect(
-        (await ssSerivce.getValue('${newServerV6.address}_password'))
-            .getOrNull(),
+        (await ssSerivce.getValue(
+          '${newServerV6.address}_password',
+        )).getOrNull(),
         'pass-new',
       );
       expect(
@@ -463,8 +464,35 @@ void main() {
       expect(gl.getOrNull()?.length, 0);
     });
 
-    test('returns Failure and keeps the old row on transaction error', () async {
-      await repository.insertServer(serverV6);
+    test(
+      'returns Failure and keeps the old row on transaction error',
+      () async {
+        await repository.insertServer(serverV6);
+        dbService.shouldThrowOnTransaction = true;
+
+        final result = await repository.replaceServer(
+          serverV6.address,
+          newServerV6,
+        );
+        expect(result.isError(), true);
+        expect(
+          result.exceptionOrNull()?.toString(),
+          contains('Failed to replace server'),
+        );
+
+        final servers = await repository.fetchServers();
+        final addresses = servers.getOrNull()!.map((s) => s.address).toList();
+        expect(addresses.contains(serverV6.address), true);
+      },
+    );
+
+    test('keeps the old secrets when the replace transaction fails', () async {
+      await repository.insertServer(
+        serverV6,
+        token: 'token-old',
+        password: 'pass-old',
+        sid: 'sid-old',
+      );
       dbService.shouldThrowOnTransaction = true;
 
       final result = await repository.replaceServer(
@@ -472,14 +500,38 @@ void main() {
         newServerV6,
       );
       expect(result.isError(), true);
-      expect(
-        result.exceptionOrNull()?.toString(),
-        contains('Failed to replace server'),
-      );
 
-      final servers = await repository.fetchServers();
-      final addresses = servers.getOrNull()!.map((s) => s.address).toList();
-      expect(addresses.contains(serverV6.address), true);
+      expect(
+        (await ssSerivce.getValue('${serverV6.address}_password')).getOrNull(),
+        'pass-old',
+      );
+      expect(
+        (await ssSerivce.getValue('${serverV6.address}_token')).getOrNull(),
+        'token-old',
+      );
+      expect(
+        (await ssSerivce.getValue('${serverV6.address}_sid')).getOrNull(),
+        'sid-old',
+      );
+    });
+
+    test('clears the default flag on other servers when replacing into a '
+        'default server', () async {
+      await repository.insertServer(serverV6); // defaultServer: true
+      await repository.insertServer(serverV5); // defaultServer: false
+
+      final result = await repository.replaceServer(
+        serverV5.address,
+        newServerV6, // defaultServer: true
+      );
+      expect(result.isSuccess(), true);
+
+      final servers = (await repository.fetchServers()).getOrNull()!;
+      final defaults = servers
+          .where((s) => s.defaultServer)
+          .map((s) => s.address)
+          .toList();
+      expect(defaults, [newServerV6.address]);
     });
   });
 
@@ -648,6 +700,30 @@ void main() {
       expect(
         result.exceptionOrNull()?.toString(),
         contains('Exception: Failed to delete unused server secrets'),
+      );
+    });
+
+    test('handles addresses with underscores correctly', () async {
+      final server = serverV6.copyWith(address: 'http://local_host');
+      await repository.insertServer(server);
+      await ssSerivce.saveValue('${server.address}_token', 'token123');
+      await ssSerivce.saveValue('${server.address}_sid', 'sid123');
+      await ssSerivce.saveValue('${server.address}_password', 'pass123');
+
+      final result = await repository.deleteUnusedServerSecrets();
+      expect(result.isSuccess(), true);
+
+      expect(
+        (await ssSerivce.getValue('${server.address}_token')).getOrNull(),
+        'token123',
+      );
+      expect(
+        (await ssSerivce.getValue('${server.address}_sid')).getOrNull(),
+        'sid123',
+      );
+      expect(
+        (await ssSerivce.getValue('${server.address}_password')).getOrNull(),
+        'pass123',
       );
     });
   });

--- a/test/ui/core/view_models/servers_viewmodel_test.dart
+++ b/test/ui/core/view_models/servers_viewmodel_test.dart
@@ -162,6 +162,82 @@ void main() async {
       });
     });
 
+    group('replaceServer Command', () {
+      const newServer = Server(
+        address: 'http://192.168.1.10:8081',
+        alias: 'test v6',
+        defaultServer: false,
+        apiVersion: 'v6',
+        allowUntrustedCert: true,
+        ignoreCertificateErrors: false,
+      );
+
+      test('replaces a server and notifies listeners', () async {
+        await serversViewModel.addServer.runAsync(server);
+        listenerCalled = false;
+
+        await serversViewModel.replaceServer.runAsync((
+          oldAddress: server.address,
+          newServer: newServer,
+        ));
+
+        expect(serversViewModel.replaceServer.errors.value, isNull);
+        expect(serversViewModel.getServersList.contains(server), false);
+        expect(serversViewModel.getServersList.contains(newServer), true);
+        expect(repository.lastReplacedOldAddress, server.address);
+        expect(repository.lastReplacedNewServer, newServer);
+        expect(listenerCalled, true);
+      });
+
+      test('updates selectedServer when the old address matches', () async {
+        await serversViewModel.addServer.runAsync(server);
+        serversViewModel.setselectedServer(server: server);
+
+        await serversViewModel.replaceServer.runAsync((
+          oldAddress: server.address,
+          newServer: newServer,
+        ));
+
+        expect(serversViewModel.replaceServer.errors.value, isNull);
+        expect(serversViewModel.selectedServer?.address, newServer.address);
+      });
+
+      test('with defaultServer=true sets default and notifies', () async {
+        await serversViewModel.addServer.runAsync(server);
+
+        final defaultNewServer = newServer.copyWith(defaultServer: true);
+        await serversViewModel.replaceServer.runAsync((
+          oldAddress: server.address,
+          newServer: defaultNewServer,
+        ));
+
+        expect(serversViewModel.replaceServer.errors.value, isNull);
+        expect(
+          serversViewModel.getServersList
+              .firstWhere((s) => s.address == newServer.address)
+              .defaultServer,
+          true,
+        );
+        expect(listenerCalled, true);
+      });
+
+      test('sets error on failure', () async {
+        await serversViewModel.addServer.runAsync(server);
+        repository.shouldFailReplace = true;
+        try {
+          await serversViewModel.replaceServer.runAsync((
+            oldAddress: server.address,
+            newServer: newServer,
+          ));
+        } catch (_) {}
+
+        expect(serversViewModel.replaceServer.errors.value, isNotNull);
+        // The old server remains untouched on failure.
+        expect(serversViewModel.getServersList.contains(server), true);
+        expect(listenerCalled, true);
+      });
+    });
+
     group('removeServer Command', () {
       test('removes a server and notifies listeners', () async {
         await serversViewModel.addServer.runAsync(server);

--- a/test/ui/servers/add_server_fullscreen_test.dart
+++ b/test/ui/servers/add_server_fullscreen_test.dart
@@ -658,6 +658,103 @@ void main() async {
     });
 
     testWidgets(
+      'preserves a multi-segment subroute and an alias-only edit stays in place',
+      (WidgetTester tester) async {
+        useLargeView(tester);
+
+        const serverMultiSeg = Server(
+          address: 'http://localhost:8081/api/v1',
+          alias: 'multi',
+          defaultServer: false,
+          apiVersion: 'v6',
+          allowUntrustedCert: true,
+          ignoreCertificateErrors: false,
+        );
+
+        await tester.pumpWidget(
+          buildWidget(
+            const AddServerFullscreen(
+              window: false,
+              title: 'test',
+              server: serverMultiSeg,
+            ),
+          ),
+        );
+        await tester.pump();
+
+        await tester.enterText(find.byType(TextField).at(0), 'renamed');
+        await tester.tap(find.byIcon(Icons.save_rounded));
+        await tester.pump(const Duration(milliseconds: 1000));
+
+        expect(serversViewModel.editServerCallCount, 1);
+        expect(serversViewModel.replaceServerCallCount, 0);
+      },
+    );
+
+    testWidgets('uppercase host with an alias-only edit stays in place', (
+      WidgetTester tester,
+    ) async {
+      useLargeView(tester);
+
+      const serverUpper = Server(
+        address: 'http://MyPi',
+        alias: 'upper',
+        defaultServer: false,
+        apiVersion: 'v6',
+        allowUntrustedCert: true,
+        ignoreCertificateErrors: false,
+      );
+
+      await tester.pumpWidget(
+        buildWidget(
+          const AddServerFullscreen(
+            window: false,
+            title: 'test',
+            server: serverUpper,
+          ),
+        ),
+      );
+      await tester.pump();
+
+      // Alias-only edit: the host case difference must not trigger replace.
+      await tester.enterText(find.byType(TextField).at(0), 'renamed');
+      await tester.tap(find.byIcon(Icons.save_rounded));
+      await tester.pump(const Duration(milliseconds: 1000));
+
+      expect(serversViewModel.editServerCallCount, 1);
+      expect(serversViewModel.replaceServerCallCount, 0);
+    });
+
+    testWidgets('clearing the password disables Save for a v6 server', (
+      WidgetTester tester,
+    ) async {
+      useLargeView(tester);
+
+      await tester.pumpWidget(
+        buildWidget(
+          const AddServerFullscreen(
+            window: false,
+            title: 'test',
+            server: _serverV6,
+          ),
+        ),
+      );
+      await tester.pump();
+
+      // password field is the last visible TextField (index 3).
+      await tester.enterText(find.byType(TextField).at(3), '');
+      await tester.pump();
+
+      final saveButton = tester.widget<IconButton>(
+        find.ancestor(
+          of: find.byIcon(Icons.save_rounded),
+          matching: find.byType(IconButton),
+        ),
+      );
+      expect(saveButton.onPressed, isNull);
+    });
+
+    testWidgets(
       'should show the failed snackbar when editing a server (socketError)',
       (WidgetTester tester) async {
         tester.view.physicalSize = const Size(1080, 2400);
@@ -1721,5 +1818,116 @@ void main() async {
         'new:fingerprint',
       );
     });
+
+    testWidgets(
+      'same-address v6 password change validates the new password and aborts the save when authentication fails',
+      (WidgetTester tester) async {
+        useLargeView(tester);
+
+        // The bundle for the (unchanged) address must re-authenticate with the
+        // edited password; force that createSession to fail.
+        final failingAuth = FakeAuthRepository()..shouldFail = true;
+
+        await tester.pumpWidget(
+          buildWidget(
+            const AddServerFullscreen(
+              window: false,
+              title: 'test',
+              server: _serverV6,
+            ),
+            authByAddress: {_serverV6.address: failingAuth},
+          ),
+        );
+        await tester.pump();
+
+        // Change only the password (address stays the same).
+        await tester.enterText(find.byType(TextField).at(3), 'new-password');
+
+        await tester.tap(find.byIcon(Icons.save_rounded));
+        await tester.pump(const Duration(milliseconds: 1000));
+
+        // The edited password is validated up-front and the save is aborted.
+        expect(failingAuth.createSessionCallCount, 1);
+        expect(serversViewModel.editServerCallCount, 0);
+        expect(find.text('Failed. Unknown error.'), findsOneWidget);
+      },
+    );
+
+    testWidgets(
+      'same-address v6 password change re-authenticates with the new password',
+      (WidgetTester tester) async {
+        useLargeView(tester);
+
+        final auth = FakeAuthRepository();
+
+        await tester.pumpWidget(
+          buildWidget(
+            const AddServerFullscreen(
+              window: false,
+              title: 'test',
+              server: _serverV6,
+            ),
+            authByAddress: {_serverV6.address: auth},
+          ),
+        );
+        await tester.pump();
+
+        await tester.enterText(find.byType(TextField).at(3), 'new-password');
+
+        await tester.tap(find.byIcon(Icons.save_rounded));
+        await tester.pump(const Duration(milliseconds: 1000));
+
+        // Editing the password forces a session create to validate it, but the
+        // edit still commits in place.
+        expect(auth.createSessionCallCount, 1);
+        expect(serversViewModel.editServerCallCount, 1);
+        expect(serversViewModel.replaceServerCallCount, 0);
+        expect(
+          find.text('Server settings updated successfully.'),
+          findsOneWidget,
+        );
+      },
+    );
+
+    testWidgets(
+      'a failed credential load does not wipe the stored secret when the save '
+      'fails',
+      (WidgetTester tester) async {
+        useLargeView(tester);
+
+        // Secure-storage read fails on load, so initPassword is an empty
+        // placeholder even though a real secret still exists in storage.
+        serversViewModel.failFetchCredentials = true;
+        fakeDnsRepository
+          ..shouldFail = true
+          ..failureException = HttpStatusCodeException(503);
+
+        await tester.pumpWidget(
+          buildWidget(
+            const AddServerFullscreen(
+              window: false,
+              title: 'test',
+              server: _serverV6,
+            ),
+          ),
+        );
+        // Let the (failing) credential load settle before editing the field so
+        // it can't overwrite the value entered below. pumpAndSettle is unusable
+        // here because the connecting spinner animates indefinitely.
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 500));
+
+        // Re-enter the (correct) password and save; the connection then fails.
+        await tester.enterText(find.byType(TextField).at(3), 'real-pass');
+        await tester.pump();
+
+        await tester.tap(find.byIcon(Icons.save_rounded));
+        await tester.pump(const Duration(milliseconds: 1000));
+
+        // The rollback must not restore the empty placeholder over the secret.
+        expect(find.text('Failed. Check address.'), findsOneWidget);
+        expect(serversViewModel.lastSavedPassword, 'real-pass');
+      },
+    );
   });
 }

--- a/test/ui/servers/add_server_fullscreen_test.dart
+++ b/test/ui/servers/add_server_fullscreen_test.dart
@@ -10,6 +10,7 @@ import 'package:pi_hole_client/ui/servers/widgets/certificate_details_dialog.dar
 import 'package:pi_hole_client/utils/exceptions.dart';
 import 'package:pi_hole_client/utils/tls_certificate.dart';
 
+import '../../../testing/fakes/repositories/api/fake_auth_repository.dart';
 import '../../../testing/fakes/repositories/api/fake_dns_repository.dart';
 import '../../../testing/fakes/repositories/local/fake_app_config_repository.dart';
 import '../../../testing/fakes/viewmodels/fake_servers_viewmodel.dart';
@@ -21,6 +22,24 @@ const _serverV6 = Server(
   alias: 'test v6',
   defaultServer: false,
   apiVersion: 'v6',
+  allowUntrustedCert: true,
+  ignoreCertificateErrors: false,
+);
+
+const _serverV6Default = Server(
+  address: 'http://localhost:8081',
+  alias: 'test v6 default',
+  defaultServer: true,
+  apiVersion: 'v6',
+  allowUntrustedCert: true,
+  ignoreCertificateErrors: false,
+);
+
+const _serverV5 = Server(
+  address: 'http://localhost:8081',
+  alias: 'test v5',
+  defaultServer: false,
+  apiVersion: 'v5',
   allowUntrustedCert: true,
   ignoreCertificateErrors: false,
 );
@@ -99,7 +118,15 @@ void main() async {
       fakeDnsRepository = FakeDnsRepository();
     });
 
-    Widget buildWidget(Widget child) {
+    // [authByAddress] maps a server address to the auth fake that its bundle
+    // should use, so the new-address and old-address bundles can be controlled
+    // independently (e.g. fail createSession on the new host, or
+    // deleteCurrentSession on the old host). Addresses not listed fall back to
+    // a default succeeding auth.
+    Widget buildWidget(
+      Widget child, {
+      Map<String, FakeAuthRepository>? authByAddress,
+    }) {
       final bundle = createFakeRepositoryBundle(dns: fakeDnsRepository);
       return buildTestApp(
         child,
@@ -110,11 +137,23 @@ void main() async {
         createRepositoryBundle: ({required server}) =>
             createFakeRepositoryBundle(
               dns: fakeDnsRepository,
+              auth: authByAddress?[server.address],
               serverAddress: server.address,
               apiVersion: server.apiVersion,
             ),
         secureStorageService: SecureStorageService(),
       );
+    }
+
+    // Gives the test surface enough room so the save/login button and the
+    // form fields are laid out and tappable.
+    void useLargeView(WidgetTester tester) {
+      tester.view.physicalSize = const Size(1080, 2400);
+      tester.view.devicePixelRatio = 2.0;
+      addTearDown(() {
+        tester.view.resetPhysicalSize();
+        tester.view.resetDevicePixelRatio();
+      });
     }
 
     testWidgets('should show the page with window', (
@@ -1059,5 +1098,334 @@ void main() async {
         );
       },
     );
+
+    // Server-edit flow tests.
+    testWidgets(
+      'address change with a failing connection does not replace and shows an error',
+      (WidgetTester tester) async {
+        useLargeView(tester);
+
+        fakeDnsRepository
+          ..shouldFail = true
+          ..failureException = HttpStatusCodeException(503);
+
+        await tester.pumpWidget(
+          buildWidget(
+            const AddServerFullscreen(
+              window: false,
+              title: 'test',
+              server: _serverV6,
+            ),
+          ),
+        );
+
+        await tester.enterText(find.byType(TextField).at(1), '192.168.1.10');
+
+        await tester.tap(find.byIcon(Icons.save_rounded));
+        await tester.pump(const Duration(milliseconds: 1000));
+
+        expect(serversViewModel.replaceServerCallCount, 0);
+        expect(find.text('Failed. Check address.'), findsOneWidget);
+      },
+    );
+
+    testWidgets('replaceServer DB failure shows the cant-save error', (
+      WidgetTester tester,
+    ) async {
+      useLargeView(tester);
+
+      serversViewModel.shouldFailReplaceServer = true;
+
+      await tester.pumpWidget(
+        buildWidget(
+          const AddServerFullscreen(
+            window: false,
+            title: 'test',
+            server: _serverV6,
+          ),
+        ),
+      );
+
+      await tester.enterText(find.byType(TextField).at(1), '192.168.1.10');
+
+      await tester.tap(find.byIcon(Icons.save_rounded));
+      await tester.pump(const Duration(milliseconds: 1000));
+
+      expect(find.text("Connection data couldn't be saved"), findsOneWidget);
+    });
+
+    testWidgets(
+      'address change carries the default flag into the replaced server',
+      (WidgetTester tester) async {
+        useLargeView(tester);
+
+        await tester.pumpWidget(
+          buildWidget(
+            const AddServerFullscreen(
+              window: false,
+              title: 'test',
+              server: _serverV6Default,
+            ),
+          ),
+        );
+
+        await tester.enterText(find.byType(TextField).at(1), '192.168.1.10');
+
+        await tester.tap(find.byIcon(Icons.save_rounded));
+        await tester.pump(const Duration(milliseconds: 1000));
+
+        expect(serversViewModel.replaceServerCallCount, 1);
+        expect(serversViewModel.lastReplacedNewServer?.defaultServer, isTrue);
+      },
+    );
+
+    testWidgets('v5 server replaces on address change', (
+      WidgetTester tester,
+    ) async {
+      useLargeView(tester);
+
+      await tester.pumpWidget(
+        buildWidget(
+          const AddServerFullscreen(
+            window: false,
+            title: 'test',
+            server: _serverV5,
+          ),
+        ),
+      );
+
+      await tester.enterText(find.byType(TextField).at(1), '192.168.1.10');
+
+      await tester.tap(find.byIcon(Icons.save_rounded));
+      await tester.pump(const Duration(milliseconds: 1000));
+
+      expect(serversViewModel.replaceServerCallCount, 1);
+      expect(serversViewModel.lastReplacedNewServer?.apiVersion, 'v5');
+    });
+
+    testWidgets('port-only change rebuilds the URL correctly', (
+      WidgetTester tester,
+    ) async {
+      useLargeView(tester);
+
+      await tester.pumpWidget(
+        buildWidget(
+          const AddServerFullscreen(
+            window: false,
+            title: 'test',
+            server: _serverHttpsIgnore,
+          ),
+        ),
+      );
+
+      await tester.enterText(find.byType(TextField).at(2), '9999');
+
+      await tester.tap(find.byIcon(Icons.save_rounded));
+      await tester.pump(const Duration(milliseconds: 1000));
+
+      expect(serversViewModel.replaceServerCallCount, 1);
+      expect(
+        serversViewModel.lastReplacedNewServer?.address,
+        'https://pi.hole:9999',
+      );
+    });
+
+    testWidgets('subroute-only change rebuilds the URL correctly', (
+      WidgetTester tester,
+    ) async {
+      useLargeView(tester);
+
+      await tester.pumpWidget(
+        buildWidget(
+          const AddServerFullscreen(
+            window: false,
+            title: 'test',
+            server: _serverHttpsIgnore,
+          ),
+        ),
+      );
+
+      await tester.enterText(find.byType(TextField).at(3), '/admin');
+
+      await tester.tap(find.byIcon(Icons.save_rounded));
+      await tester.pump(const Duration(milliseconds: 1000));
+
+      expect(serversViewModel.replaceServerCallCount, 1);
+      expect(
+        serversViewModel.lastReplacedNewServer?.address,
+        'https://pi.hole/admin',
+      );
+    });
+
+    testWidgets('editServer DB failure shows the cant-save error', (
+      WidgetTester tester,
+    ) async {
+      useLargeView(tester);
+
+      serversViewModel.shouldFailEditServer = true;
+
+      await tester.pumpWidget(
+        buildWidget(
+          const AddServerFullscreen(
+            window: false,
+            title: 'test',
+            server: _serverV6,
+          ),
+        ),
+      );
+
+      // Same address (only the alias changes) so save() takes the edit path.
+      await tester.enterText(find.byType(TextField).at(0), 'renamed');
+
+      await tester.tap(find.byIcon(Icons.save_rounded));
+      await tester.pump(const Duration(milliseconds: 1000));
+
+      // The edit was attempted (not a replace); its DB failure surfaces.
+      expect(serversViewModel.editServerCallCount, 1);
+      expect(serversViewModel.replaceServerCallCount, 0);
+      expect(find.text("Connection data couldn't be saved"), findsOneWidget);
+    });
+
+    testWidgets('inconclusive URL uniqueness check aborts the save', (
+      WidgetTester tester,
+    ) async {
+      useLargeView(tester);
+
+      serversViewModel.checkUrlExistsFails = true;
+
+      await tester.pumpWidget(
+        buildWidget(
+          const AddServerFullscreen(
+            window: false,
+            title: 'test',
+            server: _serverV6,
+          ),
+        ),
+      );
+
+      await tester.enterText(find.byType(TextField).at(1), '192.168.1.10');
+
+      await tester.tap(find.byIcon(Icons.save_rounded));
+      await tester.pump(const Duration(milliseconds: 1000));
+
+      expect(serversViewModel.replaceServerCallCount, 0);
+      expect(
+        find.text('Cannot check if this URL is already saved.'),
+        findsOneWidget,
+      );
+    });
+
+    testWidgets('with no selected server, auto-refresh is not toggled', (
+      WidgetTester tester,
+    ) async {
+      useLargeView(tester);
+
+      serversViewModel.selectedServer = null;
+
+      await tester.pumpWidget(
+        buildWidget(
+          const AddServerFullscreen(
+            window: false,
+            title: 'test',
+            server: _serverV6,
+          ),
+        ),
+      );
+
+      await tester.enterText(find.byType(TextField).at(1), '192.168.1.10');
+
+      await tester.tap(find.byIcon(Icons.save_rounded));
+      await tester.pump(const Duration(milliseconds: 1000));
+
+      expect(serversViewModel.replaceServerCallCount, 1);
+      expect(statusViewModel.stopAutoRefreshCallCount, 0);
+      expect(statusViewModel.startAutoRefreshCallCount, 0);
+    });
+
+    testWidgets('createSession failure on the new address aborts the replace', (
+      WidgetTester tester,
+    ) async {
+      useLargeView(tester);
+
+      final failingAuth = FakeAuthRepository()..shouldFail = true;
+
+      await tester.pumpWidget(
+        buildWidget(
+          const AddServerFullscreen(
+            window: false,
+            title: 'test',
+            server: _serverV6,
+          ),
+          authByAddress: {'http://192.168.1.10:8081': failingAuth},
+        ),
+      );
+
+      await tester.enterText(find.byType(TextField).at(1), '192.168.1.10');
+
+      await tester.tap(find.byIcon(Icons.save_rounded));
+      await tester.pump(const Duration(milliseconds: 1000));
+
+      // Outcome: the replace is aborted and the user sees the failure.
+      expect(serversViewModel.replaceServerCallCount, 0);
+      expect(find.text('Failed. Unknown error.'), findsOneWidget);
+    });
+
+    testWidgets('v5 address change never deletes the old session', (
+      WidgetTester tester,
+    ) async {
+      useLargeView(tester);
+
+      final oldAuth = FakeAuthRepository();
+
+      await tester.pumpWidget(
+        buildWidget(
+          const AddServerFullscreen(
+            window: false,
+            title: 'test',
+            server: _serverV5,
+          ),
+          authByAddress: {_serverV5.address: oldAuth},
+        ),
+      );
+
+      await tester.enterText(find.byType(TextField).at(1), '192.168.1.10');
+
+      await tester.tap(find.byIcon(Icons.save_rounded));
+      await tester.pump(const Duration(milliseconds: 1000));
+
+      expect(serversViewModel.replaceServerCallCount, 1);
+      expect(oldAuth.deleteCurrentSessionCallCount, 0);
+    });
+
+    testWidgets('replace still succeeds when the old session logout fails', (
+      WidgetTester tester,
+    ) async {
+      useLargeView(tester);
+
+      final oldAuth = FakeAuthRepository()..shouldFail = true;
+
+      await tester.pumpWidget(
+        buildWidget(
+          const AddServerFullscreen(
+            window: false,
+            title: 'test',
+            server: _serverV6,
+          ),
+          authByAddress: {_serverV6.address: oldAuth},
+        ),
+      );
+
+      await tester.enterText(find.byType(TextField).at(1), '192.168.1.10');
+
+      await tester.tap(find.byIcon(Icons.save_rounded));
+      await tester.pump(const Duration(milliseconds: 1000));
+
+      expect(oldAuth.deleteCurrentSessionCallCount, 1);
+      expect(serversViewModel.replaceServerCallCount, 1);
+      expect(
+        find.text('Server settings updated successfully.'),
+        findsOneWidget,
+      );
+    });
   });
 }

--- a/test/ui/servers/add_server_fullscreen_test.dart
+++ b/test/ui/servers/add_server_fullscreen_test.dart
@@ -63,6 +63,15 @@ const _serverHttpsIgnore = Server(
   ignoreCertificateErrors: true,
 );
 
+const _serverHttpsNoPin = Server(
+  address: 'https://pi.hole',
+  alias: 'https v6',
+  defaultServer: false,
+  apiVersion: 'v6',
+  allowUntrustedCert: true,
+  ignoreCertificateErrors: false,
+);
+
 TlsCertificateInfo _certInfo({String sha256 = 'new:fingerprint'}) {
   return TlsCertificateInfo(
     sha256: sha256,
@@ -912,105 +921,148 @@ void main() async {
     // TLS handshake. R27 (retry without re-prompt) is out of scope until the
     // _certValidatedForAddress memory lands on this branch.
 
-    testWidgets(
-      'R25: HTTPS edit without address change reuses the existing pin '
-      'and shows no dialog',
-      (WidgetTester tester) async {
-        tester.view.physicalSize = const Size(1080, 2400);
-        tester.view.devicePixelRatio = 2.0;
+    testWidgets('HTTPS edit without address change reuses the existing pin '
+        'and shows no dialog', (WidgetTester tester) async {
+      tester.view.physicalSize = const Size(1080, 2400);
+      tester.view.devicePixelRatio = 2.0;
 
-        addTearDown(() {
-          tester.view.resetPhysicalSize();
-          tester.view.resetDevicePixelRatio();
-        });
+      addTearDown(() {
+        tester.view.resetPhysicalSize();
+        tester.view.resetDevicePixelRatio();
+      });
 
-        final fetcher = _FakeFetcher(onStrict: _certInfo());
+      final fetcher = _FakeFetcher(onStrict: _certInfo());
 
-        await tester.pumpWidget(
-          buildWidget(
-            AddServerFullscreen(
-              window: false,
-              title: 'test',
-              server: _serverHttpsPinned,
-              fetchTlsCertificate: fetcher.call,
-            ),
+      await tester.pumpWidget(
+        buildWidget(
+          AddServerFullscreen(
+            window: false,
+            title: 'test',
+            server: _serverHttpsPinned,
+            fetchTlsCertificate: fetcher.call,
           ),
-        );
+        ),
+      );
 
-        // Change only the alias so the address (primary key) is unchanged.
-        await tester.enterText(find.byType(TextField).at(0), 'renamed');
+      // Change only the alias so the address (primary key) is unchanged.
+      await tester.enterText(find.byType(TextField).at(0), 'renamed');
 
-        await tester.tap(find.byIcon(Icons.save_rounded));
-        await tester.pump(const Duration(milliseconds: 1000));
+      await tester.tap(find.byIcon(Icons.save_rounded));
+      await tester.pump(const Duration(milliseconds: 1000));
 
-        expect(find.byType(CertificateDetailsDialog), findsNothing);
-        expect(fetcher.callCount, 0);
-        expect(serversViewModel.editServerCallCount, 1);
-        expect(serversViewModel.replaceServerCallCount, 0);
-      },
-    );
+      expect(find.byType(CertificateDetailsDialog), findsNothing);
+      expect(fetcher.callCount, 0);
+      expect(serversViewModel.editServerCallCount, 1);
+      expect(serversViewModel.replaceServerCallCount, 0);
+    });
 
-    testWidgets(
-      'R26: HTTPS address change resets the pin, prompts the dialog and '
-      'pins the new fingerprint on confirm',
-      (WidgetTester tester) async {
-        tester.view.physicalSize = const Size(1080, 2400);
-        tester.view.devicePixelRatio = 2.0;
+    testWidgets('HTTPS address change resets the pin, prompts the dialog and '
+        'pins the new fingerprint on confirm', (WidgetTester tester) async {
+      tester.view.physicalSize = const Size(1080, 2400);
+      tester.view.devicePixelRatio = 2.0;
 
-        addTearDown(() {
-          tester.view.resetPhysicalSize();
-          tester.view.resetDevicePixelRatio();
-        });
+      addTearDown(() {
+        tester.view.resetPhysicalSize();
+        tester.view.resetDevicePixelRatio();
+      });
 
-        final fetcher = _FakeFetcher(
-          strictError: const HandshakeException(),
-          onAllowBad: _certInfo(sha256: 'new:fingerprint'),
-        );
+      final fetcher = _FakeFetcher(
+        strictError: const HandshakeException(),
+        onAllowBad: _certInfo(sha256: 'new:fingerprint'),
+      );
 
-        await tester.pumpWidget(
-          buildWidget(
-            AddServerFullscreen(
-              window: false,
-              title: 'test',
-              server: _serverHttpsPinned,
-              fetchTlsCertificate: fetcher.call,
-            ),
+      await tester.pumpWidget(
+        buildWidget(
+          AddServerFullscreen(
+            window: false,
+            title: 'test',
+            server: _serverHttpsPinned,
+            fetchTlsCertificate: fetcher.call,
           ),
-        );
+        ),
+      );
 
-        // Change the host so the resulting URL (primary key) differs.
-        await tester.enterText(find.byType(TextField).at(1), 'pi.hole.new');
+      // Change the host so the resulting URL (primary key) differs.
+      await tester.enterText(find.byType(TextField).at(1), 'pi.hole.new');
 
-        await tester.tap(find.byIcon(Icons.save_rounded));
-        // Cannot pumpAndSettle: the in-progress spinner animates indefinitely.
-        await tester.pump();
-        await tester.pump(const Duration(milliseconds: 500));
+      await tester.tap(find.byIcon(Icons.save_rounded));
+      // Cannot pumpAndSettle: the in-progress spinner animates indefinitely.
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 500));
 
-        expect(find.byType(CertificateDetailsDialog), findsOneWidget);
+      expect(find.byType(CertificateDetailsDialog), findsOneWidget);
 
-        await tester.tap(find.widgetWithText(TextButton, 'Confirm'));
-        await tester.pump();
-        await tester.pump(const Duration(milliseconds: 1000));
+      await tester.tap(find.widgetWithText(TextButton, 'Confirm'));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 1000));
 
-        expect(serversViewModel.replaceServerCallCount, 1);
-        expect(
-          serversViewModel.lastReplacedOldAddress,
-          _serverHttpsPinned.address,
-        );
-        expect(
-          serversViewModel.lastReplacedNewServer?.address,
-          'https://pi.hole.new',
-        );
-        expect(
-          serversViewModel.lastReplacedNewServer?.pinnedCertificateSha256,
-          'new:fingerprint',
-        );
-      },
-    );
+      expect(serversViewModel.replaceServerCallCount, 1);
+      expect(
+        serversViewModel.lastReplacedOldAddress,
+        _serverHttpsPinned.address,
+      );
+      expect(
+        serversViewModel.lastReplacedNewServer?.address,
+        'https://pi.hole.new',
+      );
+      expect(
+        serversViewModel.lastReplacedNewServer?.pinnedCertificateSha256,
+        'new:fingerprint',
+      );
+    });
+
+    testWidgets('cancelling the certificate dialog aborts the save and keeps '
+        'the old server', (WidgetTester tester) async {
+      tester.view.physicalSize = const Size(1080, 2400);
+      tester.view.devicePixelRatio = 2.0;
+
+      addTearDown(() {
+        tester.view.resetPhysicalSize();
+        tester.view.resetDevicePixelRatio();
+      });
+
+      final fetcher = _FakeFetcher(
+        strictError: const HandshakeException(),
+        onAllowBad: _certInfo(),
+      );
+
+      await tester.pumpWidget(
+        buildWidget(
+          AddServerFullscreen(
+            window: false,
+            title: 'test',
+            server: _serverHttpsPinned,
+            fetchTlsCertificate: fetcher.call,
+          ),
+        ),
+      );
+
+      await tester.enterText(find.byType(TextField).at(1), 'pi.hole.new');
+
+      await tester.tap(find.byIcon(Icons.save_rounded));
+      // Cannot pumpAndSettle: the in-progress spinner animates indefinitely.
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 500));
+
+      expect(find.byType(CertificateDetailsDialog), findsOneWidget);
+
+      await tester.tap(find.widgetWithText(TextButton, 'Cancel'));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 1000));
+
+      expect(find.byType(CertificateDetailsDialog), findsNothing);
+      expect(serversViewModel.replaceServerCallCount, 0);
+      expect(serversViewModel.editServerCallCount, 0);
+      expect(find.text('Server settings updated successfully.'), findsNothing);
+      // No secret may be persisted for the new address: cancelling the
+      // certificate dialog must not leave orphaned credentials behind.
+      expect(serversViewModel.savePasswordCallCount, 0);
+      expect(serversViewModel.saveTokenCallCount, 0);
+    });
 
     testWidgets(
-      'R28: cancelling the certificate dialog aborts the save and keeps '
-      'the old server',
+      'cancelling the certificate dialog on a same-address edit keeps '
+      "the existing server's credentials untouched",
       (WidgetTester tester) async {
         tester.view.physicalSize = const Size(1080, 2400);
         tester.view.devicePixelRatio = 2.0;
@@ -1030,13 +1082,14 @@ void main() async {
             AddServerFullscreen(
               window: false,
               title: 'test',
-              server: _serverHttpsPinned,
+              server: _serverHttpsNoPin,
               fetchTlsCertificate: fetcher.call,
             ),
           ),
         );
 
-        await tester.enterText(find.byType(TextField).at(1), 'pi.hole.new');
+        // Change only the alias so the address (primary key) is unchanged.
+        await tester.enterText(find.byType(TextField).at(0), 'renamed');
 
         await tester.tap(find.byIcon(Icons.save_rounded));
         // Cannot pumpAndSettle: the in-progress spinner animates indefinitely.
@@ -1052,10 +1105,8 @@ void main() async {
         expect(find.byType(CertificateDetailsDialog), findsNothing);
         expect(serversViewModel.replaceServerCallCount, 0);
         expect(serversViewModel.editServerCallCount, 0);
-        expect(
-          find.text('Server settings updated successfully.'),
-          findsNothing,
-        );
+        expect(serversViewModel.savePasswordCallCount, 0);
+        expect(serversViewModel.saveTokenCallCount, 0);
       },
     );
 
@@ -1425,6 +1476,249 @@ void main() async {
       expect(
         find.text('Server settings updated successfully.'),
         findsOneWidget,
+      );
+    });
+
+    testWidgets(
+      'replace DB failure keeps the old session and cleans up the new one',
+      (WidgetTester tester) async {
+        useLargeView(tester);
+
+        serversViewModel.shouldFailReplaceServer = true;
+
+        final oldAuth = FakeAuthRepository();
+        final newAuth = FakeAuthRepository();
+
+        await tester.pumpWidget(
+          buildWidget(
+            const AddServerFullscreen(
+              window: false,
+              title: 'test',
+              server: _serverV6,
+            ),
+            authByAddress: {
+              _serverV6.address: oldAuth,
+              'http://192.168.1.10:8081': newAuth,
+            },
+          ),
+        );
+
+        await tester.enterText(find.byType(TextField).at(1), '192.168.1.10');
+
+        await tester.tap(find.byIcon(Icons.save_rounded));
+        await tester.pump(const Duration(milliseconds: 1000));
+
+        // Old session must survive a failed commit.
+        expect(oldAuth.deleteCurrentSessionCallCount, 0);
+        // New-address session + SID must be reclaimed.
+        expect(newAuth.deleteCurrentSessionCallCount, 1);
+        expect(serversViewModel.deleteSidCallCount, 1);
+      },
+    );
+
+    testWidgets(
+      'connection failure cleans up the newly created session and SID',
+      (WidgetTester tester) async {
+        useLargeView(tester);
+
+        fakeDnsRepository
+          ..shouldFail = true
+          ..failureException = HttpStatusCodeException(503);
+
+        final newAuth = FakeAuthRepository();
+
+        await tester.pumpWidget(
+          buildWidget(
+            const AddServerFullscreen(
+              window: false,
+              title: 'test',
+              server: _serverV6,
+            ),
+            authByAddress: {'http://192.168.1.10:8081': newAuth},
+          ),
+        );
+
+        await tester.enterText(find.byType(TextField).at(1), '192.168.1.10');
+
+        await tester.tap(find.byIcon(Icons.save_rounded));
+        await tester.pump(const Duration(milliseconds: 1000));
+
+        expect(newAuth.createSessionCallCount, 1);
+        expect(newAuth.deleteCurrentSessionCallCount, 1);
+        expect(serversViewModel.deleteSidCallCount, 1);
+      },
+    );
+
+    Finder apiVersionSegment(String label) => find.descendant(
+      of: find.byType(SegmentedButton<String>),
+      matching: find.text(label),
+    );
+
+    Finder connectionTypeSegment(String label) => find.descendant(
+      of: find.byType(SegmentedButton<ConnectionType>),
+      matching: find.text(label),
+    );
+
+    testWidgets(
+      'switching a same-address server from v6 to v5 logs out the old '
+      'session and drops its SID',
+      (WidgetTester tester) async {
+        useLargeView(tester);
+
+        final oldAuth = FakeAuthRepository();
+
+        await tester.pumpWidget(
+          buildWidget(
+            const AddServerFullscreen(
+              window: false,
+              title: 'test',
+              server: _serverV6,
+            ),
+            authByAddress: {_serverV6.address: oldAuth},
+          ),
+        );
+
+        await tester.tap(apiVersionSegment('v5'));
+        await tester.pump();
+
+        await tester.tap(find.byIcon(Icons.save_rounded));
+        await tester.pump(const Duration(milliseconds: 1000));
+
+        // Same address: editServer, not replaceServer.
+        expect(serversViewModel.editServerCallCount, 1);
+        expect(serversViewModel.replaceServerCallCount, 0);
+        // The orphaned v6 session and SID must be cleaned up.
+        expect(oldAuth.deleteCurrentSessionCallCount, 1);
+        expect(serversViewModel.deleteSidCallCount, 1);
+      },
+    );
+
+    testWidgets('a same-address v6 edit keeps the session and SID intact', (
+      WidgetTester tester,
+    ) async {
+      useLargeView(tester);
+
+      final oldAuth = FakeAuthRepository();
+
+      await tester.pumpWidget(
+        buildWidget(
+          const AddServerFullscreen(
+            window: false,
+            title: 'test',
+            server: _serverV6,
+          ),
+          authByAddress: {_serverV6.address: oldAuth},
+        ),
+      );
+
+      // Change only the alias; stay on v6 and the same address.
+      await tester.enterText(find.byType(TextField).at(0), 'renamed');
+
+      await tester.tap(find.byIcon(Icons.save_rounded));
+      await tester.pump(const Duration(milliseconds: 1000));
+
+      expect(serversViewModel.editServerCallCount, 1);
+      expect(serversViewModel.replaceServerCallCount, 0);
+      // No teardown: the v6 session is still in use under the same address.
+      expect(oldAuth.deleteCurrentSessionCallCount, 0);
+      expect(serversViewModel.deleteSidCallCount, 0);
+    });
+
+    testWidgets(
+      'B3: switching a same-address server from v5 to v6 edits in place',
+      (WidgetTester tester) async {
+        useLargeView(tester);
+
+        await tester.pumpWidget(
+          buildWidget(
+            const AddServerFullscreen(
+              window: false,
+              title: 'test',
+              server: _serverV5,
+            ),
+          ),
+        );
+
+        await tester.tap(apiVersionSegment('v6'));
+        await tester.pump();
+
+        await tester.tap(find.byIcon(Icons.save_rounded));
+        await tester.pump(const Duration(milliseconds: 1000));
+
+        expect(serversViewModel.editServerCallCount, 1);
+        expect(serversViewModel.replaceServerCallCount, 0);
+        // The old server was v5, so there is no v6 session/SID to reclaim.
+        expect(serversViewModel.deleteSidCallCount, 0);
+      },
+    );
+
+    testWidgets(
+      'switching HTTPS to HTTP changes the address, clears the pin and '
+      'replaces the server',
+      (WidgetTester tester) async {
+        useLargeView(tester);
+
+        await tester.pumpWidget(
+          buildWidget(
+            const AddServerFullscreen(
+              window: false,
+              title: 'test',
+              server: _serverHttpsPinned,
+            ),
+          ),
+        );
+
+        await tester.tap(connectionTypeSegment('HTTP'));
+        await tester.pump();
+
+        await tester.tap(find.byIcon(Icons.save_rounded));
+        await tester.pump(const Duration(milliseconds: 1000));
+
+        expect(serversViewModel.replaceServerCallCount, 1);
+        expect(serversViewModel.lastReplacedOldAddress, 'https://pi.hole');
+        // Dropping TLS must drop the stale pinned fingerprint.
+        expect(
+          serversViewModel.lastReplacedNewServer?.address,
+          'http://pi.hole',
+        );
+        expect(
+          serversViewModel.lastReplacedNewServer?.pinnedCertificateSha256,
+          null,
+        );
+      },
+    );
+
+    testWidgets('switching HTTP to HTTPS changes the address and pins the new '
+        'fingerprint', (WidgetTester tester) async {
+      useLargeView(tester);
+
+      final fetcher = _FakeFetcher(onStrict: _certInfo());
+
+      await tester.pumpWidget(
+        buildWidget(
+          AddServerFullscreen(
+            window: false,
+            title: 'test',
+            server: _serverV6,
+            fetchTlsCertificate: fetcher.call,
+          ),
+        ),
+      );
+
+      await tester.tap(connectionTypeSegment('HTTPS'));
+      await tester.pump();
+
+      await tester.tap(find.byIcon(Icons.save_rounded));
+      await tester.pump(const Duration(milliseconds: 1000));
+
+      expect(serversViewModel.replaceServerCallCount, 1);
+      expect(
+        serversViewModel.lastReplacedNewServer?.address,
+        'https://localhost:8081',
+      );
+      expect(
+        serversViewModel.lastReplacedNewServer?.pinnedCertificateSha256,
+        'new:fingerprint',
       );
     });
   });

--- a/test/ui/servers/add_server_fullscreen_test.dart
+++ b/test/ui/servers/add_server_fullscreen_test.dart
@@ -1,10 +1,14 @@
+import 'dart:io';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:pi_hole_client/data/services/local/secure_storage_service.dart';
 import 'package:pi_hole_client/domain/model/server/server.dart';
 import 'package:pi_hole_client/ui/core/view_models/app_config_viewmodel.dart';
 import 'package:pi_hole_client/ui/servers/widgets/add_server_fullscreen.dart';
+import 'package:pi_hole_client/ui/servers/widgets/certificate_details_dialog.dart';
 import 'package:pi_hole_client/utils/exceptions.dart';
+import 'package:pi_hole_client/utils/tls_certificate.dart';
 
 import '../../../testing/fakes/repositories/api/fake_dns_repository.dart';
 import '../../../testing/fakes/repositories/local/fake_app_config_repository.dart';
@@ -20,6 +24,58 @@ const _serverV6 = Server(
   allowUntrustedCert: true,
   ignoreCertificateErrors: false,
 );
+
+const _serverHttpsPinned = Server(
+  address: 'https://pi.hole',
+  alias: 'https v6',
+  defaultServer: false,
+  apiVersion: 'v6',
+  allowUntrustedCert: true,
+  ignoreCertificateErrors: false,
+  pinnedCertificateSha256: 'old:fingerprint',
+);
+
+const _serverHttpsIgnore = Server(
+  address: 'https://pi.hole',
+  alias: 'https v6',
+  defaultServer: false,
+  apiVersion: 'v6',
+  allowUntrustedCert: true,
+  ignoreCertificateErrors: true,
+);
+
+TlsCertificateInfo _certInfo({String sha256 = 'new:fingerprint'}) {
+  return TlsCertificateInfo(
+    sha256: sha256,
+    subject: 'CN=pi.hole',
+    issuer: 'CN=test',
+    startValidity: DateTime(2020),
+    endValidity: DateTime(2030),
+  );
+}
+
+/// A recording [TlsCertificateFetcher] for the certificate-flow tests.
+class _FakeFetcher {
+  _FakeFetcher({this.onStrict, this.strictError, this.onAllowBad});
+
+  final TlsCertificateInfo? onStrict;
+  final Exception? strictError;
+  final TlsCertificateInfo? onAllowBad;
+  int callCount = 0;
+
+  Future<TlsCertificateInfo?> call(
+    Uri uri, {
+    required bool allowBadCertificates,
+    Duration timeout = const Duration(seconds: 5),
+  }) async {
+    callCount++;
+    if (!allowBadCertificates) {
+      if (strictError != null) throw strictError!;
+      return onStrict;
+    }
+    return onAllowBad;
+  }
+}
 
 void main() async {
   await initTestApp();
@@ -433,6 +489,126 @@ void main() async {
       );
     });
 
+    testWidgets('connection fields are editable in edit mode', (
+      WidgetTester tester,
+    ) async {
+      tester.view.physicalSize = const Size(1080, 2400);
+      tester.view.devicePixelRatio = 2.0;
+
+      addTearDown(() {
+        tester.view.resetPhysicalSize();
+        tester.view.resetDevicePixelRatio();
+      });
+
+      await tester.pumpWidget(
+        buildWidget(
+          const AddServerFullscreen(
+            window: false,
+            title: 'test',
+            server: _serverV6,
+          ),
+        ),
+      );
+
+      // Address and port text fields are no longer locked.
+      expect(
+        tester.widget<TextField>(find.byType(TextField).at(1)).enabled,
+        isNot(false),
+      );
+      expect(
+        tester.widget<TextField>(find.byType(TextField).at(2)).enabled,
+        isNot(false),
+      );
+
+      // Connection type and API version segments are no longer locked.
+      final connectionSegments = tester
+          .widget<SegmentedButton<ConnectionType>>(
+            find.byType(SegmentedButton<ConnectionType>),
+          )
+          .segments;
+      for (final segment in connectionSegments) {
+        expect(segment.enabled, isNot(false));
+      }
+      final versionSegments = tester
+          .widget<SegmentedButton<String>>(find.byType(SegmentedButton<String>))
+          .segments;
+      for (final segment in versionSegments) {
+        expect(segment.enabled, isNot(false));
+      }
+    });
+
+    testWidgets('editing the address replaces the server', (
+      WidgetTester tester,
+    ) async {
+      tester.view.physicalSize = const Size(1080, 2400);
+      tester.view.devicePixelRatio = 2.0;
+
+      addTearDown(() {
+        tester.view.resetPhysicalSize();
+        tester.view.resetDevicePixelRatio();
+      });
+
+      await tester.pumpWidget(
+        buildWidget(
+          const AddServerFullscreen(
+            window: false,
+            title: 'test',
+            server: _serverV6,
+          ),
+        ),
+      );
+
+      // Change the host so the resulting URL (primary key) differs.
+      await tester.enterText(find.byType(TextField).at(1), '192.168.1.10');
+
+      await tester.tap(find.byIcon(Icons.save_rounded));
+      await tester.pump(const Duration(milliseconds: 1000));
+
+      expect(find.byType(SnackBar), findsOneWidget);
+      expect(
+        find.text('Server settings updated successfully.'),
+        findsOneWidget,
+      );
+      expect(serversViewModel.replaceServerCallCount, 1);
+      expect(serversViewModel.lastReplacedOldAddress, _serverV6.address);
+      expect(
+        serversViewModel.lastReplacedNewServer?.address,
+        'http://192.168.1.10:8081',
+      );
+    });
+
+    testWidgets('editing to an existing address shows an error', (
+      WidgetTester tester,
+    ) async {
+      tester.view.physicalSize = const Size(1080, 2400);
+      tester.view.devicePixelRatio = 2.0;
+
+      addTearDown(() {
+        tester.view.resetPhysicalSize();
+        tester.view.resetDevicePixelRatio();
+      });
+
+      serversViewModel.urlExistsResult = true;
+
+      await tester.pumpWidget(
+        buildWidget(
+          const AddServerFullscreen(
+            window: false,
+            title: 'test',
+            server: _serverV6,
+          ),
+        ),
+      );
+
+      await tester.enterText(find.byType(TextField).at(1), '192.168.1.10');
+
+      await tester.tap(find.byIcon(Icons.save_rounded));
+      await tester.pump(const Duration(milliseconds: 1000));
+
+      expect(find.text('This connection already exists'), findsOneWidget);
+      expect(serversViewModel.replaceServerCallCount, 0);
+    });
+
     testWidgets(
       'should show the failed snackbar when editing a server (socketError)',
       (WidgetTester tester) async {
@@ -689,6 +865,198 @@ void main() async {
         await tester.pump(const Duration(milliseconds: 1000));
         expect(find.byType(SnackBar), findsOneWidget);
         expect(find.text('Failed. Unknown error.'), findsOneWidget);
+      },
+    );
+
+    // Certificate flow tests (R25/R26/R28/R29) — exercise the injected
+    // TlsCertificateFetcher so the pin/dialog branches run without a real
+    // TLS handshake. R27 (retry without re-prompt) is out of scope until the
+    // _certValidatedForAddress memory lands on this branch.
+
+    testWidgets(
+      'R25: HTTPS edit without address change reuses the existing pin '
+      'and shows no dialog',
+      (WidgetTester tester) async {
+        tester.view.physicalSize = const Size(1080, 2400);
+        tester.view.devicePixelRatio = 2.0;
+
+        addTearDown(() {
+          tester.view.resetPhysicalSize();
+          tester.view.resetDevicePixelRatio();
+        });
+
+        final fetcher = _FakeFetcher(onStrict: _certInfo());
+
+        await tester.pumpWidget(
+          buildWidget(
+            AddServerFullscreen(
+              window: false,
+              title: 'test',
+              server: _serverHttpsPinned,
+              fetchTlsCertificate: fetcher.call,
+            ),
+          ),
+        );
+
+        // Change only the alias so the address (primary key) is unchanged.
+        await tester.enterText(find.byType(TextField).at(0), 'renamed');
+
+        await tester.tap(find.byIcon(Icons.save_rounded));
+        await tester.pump(const Duration(milliseconds: 1000));
+
+        expect(find.byType(CertificateDetailsDialog), findsNothing);
+        expect(fetcher.callCount, 0);
+        expect(serversViewModel.editServerCallCount, 1);
+        expect(serversViewModel.replaceServerCallCount, 0);
+      },
+    );
+
+    testWidgets(
+      'R26: HTTPS address change resets the pin, prompts the dialog and '
+      'pins the new fingerprint on confirm',
+      (WidgetTester tester) async {
+        tester.view.physicalSize = const Size(1080, 2400);
+        tester.view.devicePixelRatio = 2.0;
+
+        addTearDown(() {
+          tester.view.resetPhysicalSize();
+          tester.view.resetDevicePixelRatio();
+        });
+
+        final fetcher = _FakeFetcher(
+          strictError: const HandshakeException(),
+          onAllowBad: _certInfo(sha256: 'new:fingerprint'),
+        );
+
+        await tester.pumpWidget(
+          buildWidget(
+            AddServerFullscreen(
+              window: false,
+              title: 'test',
+              server: _serverHttpsPinned,
+              fetchTlsCertificate: fetcher.call,
+            ),
+          ),
+        );
+
+        // Change the host so the resulting URL (primary key) differs.
+        await tester.enterText(find.byType(TextField).at(1), 'pi.hole.new');
+
+        await tester.tap(find.byIcon(Icons.save_rounded));
+        // Cannot pumpAndSettle: the in-progress spinner animates indefinitely.
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 500));
+
+        expect(find.byType(CertificateDetailsDialog), findsOneWidget);
+
+        await tester.tap(find.widgetWithText(TextButton, 'Confirm'));
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 1000));
+
+        expect(serversViewModel.replaceServerCallCount, 1);
+        expect(
+          serversViewModel.lastReplacedOldAddress,
+          _serverHttpsPinned.address,
+        );
+        expect(
+          serversViewModel.lastReplacedNewServer?.address,
+          'https://pi.hole.new',
+        );
+        expect(
+          serversViewModel.lastReplacedNewServer?.pinnedCertificateSha256,
+          'new:fingerprint',
+        );
+      },
+    );
+
+    testWidgets(
+      'R28: cancelling the certificate dialog aborts the save and keeps '
+      'the old server',
+      (WidgetTester tester) async {
+        tester.view.physicalSize = const Size(1080, 2400);
+        tester.view.devicePixelRatio = 2.0;
+
+        addTearDown(() {
+          tester.view.resetPhysicalSize();
+          tester.view.resetDevicePixelRatio();
+        });
+
+        final fetcher = _FakeFetcher(
+          strictError: const HandshakeException(),
+          onAllowBad: _certInfo(),
+        );
+
+        await tester.pumpWidget(
+          buildWidget(
+            AddServerFullscreen(
+              window: false,
+              title: 'test',
+              server: _serverHttpsPinned,
+              fetchTlsCertificate: fetcher.call,
+            ),
+          ),
+        );
+
+        await tester.enterText(find.byType(TextField).at(1), 'pi.hole.new');
+
+        await tester.tap(find.byIcon(Icons.save_rounded));
+        // Cannot pumpAndSettle: the in-progress spinner animates indefinitely.
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 500));
+
+        expect(find.byType(CertificateDetailsDialog), findsOneWidget);
+
+        await tester.tap(find.widgetWithText(TextButton, 'Cancel'));
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 1000));
+
+        expect(find.byType(CertificateDetailsDialog), findsNothing);
+        expect(serversViewModel.replaceServerCallCount, 0);
+        expect(serversViewModel.editServerCallCount, 0);
+        expect(
+          find.text('Server settings updated successfully.'),
+          findsNothing,
+        );
+      },
+    );
+
+    testWidgets(
+      'R29: ignoreCertificateErrors skips certificate validation, clears the '
+      'pin and never calls the fetcher',
+      (WidgetTester tester) async {
+        tester.view.physicalSize = const Size(1080, 2400);
+        tester.view.devicePixelRatio = 2.0;
+
+        addTearDown(() {
+          tester.view.resetPhysicalSize();
+          tester.view.resetDevicePixelRatio();
+        });
+
+        final fetcher = _FakeFetcher(onStrict: _certInfo());
+
+        await tester.pumpWidget(
+          buildWidget(
+            AddServerFullscreen(
+              window: false,
+              title: 'test',
+              server: _serverHttpsIgnore,
+              fetchTlsCertificate: fetcher.call,
+            ),
+          ),
+        );
+
+        await tester.enterText(find.byType(TextField).at(1), 'pi.hole.new');
+
+        await tester.tap(find.byIcon(Icons.save_rounded));
+        await tester.pump(const Duration(milliseconds: 1000));
+
+        expect(find.byType(CertificateDetailsDialog), findsNothing);
+        expect(fetcher.callCount, 0);
+        expect(serversViewModel.replaceServerCallCount, 1);
+        expect(
+          serversViewModel.lastReplacedNewServer?.pinnedCertificateSha256,
+          isNull,
+        );
       },
     );
   });

--- a/test/ui/servers/widgets/transport_security_indicator_test.dart
+++ b/test/ui/servers/widgets/transport_security_indicator_test.dart
@@ -1,7 +1,11 @@
+import 'dart:async';
+import 'dart:io';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:pi_hole_client/domain/model/server/server.dart';
 import 'package:pi_hole_client/ui/servers/widgets/transport_security_indicator.dart';
+import 'package:pi_hole_client/utils/tls_certificate.dart';
 
 import '../../../../testing/test_app.dart';
 
@@ -23,6 +27,39 @@ void main() async {
       ignoreCertificateErrors: ignoreCertificateErrors,
       pinnedCertificateSha256: pinnedCertificateSha256,
     );
+  }
+
+  TlsCertificateInfo makeCertInfo({String sha256 = 'aa:bb:cc'}) {
+    return TlsCertificateInfo(
+      sha256: sha256,
+      subject: 'CN=pi.hole',
+      issuer: 'CN=test',
+      startValidity: DateTime(2020),
+      endValidity: DateTime(2030),
+    );
+  }
+
+  /// Builds a fake [TlsCertificateFetcher].
+  ///
+  /// When [allowBadCertificates] is `false` (strict platform validation) it
+  /// returns [onStrict] or throws [strictError]; when `true` it returns
+  /// [onAllowBad]. This mirrors the two ways the indicator probes a server.
+  TlsCertificateFetcher fakeFetcher({
+    TlsCertificateInfo? onStrict,
+    Exception? strictError,
+    TlsCertificateInfo? onAllowBad,
+  }) {
+    return (
+      Uri uri, {
+      required bool allowBadCertificates,
+      Duration timeout = const Duration(seconds: 5),
+    }) async {
+      if (!allowBadCertificates) {
+        if (strictError != null) throw strictError;
+        return onStrict;
+      }
+      return onAllowBad;
+    };
   }
 
   group('TransportSecurityIndicator', () {
@@ -117,6 +154,138 @@ void main() async {
       await tester.pumpAndSettle();
 
       expect(find.text('HTTP'), findsOneWidget);
+    });
+  });
+
+  group('TransportSecurityIndicator (injected fetcher)', () {
+    testWidgets('trusted cert without pin shows verified icon', (tester) async {
+      await tester.pumpWidget(
+        buildTestApp(
+          TransportSecurityIndicator(
+            server: makeServer(address: 'https://pi.hole'),
+            fetchTlsCertificate: fakeFetcher(onStrict: makeCertInfo()),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.byIcon(Icons.verified_user), findsOneWidget);
+    });
+
+    testWidgets('trusted cert with pin shows pinned icon', (tester) async {
+      await tester.pumpWidget(
+        buildTestApp(
+          TransportSecurityIndicator(
+            server: makeServer(
+              address: 'https://pi.hole',
+              pinnedCertificateSha256: 'aa:bb:cc',
+            ),
+            fetchTlsCertificate: fakeFetcher(onStrict: makeCertInfo()),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.byIcon(Icons.push_pin), findsOneWidget);
+    });
+
+    testWidgets('untrusted cert blocked shows gpp_bad icon', (tester) async {
+      await tester.pumpWidget(
+        buildTestApp(
+          TransportSecurityIndicator(
+            server: makeServer(address: 'https://pi.hole'),
+            fetchTlsCertificate: fakeFetcher(
+              strictError: const HandshakeException(),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.byIcon(Icons.gpp_bad), findsOneWidget);
+    });
+
+    testWidgets('untrusted cert allowed without pin shows gpp_maybe icon', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        buildTestApp(
+          TransportSecurityIndicator(
+            server: makeServer(
+              address: 'https://pi.hole',
+              allowUntrustedCert: true,
+            ),
+            fetchTlsCertificate: fakeFetcher(
+              strictError: const HandshakeException(),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.byIcon(Icons.gpp_maybe), findsOneWidget);
+    });
+
+    testWidgets('untrusted cert with matching pin shows pinned icon', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        buildTestApp(
+          TransportSecurityIndicator(
+            server: makeServer(
+              address: 'https://pi.hole',
+              allowUntrustedCert: true,
+              pinnedCertificateSha256: 'aa:bb:cc',
+            ),
+            fetchTlsCertificate: fakeFetcher(
+              strictError: const HandshakeException(),
+              onAllowBad: makeCertInfo(sha256: 'aa:bb:cc'),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.byIcon(Icons.push_pin), findsOneWidget);
+    });
+
+    testWidgets('untrusted cert with mismatching pin shows error icon', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        buildTestApp(
+          TransportSecurityIndicator(
+            server: makeServer(
+              address: 'https://pi.hole',
+              allowUntrustedCert: true,
+              pinnedCertificateSha256: 'aa:bb:cc',
+            ),
+            fetchTlsCertificate: fakeFetcher(
+              strictError: const HandshakeException(),
+              onAllowBad: makeCertInfo(sha256: 'dd:ee:ff'),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.byIcon(Icons.error), findsOneWidget);
+    });
+
+    testWidgets('timeout on strict probe shows unknown icon', (tester) async {
+      await tester.pumpWidget(
+        buildTestApp(
+          TransportSecurityIndicator(
+            server: makeServer(address: 'https://pi.hole'),
+            fetchTlsCertificate: fakeFetcher(
+              strictError: TimeoutException('timed out'),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.byIcon(Icons.help_outline), findsOneWidget);
     });
   });
 }

--- a/test/utils/url_test.dart
+++ b/test/utils/url_test.dart
@@ -1,0 +1,97 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pi_hole_client/utils/url.dart';
+
+void main() {
+  group('isSameEndpoint', () {
+    test('returns true for identical URLs', () {
+      expect(isSameEndpoint('https://pi.hole', 'https://pi.hole'), isTrue);
+    });
+
+    test('ignores host case differences', () {
+      expect(isSameEndpoint('https://Pi.Hole', 'https://pi.hole'), isTrue);
+    });
+
+    test('ignores scheme case differences', () {
+      expect(isSameEndpoint('HTTPS://pi.hole', 'https://pi.hole'), isTrue);
+    });
+
+    test('ignores a trailing slash', () {
+      expect(isSameEndpoint('https://pi.hole/', 'https://pi.hole'), isTrue);
+    });
+
+    test('treats a bare slash and empty path as equal', () {
+      expect(isSameEndpoint('https://pi.hole/', 'https://pi.hole'), isTrue);
+    });
+
+    test('keeps subroute path case-sensitive', () {
+      expect(
+        isSameEndpoint('https://pi.hole/API', 'https://pi.hole/api'),
+        isFalse,
+      );
+    });
+
+    test('matches subroutes that only differ by a trailing slash', () {
+      expect(
+        isSameEndpoint('https://pi.hole/api/v1/', 'https://pi.hole/api/v1'),
+        isTrue,
+      );
+    });
+
+    test('distinguishes different schemes', () {
+      expect(isSameEndpoint('http://pi.hole', 'https://pi.hole'), isFalse);
+    });
+
+    test('distinguishes different hosts', () {
+      expect(isSameEndpoint('https://pi.hole', 'https://example.com'), isFalse);
+    });
+
+    test('distinguishes different ports', () {
+      expect(
+        isSameEndpoint('https://pi.hole:8080', 'https://pi.hole:9090'),
+        isFalse,
+      );
+    });
+
+    test('treats the default https port as equal to an omitted port', () {
+      expect(isSameEndpoint('https://pi.hole', 'https://pi.hole:443'), isTrue);
+    });
+
+    test('treats the default http port as equal to an omitted port', () {
+      expect(isSameEndpoint('http://pi.hole', 'http://pi.hole:80'), isTrue);
+    });
+
+    test('normalises the default port alongside a subroute', () {
+      expect(
+        isSameEndpoint('https://pi.hole/admin', 'https://pi.hole:443/admin'),
+        isTrue,
+      );
+    });
+
+    test('does not equate an explicit non-default port with the default', () {
+      expect(
+        isSameEndpoint('https://pi.hole', 'https://pi.hole:8080'),
+        isFalse,
+      );
+    });
+
+    test('does not equate a default port across different schemes', () {
+      // http default (80) and https default (443) must stay distinct.
+      expect(
+        isSameEndpoint('http://pi.hole:80', 'https://pi.hole:443'),
+        isFalse,
+      );
+    });
+
+    test('distinguishes different subroutes', () {
+      expect(
+        isSameEndpoint('https://pi.hole/api', 'https://pi.hole/admin'),
+        isFalse,
+      );
+    });
+
+    test('falls back to string equality when a URL is unparseable', () {
+      expect(isSameEndpoint('::: not a url', '::: not a url'), isTrue);
+      expect(isSameEndpoint('::: not a url', 'https://pi.hole'), isFalse);
+    });
+  });
+}

--- a/test/widgets/helpers.mocks.dart
+++ b/test/widgets/helpers.mocks.dart
@@ -541,6 +541,19 @@ class MockServersViewModel extends _i1.Mock implements _i14.ServersViewModel {
           as _i3.Command<_i15.Server, void>);
 
   @override
+  _i3.Command<({_i15.Server newServer, String oldAddress}), void>
+  get replaceServer =>
+      (super.noSuchMethod(
+            Invocation.getter(#replaceServer),
+            returnValue:
+                _FakeCommand_1<
+                  ({_i15.Server newServer, String oldAddress}),
+                  void
+                >(this, Invocation.getter(#replaceServer)),
+          )
+          as _i3.Command<({_i15.Server newServer, String oldAddress}), void>);
+
+  @override
   _i3.Command<String, void> get removeServer =>
       (super.noSuchMethod(
             Invocation.getter(#removeServer),
@@ -607,6 +620,14 @@ class MockServersViewModel extends _i1.Mock implements _i14.ServersViewModel {
   @override
   set editServer(_i3.Command<_i15.Server, void>? value) => super.noSuchMethod(
     Invocation.setter(#editServer, value),
+    returnValueForMissingStub: null,
+  );
+
+  @override
+  set replaceServer(
+    _i3.Command<({_i15.Server newServer, String oldAddress}), void>? value,
+  ) => super.noSuchMethod(
+    Invocation.setter(#replaceServer, value),
     returnValueForMissingStub: null,
   );
 
@@ -1529,6 +1550,14 @@ class MockDomainsViewModel extends _i1.Mock implements _i27.DomainsViewModel {
           as _i7.LoadStatus);
 
   @override
+  bool get isRevalidating =>
+      (super.noSuchMethod(
+            Invocation.getter(#isRevalidating),
+            returnValue: false,
+          )
+          as bool);
+
+  @override
   set loadDomains(_i3.Command<void, void>? value) => super.noSuchMethod(
     Invocation.setter(#loadDomains, value),
     returnValueForMissingStub: null,
@@ -1562,6 +1591,12 @@ class MockDomainsViewModel extends _i1.Mock implements _i27.DomainsViewModel {
   bool get hasListeners =>
       (super.noSuchMethod(Invocation.getter(#hasListeners), returnValue: false)
           as bool);
+
+  @override
+  void update({_i22.DomainRepository? domainRepository}) => super.noSuchMethod(
+    Invocation.method(#update, [], {#domainRepository: domainRepository}),
+    returnValueForMissingStub: null,
+  );
 
   @override
   void setSelectedTab(int? tab) => super.noSuchMethod(

--- a/testing/fakes/repositories/api/fake_auth_repository.dart
+++ b/testing/fakes/repositories/api/fake_auth_repository.dart
@@ -7,9 +7,12 @@ import '../../../models/v6/auth.dart';
 class FakeAuthRepository implements AuthRepository {
   bool shouldFail = false;
   int getAllSessionsCallCount = 0;
+  int createSessionCallCount = 0;
+  int deleteCurrentSessionCallCount = 0;
 
   @override
   Future<Result<Auth>> createSession(String password) async {
+    createSessionCallCount++;
     if (shouldFail) {
       return Failure(Exception('Force createSession failure'));
     }
@@ -18,6 +21,7 @@ class FakeAuthRepository implements AuthRepository {
 
   @override
   Future<Result<Unit>> deleteCurrentSession() async {
+    deleteCurrentSessionCallCount++;
     if (shouldFail) {
       return Failure(Exception('Force deleteCurrentSession failure'));
     }

--- a/testing/fakes/repositories/local/fake_server_repository.dart
+++ b/testing/fakes/repositories/local/fake_server_repository.dart
@@ -22,8 +22,10 @@ class FakeServerRepository implements ServerRepository {
   String? lastUpdatedDefaultAddress;
   int savePasswordCallCount = 0;
   String? lastSavedPasswordAddress;
+  String? lastSavedPassword;
   int saveTokenCallCount = 0;
   String? lastSavedTokenAddress;
+  String? lastSavedToken;
 
   @override
   Future<Result<List<Server>>> fetchServers() async {
@@ -78,13 +80,7 @@ class FakeServerRepository implements ServerRepository {
   }
 
   @override
-  Future<Result<int>> replaceServer(
-    String oldAddress,
-    Server newServer, {
-    String? token,
-    String? password,
-    String? sid,
-  }) async {
+  Future<Result<int>> replaceServer(String oldAddress, Server newServer) async {
     replaceCallCount++;
     lastReplacedOldAddress = oldAddress;
     lastReplacedNewServer = newServer;
@@ -131,22 +127,40 @@ class FakeServerRepository implements ServerRepository {
     return Success.unit();
   }
 
+  /// Stored credentials returned by [fetchPassword]/[fetchCredentials].
+  ///
+  /// Defaults to non-empty values so that an edit screen loads with a populated
+  /// password/token, matching a real saved server. Tests can override these to
+  /// simulate a server with no stored secret.
+  String fakePassword = 'stored-pass';
+  String fakeToken = 'stored-token';
+
+  /// When true, [fetchCredentials] returns a [Failure], simulating a transient
+  /// secure-storage read error on edit-screen load.
+  bool shouldFailFetchCredentials = false;
+
   @override
   Future<Result<String>> fetchPassword(String address) async {
-    return const Success('');
+    return Success(fakePassword);
   }
 
   @override
   Future<Result<({String token, String password})>> fetchCredentials(
     String address,
   ) async {
-    return const Success((token: '', password: ''));
+    if (shouldFailFetchCredentials) {
+      return Failure(
+        Exception('FakeServerRepository: fetchCredentials failed'),
+      );
+    }
+    return Success((token: fakeToken, password: fakePassword));
   }
 
   @override
   Future<Result<void>> savePassword(String address, String password) async {
     savePasswordCallCount++;
     lastSavedPasswordAddress = address;
+    lastSavedPassword = password;
     return Success.unit();
   }
 
@@ -154,6 +168,7 @@ class FakeServerRepository implements ServerRepository {
   Future<Result<void>> saveToken(String address, String token) async {
     saveTokenCallCount++;
     lastSavedTokenAddress = address;
+    lastSavedToken = token;
     return Success.unit();
   }
 

--- a/testing/fakes/repositories/local/fake_server_repository.dart
+++ b/testing/fakes/repositories/local/fake_server_repository.dart
@@ -20,6 +20,10 @@ class FakeServerRepository implements ServerRepository {
   String? lastDeletedAddress;
   int updateDefaultCallCount = 0;
   String? lastUpdatedDefaultAddress;
+  int savePasswordCallCount = 0;
+  String? lastSavedPasswordAddress;
+  int saveTokenCallCount = 0;
+  String? lastSavedTokenAddress;
 
   @override
   Future<Result<List<Server>>> fetchServers() async {
@@ -141,11 +145,15 @@ class FakeServerRepository implements ServerRepository {
 
   @override
   Future<Result<void>> savePassword(String address, String password) async {
+    savePasswordCallCount++;
+    lastSavedPasswordAddress = address;
     return Success.unit();
   }
 
   @override
   Future<Result<void>> saveToken(String address, String token) async {
+    saveTokenCallCount++;
+    lastSavedTokenAddress = address;
     return Success.unit();
   }
 
@@ -156,6 +164,11 @@ class FakeServerRepository implements ServerRepository {
 
   @override
   Future<Result<void>> deleteToken(String address) async {
+    return Success.unit();
+  }
+
+  @override
+  Future<Result<void>> deleteSid(String address) async {
     return Success.unit();
   }
 }

--- a/testing/fakes/repositories/local/fake_server_repository.dart
+++ b/testing/fakes/repositories/local/fake_server_repository.dart
@@ -6,12 +6,16 @@ class FakeServerRepository implements ServerRepository {
   // Failure controls
   bool shouldFailInsert = false;
   bool shouldFailUpdate = false;
+  bool shouldFailReplace = false;
   bool shouldFailDelete = false;
   bool shouldFailUpdateDefault = false;
 
   // Call tracking
   int insertCallCount = 0;
   int updateCallCount = 0;
+  int replaceCallCount = 0;
+  String? lastReplacedOldAddress;
+  Server? lastReplacedNewServer;
   int deleteCallCount = 0;
   String? lastDeletedAddress;
   int updateDefaultCallCount = 0;
@@ -65,6 +69,23 @@ class FakeServerRepository implements ServerRepository {
     updateCallCount++;
     if (shouldFailUpdate) {
       return Failure(Exception('FakeServerRepository: updateServer failed'));
+    }
+    return const Success(1);
+  }
+
+  @override
+  Future<Result<int>> replaceServer(
+    String oldAddress,
+    Server newServer, {
+    String? token,
+    String? password,
+    String? sid,
+  }) async {
+    replaceCallCount++;
+    lastReplacedOldAddress = oldAddress;
+    lastReplacedNewServer = newServer;
+    if (shouldFailReplace) {
+      return Failure(Exception('FakeServerRepository: replaceServer failed'));
     }
     return const Success(1);
   }

--- a/testing/fakes/viewmodels/fake_servers_viewmodel.dart
+++ b/testing/fakes/viewmodels/fake_servers_viewmodel.dart
@@ -33,6 +33,9 @@ class FakeServersViewModel extends ServersViewModel {
 
   set shouldFailRemoveServer(bool value) => _fakeRepo.shouldFailDelete = value;
 
+  set shouldFailReplaceServer(bool value) =>
+      _fakeRepo.shouldFailReplace = value;
+
   set shouldFailSetDefaultServer(bool value) =>
       _fakeRepo.shouldFailUpdateDefault = value;
 
@@ -43,6 +46,12 @@ class FakeServersViewModel extends ServersViewModel {
   int get setDefaultServerCallCount => _fakeRepo.updateDefaultCallCount;
   int get addServerCallCount => _fakeRepo.insertCallCount;
   int get editServerCallCount => _fakeRepo.updateCallCount;
+  int get replaceServerCallCount => _fakeRepo.replaceCallCount;
+  String? get lastReplacedOldAddress => _fakeRepo.lastReplacedOldAddress;
+  Server? get lastReplacedNewServer => _fakeRepo.lastReplacedNewServer;
+
+  /// Controls the result returned by [checkUrlExists] in tests.
+  bool urlExistsResult = false;
 
   // Additional call-tracking fields for non-Command methods
   int setselectedServerCallCount = 0;
@@ -131,6 +140,6 @@ class FakeServersViewModel extends ServersViewModel {
 
   @override
   FutureOr<Map<String, dynamic>> checkUrlExists(String url) async {
-    return {'result': 'success', 'exists': false};
+    return {'result': 'success', 'exists': urlExistsResult};
   }
 }

--- a/testing/fakes/viewmodels/fake_servers_viewmodel.dart
+++ b/testing/fakes/viewmodels/fake_servers_viewmodel.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:pi_hole_client/domain/model/server/server.dart';
 import 'package:pi_hole_client/ui/core/view_models/servers_viewmodel.dart';
+import 'package:result_dart/result_dart.dart';
 
 import '../repositories/local/fake_server_repository.dart';
 
@@ -51,6 +52,14 @@ class FakeServersViewModel extends ServersViewModel {
   int get replaceServerCallCount => _fakeRepo.replaceCallCount;
   String? get lastReplacedOldAddress => _fakeRepo.lastReplacedOldAddress;
   Server? get lastReplacedNewServer => _fakeRepo.lastReplacedNewServer;
+  int get savePasswordCallCount => _fakeRepo.savePasswordCallCount;
+  String? get lastSavedPasswordAddress => _fakeRepo.lastSavedPasswordAddress;
+  int get saveTokenCallCount => _fakeRepo.saveTokenCallCount;
+  String? get lastSavedTokenAddress => _fakeRepo.lastSavedTokenAddress;
+
+  /// Counts calls to `deleteSid`. The production wrapper is added later; until
+  /// then this stays 0, which is what the state-integrity tests assert against.
+  int deleteSidCallCount = 0;
 
   /// Controls the result returned by [checkUrlExists] in tests.
   bool urlExistsResult = false;
@@ -142,6 +151,12 @@ class FakeServersViewModel extends ServersViewModel {
     setUnverifiedBannerDismissedCallCount++;
     lastUnverifiedBannerDismissedValue = dismissed;
     notifyListeners();
+  }
+
+  @override
+  Future<Result<void>> deleteSid(String address) async {
+    deleteSidCallCount++;
+    return Success.unit();
   }
 
   @override

--- a/testing/fakes/viewmodels/fake_servers_viewmodel.dart
+++ b/testing/fakes/viewmodels/fake_servers_viewmodel.dart
@@ -42,6 +42,9 @@ class FakeServersViewModel extends ServersViewModel {
   set shouldFailSetDefaultServer(bool value) =>
       _fakeRepo.shouldFailUpdateDefault = value;
 
+  set failFetchCredentials(bool value) =>
+      _fakeRepo.shouldFailFetchCredentials = value;
+
   // --- Call tracking (delegate to repo) ---
 
   int get removeServerCallCount => _fakeRepo.deleteCallCount;
@@ -54,8 +57,10 @@ class FakeServersViewModel extends ServersViewModel {
   Server? get lastReplacedNewServer => _fakeRepo.lastReplacedNewServer;
   int get savePasswordCallCount => _fakeRepo.savePasswordCallCount;
   String? get lastSavedPasswordAddress => _fakeRepo.lastSavedPasswordAddress;
+  String? get lastSavedPassword => _fakeRepo.lastSavedPassword;
   int get saveTokenCallCount => _fakeRepo.saveTokenCallCount;
   String? get lastSavedTokenAddress => _fakeRepo.lastSavedTokenAddress;
+  String? get lastSavedToken => _fakeRepo.lastSavedToken;
 
   /// Counts calls to `deleteSid`. The production wrapper is added later; until
   /// then this stays 0, which is what the state-integrity tests assert against.

--- a/testing/fakes/viewmodels/fake_servers_viewmodel.dart
+++ b/testing/fakes/viewmodels/fake_servers_viewmodel.dart
@@ -36,6 +36,8 @@ class FakeServersViewModel extends ServersViewModel {
   set shouldFailReplaceServer(bool value) =>
       _fakeRepo.shouldFailReplace = value;
 
+  set shouldFailEditServer(bool value) => _fakeRepo.shouldFailUpdate = value;
+
   set shouldFailSetDefaultServer(bool value) =>
       _fakeRepo.shouldFailUpdateDefault = value;
 
@@ -52,6 +54,10 @@ class FakeServersViewModel extends ServersViewModel {
 
   /// Controls the result returned by [checkUrlExists] in tests.
   bool urlExistsResult = false;
+
+  /// When true, [checkUrlExists] returns `result: 'fail'` to simulate an
+  /// inconclusive uniqueness check.
+  bool checkUrlExistsFails = false;
 
   // Additional call-tracking fields for non-Command methods
   int setselectedServerCallCount = 0;
@@ -140,6 +146,9 @@ class FakeServersViewModel extends ServersViewModel {
 
   @override
   FutureOr<Map<String, dynamic>> checkUrlExists(String url) async {
+    if (checkUrlExistsFails) {
+      return {'result': 'fail', 'exists': false};
+    }
     return {'result': 'success', 'exists': urlExistsResult};
   }
 }

--- a/testing/fakes/viewmodels/fake_status_viewmodel.dart
+++ b/testing/fakes/viewmodels/fake_status_viewmodel.dart
@@ -124,17 +124,21 @@ class FakeStatusViewModel extends StatusViewModel {
     notifyListeners();
   }
 
+  // Call tracking for auto-refresh gating assertions.
+  int startAutoRefreshCallCount = 0;
+  int stopAutoRefreshCallCount = 0;
+
   @override
   void startAutoRefresh({
     bool runImmediately = true,
     bool isDelay = false,
     bool showLoadingIndicator = true,
   }) {
-    // No-op: prevent real timers from starting in tests.
+    startAutoRefreshCallCount++;
   }
 
   @override
   void stopAutoRefresh({bool showLoadingIndicator = true}) {
-    // No-op: prevent real timer cancellation in tests.
+    stopAutoRefreshCallCount++;
   }
 }

--- a/testing/test_app.dart
+++ b/testing/test_app.dart
@@ -107,6 +107,7 @@ Widget buildTestApp(
 RepositoryBundle createFakeRepositoryBundle({
   FakeActionsRepository? actions,
   FakeAdlistRepository? adlist,
+  FakeAuthRepository? auth,
   FakeConfigRepository? config,
   FakeDnsRepository? dns,
   FakeDomainRepository? domain,
@@ -116,7 +117,7 @@ RepositoryBundle createFakeRepositoryBundle({
   return RepositoryBundle(
     actions: actions ?? FakeActionsRepository(),
     adlist: adlist ?? FakeAdlistRepository(),
-    auth: FakeAuthRepository(),
+    auth: auth ?? FakeAuthRepository(),
     client: FakeClientRepository(),
     config: config ?? FakeConfigRepository(),
     dhcp: FakeDhcpRepository(),


### PR DESCRIPTION
## Overview
Previously the address, port, protocol and API version of a saved server were locked once created. This PR makes those connection fields editable.

## Changes
- Allow editing connection fields; save via `editServer` when the address is unchanged, or `replaceServer` when it changes.
- `replaceServer` migrates credentials, terminates the old v6 session, and runs inside a transaction; a URL-uniqueness pre-check aborts before any destructive operation.
- Re-validate the pinned TLS certificate when the host changes; skip when ignoring cert errors or downgrading to HTTP.
- Add widget/repository/view-model tests covering the edit-replace matrix, and extend the test fakes to support the new scenarios.

## Summary by Sourcery

Make saved server connection details fully editable and introduce a safe replace flow when a server’s address changes, including credential, session, and TLS certificate handling, backed by repository and view-model updates.

New Features:
- Allow editing of address, port, protocol, and API version for existing servers in the add/edit server fullscreen UI.
- Add a repository-level replaceServer operation and corresponding view-model command to migrate a server when its address (primary key) changes while preserving invariants like a single default server.
- Introduce URL endpoint comparison utilities to distinguish meaningful address changes from cosmetic ones (e.g. case or trailing slash).

Bug Fixes:
- Prevent loss or corruption of stored credentials when edit flows fail or when secure-storage reads are temporarily unavailable.
- Ensure secure-storage cleanup only removes secrets for truly deleted servers, including addresses containing underscores.
- Avoid orphaned or duplicated sessions and SIDs across address changes, API version switches, and failed replaces.

Enhancements:
- Parse and rebuild server URLs using Uri rather than string splits to robustly handle ports and multi-segment subroutes.
- Rework edit flows to revalidate TLS certificates when the effective host changes, including HTTPS↔HTTP switches and ignore-certificate-errors modes.
- Make default-server updates atomic in the local repository by wrapping inserts, updates, and replaces in transactions.
- Extend TLS transport security indicator logic to support injected certificate fetchers, improving testability and coverage.
- Tighten Save-button enablement logic to wait for credential load and require appropriate secrets for v5/v6 servers.
- Initialize and clean up auto-refresh behavior and sessions more carefully around server edit and replace operations.

Tests:
- Expand add_server_fullscreen widget tests to cover edit vs replace behavior, credential validation, TLS pinning flows, error handling, and session/auto-refresh side effects.
- Add repository tests for insert/update transactional default handling, replaceServer behavior, and robust secret cleanup.
- Extend servers_viewmodel tests to cover the new replaceServer command semantics.
- Add tests for URL normalisation and endpoint comparison in the new utils/url helper.
- Enhance transport_security_indicator tests using fake TLS certificate fetchers to exercise more TLS and pinning scenarios.

Chores:
- Augment fake repositories, view-models, and mocks to support new replaceServer, credential, and session tracking needed by the extended tests.
- Trigger best-effort cleanup of orphaned server secrets at app startup.