### PR TITLE
feat(auth): enforce TLS certificate pinning end-to-end with recovery

### DIFF
--- a/lib/config/dependencies.dart
+++ b/lib/config/dependencies.dart
@@ -67,7 +67,18 @@ List<SingleChildWidget> createProviders({
       update: (_, servers, storage, previous) {
         final server = servers.selectedServer;
         if (server == null) return null;
-        if (previous?.serverAddress == server.address) return previous;
+        // Reuse the existing bundle only when nothing affecting the HTTP
+        // connection changed.
+        if (previous != null &&
+            previous.serverAddress == server.address &&
+            previous.apiVersion == server.apiVersion &&
+            previous.allowUntrustedCert == server.allowUntrustedCert &&
+            previous.ignoreCertificateErrors ==
+                server.ignoreCertificateErrors &&
+            previous.pinnedCertificateSha256 ==
+                server.pinnedCertificateSha256) {
+          return previous;
+        }
         return RepositoryBundleFactory.create(server: server, storage: storage);
       },
     ),

--- a/lib/data/repositories/api/interfaces/repository_bundle.dart
+++ b/lib/data/repositories/api/interfaces/repository_bundle.dart
@@ -38,6 +38,9 @@ class RepositoryBundle {
     required this.realtimeStatus,
     required this.serverAddress,
     required this.apiVersion,
+    this.allowUntrustedCert = false,
+    this.ignoreCertificateErrors = false,
+    this.pinnedCertificateSha256,
   });
 
   final ActionsRepository actions;
@@ -56,4 +59,7 @@ class RepositoryBundle {
   final RealtimeStatusRepository realtimeStatus;
   final String serverAddress;
   final String apiVersion;
+  final bool allowUntrustedCert;
+  final bool ignoreCertificateErrors;
+  final String? pinnedCertificateSha256;
 }

--- a/lib/data/repositories/api/repository_factory.dart
+++ b/lib/data/repositories/api/repository_factory.dart
@@ -97,6 +97,9 @@ class RepositoryBundleFactory {
           ),
           serverAddress: server.address,
           apiVersion: server.apiVersion,
+          allowUntrustedCert: server.allowUntrustedCert,
+          ignoreCertificateErrors: server.ignoreCertificateErrors,
+          pinnedCertificateSha256: server.pinnedCertificateSha256,
         );
       default:
         final client = PiholeV5ApiClient(
@@ -125,6 +128,9 @@ class RepositoryBundleFactory {
           ),
           serverAddress: server.address,
           apiVersion: server.apiVersion,
+          allowUntrustedCert: server.allowUntrustedCert,
+          ignoreCertificateErrors: server.ignoreCertificateErrors,
+          pinnedCertificateSha256: server.pinnedCertificateSha256,
         );
     }
   }

--- a/lib/data/repositories/api/repository_factory.dart
+++ b/lib/data/repositories/api/repository_factory.dart
@@ -45,7 +45,12 @@ class RepositoryBundleFactory {
 
     switch (server.apiVersion) {
       case SupportedApiVersions.v6:
-        final client = PiholeV6ApiClient(url: server.address);
+        final client = PiholeV6ApiClient(
+          url: server.address,
+          allowUntrustedCert: server.allowUntrustedCert,
+          ignoreCertificateErrors: server.ignoreCertificateErrors,
+          pinnedCertificateSha256: server.pinnedCertificateSha256,
+        );
         final sessionCache = V6SessionCache(creds: creds, client: client);
 
         return RepositoryBundle(
@@ -94,7 +99,12 @@ class RepositoryBundleFactory {
           apiVersion: server.apiVersion,
         );
       default:
-        final client = PiholeV5ApiClient(url: server.address);
+        final client = PiholeV5ApiClient(
+          url: server.address,
+          allowUntrustedCert: server.allowUntrustedCert,
+          ignoreCertificateErrors: server.ignoreCertificateErrors,
+          pinnedCertificateSha256: server.pinnedCertificateSha256,
+        );
         return RepositoryBundle(
           actions: ActionsRepositoryV5(client: client, creds: creds),
           adlist: AdlistRepositoryV5(client: client, creds: creds),

--- a/lib/data/services/api/pihole_v5_api_client.dart
+++ b/lib/data/services/api/pihole_v5_api_client.dart
@@ -22,6 +22,7 @@ class PiholeV5ApiClient {
     http.Client? client,
     bool? allowUntrustedCert,
     bool? ignoreCertificateErrors,
+    String? pinnedCertificateSha256,
   }) : _url = url,
        _client =
            client ??
@@ -29,6 +30,7 @@ class PiholeV5ApiClient {
              createHttpClient(
                allowUntrustedCert: allowUntrustedCert ?? true,
                ignoreCertificateErrors: ignoreCertificateErrors ?? false,
+               pinnedCertificateSha256: pinnedCertificateSha256,
              ),
            );
 

--- a/lib/data/services/api/pihole_v6_api_client.dart
+++ b/lib/data/services/api/pihole_v6_api_client.dart
@@ -47,6 +47,7 @@ class PiholeV6ApiClient {
     http.Client? client,
     bool? allowUntrustedCert,
     bool? ignoreCertificateErrors,
+    String? pinnedCertificateSha256,
   }) : _url = url,
        _client =
            client ??
@@ -54,6 +55,7 @@ class PiholeV6ApiClient {
              createHttpClient(
                allowUntrustedCert: allowUntrustedCert ?? true,
                ignoreCertificateErrors: ignoreCertificateErrors ?? false,
+               pinnedCertificateSha256: pinnedCertificateSha256,
              ),
            );
 

--- a/lib/ui/core/actions/handle_certificate_recovery.dart
+++ b/lib/ui/core/actions/handle_certificate_recovery.dart
@@ -1,0 +1,30 @@
+import 'package:flutter/material.dart';
+import 'package:pi_hole_client/data/repositories/api/interfaces/repository_bundle.dart';
+import 'package:pi_hole_client/ui/core/services/server_connection_service.dart';
+import 'package:pi_hole_client/ui/core/view_models/app_config_viewmodel.dart';
+import 'package:pi_hole_client/ui/core/view_models/servers_viewmodel.dart';
+import 'package:pi_hole_client/ui/core/view_models/status_viewmodel.dart';
+import 'package:provider/provider.dart';
+
+Future<void> handleCertificateRecovery(
+  BuildContext context,
+  Exception error,
+) async {
+  final serversViewModel = Provider.of<ServersViewModel>(
+    context,
+    listen: false,
+  );
+  final server = serversViewModel.selectedServer;
+  if (server == null) return;
+
+  final service = ServerConnectionService(
+    context: context,
+    appConfigViewModel: Provider.of<AppConfigViewModel>(context, listen: false),
+    statusViewModel: Provider.of<StatusViewModel>(context, listen: false),
+    serversViewModel: serversViewModel,
+    server: server,
+    createBundle: Provider.of<CreateRepositoryBundle>(context, listen: false),
+  );
+
+  await service.showCertificateErrorRecovery(error);
+}

--- a/lib/ui/core/actions/handle_certificate_recovery.dart
+++ b/lib/ui/core/actions/handle_certificate_recovery.dart
@@ -6,7 +6,9 @@ import 'package:pi_hole_client/ui/core/view_models/servers_viewmodel.dart';
 import 'package:pi_hole_client/ui/core/view_models/status_viewmodel.dart';
 import 'package:provider/provider.dart';
 
-Future<void> handleCertificateRecovery(
+/// Returns true when the pin was updated and a reconnect was attempted, so the
+/// caller can refresh data immediately instead of waiting for the next tick.
+Future<bool> handleCertificateRecovery(
   BuildContext context,
   Exception error,
 ) async {
@@ -15,7 +17,7 @@ Future<void> handleCertificateRecovery(
     listen: false,
   );
   final server = serversViewModel.selectedServer;
-  if (server == null) return;
+  if (server == null) return false;
 
   final service = ServerConnectionService(
     context: context,
@@ -26,5 +28,5 @@ Future<void> handleCertificateRecovery(
     createBundle: Provider.of<CreateRepositoryBundle>(context, listen: false),
   );
 
-  await service.showCertificateErrorRecovery(error);
+  return service.showCertificateErrorRecovery(error);
 }

--- a/lib/ui/core/services/server_connection_service.dart
+++ b/lib/ui/core/services/server_connection_service.dart
@@ -343,9 +343,15 @@ class ServerConnectionService {
     }
 
     if (error == null || !_isSslError(error)) return;
-    if (targetContext == null) return;
-    if (!targetContext.mounted) return;
+    if (targetContext == null || !targetContext.mounted) return;
 
+    await _promptCertificateRecovery(targetContext);
+  }
+
+  // Caution snackbar + dialog offering a pin update (on mismatch) or edit,
+  // then reconnects on a successful pin update. Callers ensure the error is an
+  // SSL error and [targetContext] is mounted.
+  Future<void> _promptCertificateRecovery(BuildContext targetContext) async {
     final isPinMismatch = await _isPinnedCertificateMismatch(server);
 
     if (!targetContext.mounted) return;
@@ -407,6 +413,14 @@ class ServerConnectionService {
         _openEditServer(targetContext, server);
       }
     }
+  }
+
+  /// Recovery entry for an already-selected server (e.g. auto-refresh hit a pin
+  /// mismatch). Unlike [connect]/[_onFailure] it does not restart auto-refresh,
+  /// so dismissing the dialog avoids looping on the same 495.
+  Future<void> showCertificateErrorRecovery(Exception error) async {
+    if (!_isSslError(error) || !context.mounted) return;
+    await _promptCertificateRecovery(context);
   }
 
   Future<Server?> _openUpdatePinnedFingerprint(

--- a/lib/ui/core/services/server_connection_service.dart
+++ b/lib/ui/core/services/server_connection_service.dart
@@ -349,12 +349,13 @@ class ServerConnectionService {
   }
 
   // Caution snackbar + dialog offering a pin update (on mismatch) or edit,
-  // then reconnects on a successful pin update. Callers ensure the error is an
-  // SSL error and [targetContext] is mounted.
-  Future<void> _promptCertificateRecovery(BuildContext targetContext) async {
+  // then reconnects on a successful pin update. Returns true when the pin was
+  // updated and a reconnect was attempted. Callers ensure the error is an SSL
+  // error and [targetContext] is mounted.
+  Future<bool> _promptCertificateRecovery(BuildContext targetContext) async {
     final isPinMismatch = await _isPinnedCertificateMismatch(server);
 
-    if (!targetContext.mounted) return;
+    if (!targetContext.mounted) return false;
     final loc = AppLocalizations.of(targetContext)!;
 
     showCautionSnackBar(
@@ -408,19 +409,22 @@ class ServerConnectionService {
             showModal: showModal,
             fetchTlsCertificate: fetchTlsCertificate,
           ).connect();
+          return true;
         }
       } else {
         _openEditServer(targetContext, server);
       }
     }
+    return false;
   }
 
   /// Recovery entry for an already-selected server (e.g. auto-refresh hit a pin
   /// mismatch). Unlike [connect]/[_onFailure] it does not restart auto-refresh,
-  /// so dismissing the dialog avoids looping on the same 495.
-  Future<void> showCertificateErrorRecovery(Exception error) async {
-    if (!_isSslError(error) || !context.mounted) return;
-    await _promptCertificateRecovery(context);
+  /// so dismissing the dialog avoids looping on the same 495. Returns true when
+  /// the pin was updated and a reconnect was attempted.
+  Future<bool> showCertificateErrorRecovery(Exception error) async {
+    if (!_isSslError(error) || !context.mounted) return false;
+    return _promptCertificateRecovery(context);
   }
 
   Future<Server?> _openUpdatePinnedFingerprint(

--- a/lib/ui/core/view_models/status_viewmodel.dart
+++ b/lib/ui/core/view_models/status_viewmodel.dart
@@ -66,6 +66,10 @@ class StatusViewModel with ChangeNotifier {
   int? _previousRefreshTime;
   bool _isAutoRefreshRunning = false;
 
+  // Raised when auto-refresh stops on a TLS error (e.g. pin mismatch); the UI
+  // shows the recovery dialog, then clears it.
+  Exception? _fatalConnectionError;
+
   // ---------------------------------------------------------------------------
   // Getters — API unchanged from the former StatusViewModel so that all 15+
   // UI widgets using `context.select<StatusViewModel, ...>` need zero changes.
@@ -99,6 +103,12 @@ class StatusViewModel with ChangeNotifier {
   LoadStatus get getOvertimeDataLoadStatus => _overtimeDataLoading;
 
   bool get isAutoRefreshRunning => _isAutoRefreshRunning;
+
+  Exception? get fatalConnectionError => _fatalConnectionError;
+
+  void clearFatalConnectionError() {
+    _fatalConnectionError = null;
+  }
 
   /// Derived getter: extracts client hostnames from the current
   /// [RealtimeStatus]. Used by `LogsViewModel` via ProxyProvider to replace
@@ -297,6 +307,26 @@ class StatusViewModel with ChangeNotifier {
     _setupMetricsDataTimer(runImmediately: runImmediately, isDelay: isDelay);
   }
 
+  bool _isSslError(Object? error) =>
+      error is HttpStatusCodeException && error.statusCode == 495;
+
+  // Stops auto-refresh and signals the UI on a TLS error. Returns true if
+  // handled, so callers skip their normal error handling.
+  bool _handleSslErrorIfNeeded(Object? error, String? selectedUrlBefore) {
+    if (!_isSslError(error) || selectedUrlBefore != _selectedServerAddress) {
+      return false;
+    }
+    logger.w('TLS error during status refresh; stopping auto-refresh: $error');
+    _serverStatus = LoadStatus.error;
+    _statusLoading = LoadStatus.error;
+    _stopAutoRefresh(showLoadingIndicator: false);
+    _fatalConnectionError = error is Exception
+        ? error
+        : Exception(error.toString());
+    notifyListeners();
+    return true;
+  }
+
   void _stopAutoRefresh({bool showLoadingIndicator = true}) {
     if (showLoadingIndicator) {
       _statusLoading = LoadStatus.loading;
@@ -369,6 +399,7 @@ class StatusViewModel with ChangeNotifier {
 
   Future<bool> _fetchStatusData() async {
     if (_selectedServerAddress == null) return false;
+    final selectedUrlBefore = _selectedServerAddress;
 
     final useCase = _createRealtimeStatusUseCase();
     if (useCase == null) return false;
@@ -384,6 +415,7 @@ class StatusViewModel with ChangeNotifier {
         return true;
       },
       (error) {
+        if (_handleSslErrorIfNeeded(error, selectedUrlBefore)) return false;
         _statusLoading = LoadStatus.error;
         notifyListeners();
         return false;
@@ -511,6 +543,7 @@ class StatusViewModel with ChangeNotifier {
           }
         },
         (error) {
+          if (_handleSslErrorIfNeeded(error, selectedUrlBefore)) return;
           if (selectedUrlBefore == _selectedServerAddress) {
             var changed = false;
             if (_serverStatus == LoadStatus.loaded) {

--- a/lib/ui/home/widgets/home_screen.dart
+++ b/lib/ui/home/widgets/home_screen.dart
@@ -46,6 +46,17 @@ class _HomeScreenState extends State<HomeScreen> {
     widget.statusViewModel.addListener(_onStatusViewModelChanged);
   }
 
+  @override
+  void didUpdateWidget(covariant HomeScreen oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    // statusViewModel is an app singleton so this rarely changes, but re-bind
+    // the listener defensively if a new instance is ever passed in.
+    if (oldWidget.statusViewModel != widget.statusViewModel) {
+      oldWidget.statusViewModel.removeListener(_onStatusViewModelChanged);
+      widget.statusViewModel.addListener(_onStatusViewModelChanged);
+    }
+  }
+
   // Show the certificate recovery dialog when auto-refresh stops on a TLS error.
   void _onStatusViewModelChanged() {
     final error = widget.statusViewModel.fatalConnectionError;
@@ -80,6 +91,7 @@ class _HomeScreenState extends State<HomeScreen> {
   @override
   void dispose() {
     scrollController.removeListener(_scrollListener);
+    scrollController.dispose();
     widget.statusViewModel.removeListener(_onStatusViewModelChanged);
     super.dispose();
   }

--- a/lib/ui/home/widgets/home_screen.dart
+++ b/lib/ui/home/widgets/home_screen.dart
@@ -53,11 +53,9 @@ class _HomeScreenState extends State<HomeScreen> {
     _handlingCertError = true;
     widget.statusViewModel.clearFatalConnectionError();
     WidgetsBinding.instance.addPostFrameCallback((_) async {
-      if (mounted) {
-        await handleCertificateRecovery(context, error);
-      }
-      if (mounted) {
-        await refreshServerStatus(context);
+      // Refresh immediately only when the pin was updated.
+      if (mounted && await handleCertificateRecovery(context, error)) {
+        if (mounted) await refreshServerStatus(context);
       }
       _handlingCertError = false;
     });

--- a/lib/ui/home/widgets/home_screen.dart
+++ b/lib/ui/home/widgets/home_screen.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:pi_hole_client/domain/model/enums.dart';
 import 'package:pi_hole_client/domain/model/server/api_versions.dart';
+import 'package:pi_hole_client/ui/core/actions/handle_certificate_recovery.dart';
 import 'package:pi_hole_client/ui/core/actions/refresh_server_status.dart';
 import 'package:pi_hole_client/ui/core/actions/server_management.dart';
 import 'package:pi_hole_client/ui/core/ui/helpers/responsive.dart';
@@ -34,6 +35,7 @@ class HomeScreen extends StatefulWidget {
 class _HomeScreenState extends State<HomeScreen> {
   late bool isVisible;
   final ScrollController scrollController = ScrollController();
+  bool _handlingCertError = false;
 
   @override
   void initState() {
@@ -41,6 +43,24 @@ class _HomeScreenState extends State<HomeScreen> {
 
     isVisible = true;
     scrollController.addListener(_scrollListener);
+    widget.statusViewModel.addListener(_onStatusViewModelChanged);
+  }
+
+  // Show the certificate recovery dialog when auto-refresh stops on a TLS error.
+  void _onStatusViewModelChanged() {
+    final error = widget.statusViewModel.fatalConnectionError;
+    if (error == null || _handlingCertError) return;
+    _handlingCertError = true;
+    widget.statusViewModel.clearFatalConnectionError();
+    WidgetsBinding.instance.addPostFrameCallback((_) async {
+      if (mounted) {
+        await handleCertificateRecovery(context, error);
+      }
+      if (mounted) {
+        await refreshServerStatus(context);
+      }
+      _handlingCertError = false;
+    });
   }
 
   void _scrollListener() {
@@ -62,6 +82,7 @@ class _HomeScreenState extends State<HomeScreen> {
   @override
   void dispose() {
     scrollController.removeListener(_scrollListener);
+    widget.statusViewModel.removeListener(_onStatusViewModelChanged);
     super.dispose();
   }
 

--- a/test/ui/core/view_models/status_viewmodel_test.dart
+++ b/test/ui/core/view_models/status_viewmodel_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:pi_hole_client/domain/model/enums.dart';
 import 'package:pi_hole_client/ui/core/view_models/status_viewmodel.dart';
+import 'package:pi_hole_client/utils/exceptions.dart';
 
 import '../../../../testing/fakes/repositories/api/fake_dns_repository.dart';
 import '../../../../testing/fakes/repositories/api/fake_ftl_repository.dart';
@@ -224,6 +225,50 @@ void main() {
       expect(vm.getServerStatus, LoadStatus.loading);
       final ok = await vm.refreshOnce();
       expect(ok, isFalse);
+    });
+  });
+
+  group('StatusViewModel - TLS (495) error handling', () {
+    late StatusViewModel vm;
+
+    tearDown(() => vm.dispose());
+
+    test('a 495 TLS error raises fatalConnectionError', () async {
+      vm = StatusViewModel();
+      final failingRepo = FakeRealTimeStatusRepository()
+        ..shouldFail = true
+        ..failureError = HttpStatusCodeException(495, 'SSL handshake failed');
+      _setup(vm, realtimeStatusRepository: failingRepo);
+
+      await vm.refreshOnce();
+
+      expect(vm.fatalConnectionError, isA<HttpStatusCodeException>());
+      expect(vm.getServerStatus, LoadStatus.error);
+    });
+
+    test('a non-TLS failure does not raise fatalConnectionError', () async {
+      vm = StatusViewModel();
+      final failingRepo = FakeRealTimeStatusRepository()..shouldFail = true;
+      _setup(vm, realtimeStatusRepository: failingRepo);
+
+      await vm.refreshOnce();
+
+      expect(vm.fatalConnectionError, isNull);
+      expect(vm.getServerStatus, LoadStatus.error);
+    });
+
+    test('clearFatalConnectionError resets the signal', () async {
+      vm = StatusViewModel();
+      final failingRepo = FakeRealTimeStatusRepository()
+        ..shouldFail = true
+        ..failureError = HttpStatusCodeException(495, 'SSL handshake failed');
+      _setup(vm, realtimeStatusRepository: failingRepo);
+
+      await vm.refreshOnce();
+      expect(vm.fatalConnectionError, isNotNull);
+
+      vm.clearFatalConnectionError();
+      expect(vm.fatalConnectionError, isNull);
     });
   });
 

--- a/test/ui/home/home_test.dart
+++ b/test/ui/home/home_test.dart
@@ -11,6 +11,7 @@ import 'package:pi_hole_client/ui/home/widgets/home_appbar/switch_server_modal.d
 import 'package:pi_hole_client/ui/home/widgets/home_screen.dart';
 import 'package:pi_hole_client/ui/home/widgets/server_status_chips.dart';
 import 'package:pi_hole_client/ui/servers/widgets/servers_screen.dart';
+import 'package:pi_hole_client/utils/exceptions.dart';
 import 'package:skeletonizer/skeletonizer.dart';
 
 import '../../../testing/fakes/repositories/local/fake_app_config_repository.dart';
@@ -114,6 +115,39 @@ void main() async {
       // clients graph
       expect(find.text('Client activity last 24 hours'), findsOneWidget);
     });
+
+    testWidgets(
+      'shows the certificate recovery dialog when auto-refresh hits a TLS error',
+      (WidgetTester tester) async {
+        await tester.pumpWidget(
+          buildTestApp(
+            HomeScreen(
+              serversViewModel: serversViewModel,
+              appConfigViewModel: appConfigViewModel,
+              statusViewModel: statusViewModel,
+            ),
+            appConfigViewModel: appConfigViewModel,
+            serversViewModel: serversViewModel,
+            statusViewModel: statusViewModel,
+            logsViewModel: logsViewModel,
+            repositoryBundle: createFakeRepositoryBundle(),
+            createRepositoryBundle: ({required server}) =>
+                createFakeRepositoryBundle(),
+          ),
+        );
+        await tester.pumpAndSettle();
+        expect(find.byType(AlertDialog), findsNothing);
+
+        // Simulate auto-refresh detecting a pinned-certificate mismatch.
+        statusViewModel.fatalConnectionError = HttpStatusCodeException(
+          495,
+          'SSL handshake failed',
+        );
+        await tester.pumpAndSettle();
+
+        expect(find.byType(AlertDialog), findsOneWidget);
+      },
+    );
 
     testWidgets('should show status chips for v6 server', (
       WidgetTester tester,

--- a/testing/fakes/repositories/api/fake_realtime_status_repository.dart
+++ b/testing/fakes/repositories/api/fake_realtime_status_repository.dart
@@ -7,10 +7,16 @@ import '../../../models/v5/realtime_status.dart';
 class FakeRealTimeStatusRepository implements RealtimeStatusRepository {
   bool shouldFail = false;
 
+  /// Error returned when [shouldFail] is true. Lets tests inject a specific
+  /// failure (e.g. a 495 TLS error) instead of the generic one.
+  Exception? failureError;
+
   @override
   Future<Result<RealtimeStatus>> fetchRealtimeStatus() async {
     if (shouldFail) {
-      return Failure(Exception('Failed to fetch real-time status'));
+      return Failure(
+        failureError ?? Exception('Failed to fetch real-time status'),
+      );
     }
     return Success(kRepoFetchRealTimeStatus);
   }

--- a/testing/fakes/viewmodels/fake_status_viewmodel.dart
+++ b/testing/fakes/viewmodels/fake_status_viewmodel.dart
@@ -19,6 +19,7 @@ class FakeStatusViewModel extends StatusViewModel {
   FtlDnsMetrics? _ftlDnsMetrics;
   FtlSystem? _ftlSystem;
   FtlSensor? _ftlSensor;
+  Exception? _fatalConnectionError;
 
   @override
   LoadStatus get getStatusLoading => _statusLoading;
@@ -52,6 +53,19 @@ class FakeStatusViewModel extends StatusViewModel {
 
   @override
   FtlSensor? get getFtlSensor => _ftlSensor;
+
+  @override
+  Exception? get fatalConnectionError => _fatalConnectionError;
+
+  @override
+  void clearFatalConnectionError() {
+    _fatalConnectionError = null;
+  }
+
+  set fatalConnectionError(Exception? value) {
+    _fatalConnectionError = value;
+    notifyListeners();
+  }
 
   @override
   double? get getQueriesPerMinute {


### PR DESCRIPTION
## Overview
Pinning settings were stored and shown in the UI but never passed to the HTTP clients, so any certificate was silently accepted. This wires them into the TLS connection, rebuilds the connection when they change, and adds a recovery flow when a pinned certificate no longer matches.

## Changes
- Pass `allowUntrustedCert` / `ignoreCertificateErrors` / `pinnedCertificateSha256` from the server config into the v5/v6 HTTP clients via the repository factory, so pinning and untrusted-cert rules are actually enforced on every request.
- Rebuild the `RepositoryBundle` when certificate settings change (previously only on address change), so an updated pin takes effect immediately instead of reusing a stale HTTP client baked with the old fingerprint.
- Detect a TLS handshake failure (495) during status auto-refresh, stop the refresh loop to avoid spamming handshake errors, and show the existing certificate recovery dialog on Home so the user can update the pin and resume — reusing the same flow as server selection.
- Add tests covering the TLS-error detection signal in `StatusViewModel` and the recovery dialog appearing on Home.

> [!NOTE]
> This changes behavior: a server with a stored pin that no longer matches its current certificate will now fail to connect. 
> Recovery is one tap via the "update pin" dialog, which now appears on Home as well as on server selection.

## Summary by Sourcery

Enforce TLS certificate pinning and surface certificate mismatch errors through the status auto-refresh flow with a guided recovery on Home.

New Features:
- Propagate TLS settings, including pinned certificate fingerprints, from server configuration into v5 and v6 API clients via the repository bundle so connections honor pinning and certificate-trust options.
- Expose a certificate error recovery flow from the Home screen when auto-refresh encounters a TLS error, reusing the existing server connection service.

Bug Fixes:
- Detect TLS handshake failures (HTTP 495) during status refresh, stop the auto-refresh loop, and mark status as errored instead of repeatedly retrying.
- Ensure repository bundles are rebuilt when any TLS-related server setting changes so clients do not reuse stale certificate pins.

Enhancements:
- Extend RepositoryBundle to carry TLS configuration flags alongside server address and API version.
- Add a fatalConnectionError signal to StatusViewModel to coordinate UI responses to unrecoverable TLS errors.
- Refine server connection service behavior to offer certificate recovery for already-selected servers without restarting auto-refresh loops.

Tests:
- Add unit tests for StatusViewModel TLS error detection and fatalConnectionError signaling behavior.
- Add widget tests verifying that the Home screen shows the certificate recovery dialog when a TLS error is signaled and that fake repositories can simulate specific TLS failures.