### PR TITLE
refactor(servers): extract add/edit connection orchestration

### DIFF
--- a/docs/server-connection-flow.md
+++ b/docs/server-connection-flow.md
@@ -1,0 +1,201 @@
+# Server Connection Flow (add / edit)
+
+How the **Add / Edit server** screen connects to a Pi-hole and persists it.
+
+- UI: `lib/ui/servers/widgets/add_server_fullscreen.dart` (`AddServerFullscreen`)
+- Orchestration: `lib/ui/servers/view_models/add_server_viewmodel.dart`
+  (`AddServerViewModel.createServer` / `updateServer`)
+
+The view model owns the orchestration and returns a sealed outcome
+(`CreateOutcome` / `UpdateOutcome`). The widget builds the request, awaits the
+command and maps the outcome to UI (snackbar / navigation). The certificate
+dialog and the SSL-error snackbar stay in the widget and are injected per
+request through the `resolveCertificate` callback.
+
+## Layers
+
+```mermaid
+flowchart LR
+  W[AddServerFullscreen<br/>widget] --> VM[AddServerViewModel]
+  VM --> SV[ServersViewModel<br/>url check, credentials, DB commands]
+  VM --> ST[StatusViewModel<br/>auto-refresh]
+  VM --> B[RepositoryBundle<br/>auth + dns]
+  W -. resolveCertificate callback .-> VM
+```
+
+## Add a new server - `createServer`
+
+A cancelled/blocked certificate does **not** stop create: it keeps the
+original server and the connection test below reports the error.
+
+```mermaid
+flowchart TD
+  A([createServer req]) --> B{checkUrl}
+  B -- duplicate --> BD([CreateDuplicateUrl])
+  B -- failed --> BF([CreateUrlCheckFailed])
+  B -- available --> C[savePassword + saveToken]
+  C --> D[resolveCertificate<br/>cancel/blocked: keep original, continue]
+  D --> E{apiVersion == v6?}
+  E -- yes --> F[auth.createSession]
+  F -- error --> G[deletePassword + deleteToken] --> H([CreateApiError])
+  F -- ok --> I[dns.fetchBlockingStatus<br/>skipRenewal: true]
+  E -- no --> I
+  I -- success --> J([CreateSuccess server])
+  I -- error --> K[deletePassword + deleteToken] --> L([CreateApiError])
+```
+
+On `CreateSuccess` the widget pops, shows the success snackbar, then persists
+the server (`serversViewModel.addServer.runAsync`, fire-and-forget).
+
+## Edit an existing server - `updateServer`
+
+A cancelled/blocked certificate **aborts** the save (`UpdateCancelled`); the
+message was already shown by `resolveCertificate`. Auto-refresh is stopped for
+the duration and restarted on every exit path.
+
+```mermaid
+flowchart TD
+  A([updateServer req]) --> B{address changed?}
+  B -- yes --> C{checkUrl newUrl}
+  C -- duplicate --> CD([UpdateDuplicateUrl])
+  C -- failed --> CF([UpdateUrlCheckFailed])
+  C -- available --> D[build serverObj<br/>pin reset if address changed]
+  B -- no --> D
+  D --> E[stopAutoRefresh if a server is selected]
+  E --> F[resolveCertificate]
+  F -- cancelled/blocked --> G[restartAutoRefresh] --> H([UpdateCancelled])
+  F -- ok --> I[savePassword + saveToken at target]
+  I --> J[authenticate]
+  J -- error --> K{needsRollback?}
+  K -- yes --> L[rollbackFailedSave]
+  K -- no --> M[restoreSecrets + restartAutoRefresh]
+  L --> M
+  M --> N([UpdateApiError])
+  J -- ok --> O[dns.fetchBlockingStatus<br/>skipRenewal: sessionCreated]
+  O -- error --> P[rollbackFailedSave + restartAutoRefresh] --> Q([UpdateApiError])
+  O -- success --> R[commit: replaceServer / editServer]
+  R -- error --> S[rollbackFailedSave + restartAutoRefresh] --> T([UpdateDbError])
+  R -- ok --> U[cleanupAfterCommit<br/>logout old v6 session, drop old creds/SID]
+  U --> V[restartAutoRefresh] --> W([UpdateSuccess])
+```
+
+On `UpdateSuccess` the widget pops and shows the success snackbar.
+
+### Session handling inside `updateServer` - `_authenticate`
+
+Only re-authenticates when needed, to avoid duplicate sessions on transient
+failures (503/504/timeout).
+
+```mermaid
+flowchart TD
+  A([authenticate]) --> Z{apiVersion == v6?}
+  Z -- no --> N0([sessionCreated = false])
+  Z -- yes --> B{address changed?}
+  B -- yes --> C[auth.createSession]
+  C -- error --> CE([error, needsRollback = true])
+  C -- ok --> CS([sessionCreated = true])
+  B -- no --> D{password changed?}
+  D -- yes --> E[auth.createSession]
+  E -- error --> EE([error])
+  E -- ok --> ES([sessionCreated = true])
+  D -- no --> P[preCheck: dns.fetchBlockingStatus]
+  P -- ok --> N1([reuse current session])
+  P -- error --> R{reauthRequired?<br/>401 / SidNotFound}
+  R -- no --> RE([error])
+  R -- yes --> H[auth.createSession]
+  H -- error --> HE([error])
+  H -- ok --> HS([sessionCreated = true])
+```
+
+## Sequence - add a new server
+
+```mermaid
+sequenceDiagram
+  actor U as User
+  participant W as AddServerFullscreen
+  participant VM as AddServerViewModel
+  participant SV as ServersViewModel
+  participant B as RepositoryBundle
+
+  U->>W: tap Connect
+  W->>VM: createServer.runAsync(req)
+  VM->>SV: checkUrlExists(url)
+  VM->>SV: savePassword / saveToken
+  VM->>W: resolveCertificate(server)
+  Note over W: pin dialog / ssl-error snackbar (UI)
+  opt apiVersion == v6
+    VM->>B: auth.createSession(password)
+  end
+  VM->>B: dns.fetchBlockingStatus(skipRenewal: true)
+  VM-->>W: CreateSuccess(server) | CreateApiError | CreateDuplicateUrl | CreateUrlCheckFailed
+  alt success
+    W->>W: Navigator.maybePop + success snackbar
+    W->>SV: addServer.runAsync(server)
+  else failure
+    W->>W: error snackbar
+  end
+```
+
+## Sequence - edit an existing server
+
+```mermaid
+sequenceDiagram
+  actor U as User
+  participant W as AddServerFullscreen
+  participant VM as AddServerViewModel
+  participant SV as ServersViewModel
+  participant ST as StatusViewModel
+  participant B as RepositoryBundle
+
+  U->>W: tap Save
+  W->>VM: updateServer.runAsync(req)
+  opt address changed
+    VM->>SV: checkUrlExists(newUrl)
+  end
+  VM->>ST: stopAutoRefresh
+  VM->>W: resolveCertificate(server)
+  VM->>SV: savePassword / saveToken (target)
+  VM->>B: auth.createSession / dns.fetchBlockingStatus (see _authenticate)
+  VM->>B: dns.fetchBlockingStatus(skipRenewal: sessionCreated)
+  alt connection ok
+    VM->>SV: replaceServer / editServer (commit)
+    VM->>B: old bundle.auth.deleteCurrentSession (cleanup)
+    VM->>SV: delete old credentials / SID (cleanup)
+  else failure
+    VM->>SV: rollback (delete new creds/SID or restore old)
+  end
+  VM->>ST: startAutoRefresh
+  VM-->>W: UpdateSuccess | UpdateCancelled | UpdateApiError | UpdateDbError | UpdateDuplicateUrl | UpdateUrlCheckFailed
+  alt UpdateSuccess
+    W->>W: Navigator.maybePop + success snackbar
+  else UpdateApiError / UpdateDbError / duplicate / urlCheckFailed
+    W->>W: error snackbar
+  else UpdateCancelled
+    W->>W: nothing (message already shown by resolveCertificate)
+  end
+```
+
+## Outcome → UI mapping
+
+| Outcome                                         | Widget reaction                                                        |
+| ----------------------------------------------- | ---------------------------------------------------------------------- |
+| `CreateSuccess(server)`                         | pop → "connected successfully" → `addServer.runAsync(server)`          |
+| `UpdateSuccess`                                 | pop → "edited successfully"                                            |
+| `CreateDuplicateUrl` / `UpdateDuplicateUrl`     | "connection already exists" snackbar                                   |
+| `CreateUrlCheckFailed` / `UpdateUrlCheckFailed` | "cannot check URL" snackbar                                            |
+| `CreateApiError` / `UpdateApiError`             | status-code-specific error snackbar + log (`handleApiErrorResult`)     |
+| `UpdateDbError`                                 | "cannot save connection data" snackbar                                 |
+| `UpdateCancelled`                               | nothing - the certificate dialog / SSL error already informed the user |
+
+## Notes
+
+- **Create vs edit certificate-cancel asymmetry is intentional**: `createServer`
+  continues after a cancelled/blocked certificate (the connection test then
+  surfaces the error), while `updateServer` aborts with `UpdateCancelled`.
+- The view model never shows UI itself. The certificate pin dialog and SSL-error
+  snackbar live in the widget and are reached via the `resolveCertificate`
+  callback passed in the request.
+- The connecting overlay is driven by a local `isConnecting` flag toggled around
+  `runAsync`.
+- See also: [ARCHITECTURE.md](ARCHITECTURE.md).
+```

--- a/docs/server-connection-flow.md
+++ b/docs/server-connection-flow.md
@@ -26,7 +26,8 @@ flowchart LR
 ## Add a new server - `createServer`
 
 A cancelled/blocked certificate **aborts** the add (`CreateCancelled`),
-mirroring `updateServer`; the credentials saved above are removed first.
+mirroring `updateServer`; no credentials or remote session are created before
+the abort.
 
 ```mermaid
 flowchart TD
@@ -121,9 +122,9 @@ sequenceDiagram
   U->>W: tap Connect
   W->>VM: createServer.runAsync(req)
   VM->>SV: checkUrlExists(url)
-  VM->>SV: savePassword / saveToken
   VM->>W: resolveCertificate(server)
   Note over W: pin dialog / ssl-error snackbar (UI)
+  VM->>SV: savePassword / saveToken
   opt apiVersion == v6
     VM->>B: auth.createSession(password)
   end

--- a/docs/server-connection-flow.md
+++ b/docs/server-connection-flow.md
@@ -25,17 +25,18 @@ flowchart LR
 
 ## Add a new server - `createServer`
 
-A cancelled/blocked certificate does **not** stop create: it keeps the
-original server and the connection test below reports the error.
+A cancelled/blocked certificate **aborts** the add (`CreateCancelled`),
+mirroring `updateServer`; the credentials saved above are removed first.
 
 ```mermaid
 flowchart TD
   A([createServer req]) --> B{checkUrl}
   B -- duplicate --> BD([CreateDuplicateUrl])
   B -- failed --> BF([CreateUrlCheckFailed])
-  B -- available --> C[savePassword + saveToken]
-  C --> D[resolveCertificate<br/>cancel/blocked: keep original, continue]
-  D --> E{apiVersion == v6?}
+  B -- available --> D[resolveCertificate]
+  D -- cancelled/blocked --> DX([CreateCancelled])
+  D -- ok --> C[savePassword + saveToken]
+  C --> E{apiVersion == v6?}
   E -- yes --> F[auth.createSession]
   F -- error --> G[deletePassword + deleteToken] --> H([CreateApiError])
   F -- ok --> I[dns.fetchBlockingStatus<br/>skipRenewal: true]
@@ -127,12 +128,14 @@ sequenceDiagram
     VM->>B: auth.createSession(password)
   end
   VM->>B: dns.fetchBlockingStatus(skipRenewal: true)
-  VM-->>W: CreateSuccess(server) | CreateApiError | CreateDuplicateUrl | CreateUrlCheckFailed
+  VM-->>W: CreateSuccess(server) | CreateCancelled | CreateApiError | CreateDuplicateUrl | CreateUrlCheckFailed
   alt success
     W->>W: Navigator.maybePop + success snackbar
     W->>SV: addServer.runAsync(server)
   else failure
     W->>W: error snackbar
+  else cancelled
+    W->>W: nothing (message already shown by resolveCertificate)
   end
 ```
 
@@ -185,13 +188,14 @@ sequenceDiagram
 | `CreateUrlCheckFailed` / `UpdateUrlCheckFailed` | "cannot check URL" snackbar                                            |
 | `CreateApiError` / `UpdateApiError`             | status-code-specific error snackbar + log (`handleApiErrorResult`)     |
 | `UpdateDbError`                                 | "cannot save connection data" snackbar                                 |
-| `UpdateCancelled`                               | nothing - the certificate dialog / SSL error already informed the user |
+| `CreateCancelled` / `UpdateCancelled`           | nothing - the certificate dialog / SSL error already informed the user |
 
 ## Notes
 
-- **Create vs edit certificate-cancel asymmetry is intentional**: `createServer`
-  continues after a cancelled/blocked certificate (the connection test then
-  surfaces the error), while `updateServer` aborts with `UpdateCancelled`.
+- **Create and edit behave symmetrically on certificate cancel**: both
+  `createServer` and `updateServer` abort (`CreateCancelled` / `UpdateCancelled`)
+  when the pin dialog is cancelled or the certificate is blocked; no connection
+  is attempted.
 - The view model never shows UI itself. The certificate pin dialog and SSL-error
   snackbar live in the widget and are reached via the `resolveCertificate`
   callback passed in the request.

--- a/lib/ui/servers/view_models/add_server_viewmodel.dart
+++ b/lib/ui/servers/view_models/add_server_viewmodel.dart
@@ -92,7 +92,7 @@ class UpdateServerRequest {
 }
 
 // ==================================================================
-// Outcome of [AddServerViewModel.connect], mapped to UI reactions by the widget.
+// Outcome of [AddServerViewModel.createServer], mapped to UI by the widget.
 // ==================================================================
 sealed class CreateOutcome {
   const CreateOutcome();
@@ -122,7 +122,7 @@ final class CreateApiError extends CreateOutcome {
 }
 
 // ==================================================================
-// Outcome of [AddServerViewModel.save], mapped to UI reactions by the widget.
+// Outcome of [AddServerViewModel.updateServer], mapped to UI by the widget.
 // ==================================================================
 sealed class UpdateOutcome {
   const UpdateOutcome();
@@ -248,6 +248,7 @@ class AddServerViewModel extends ChangeNotifier {
         return CreateApiError(authResult.exceptionOrNull()!, req.apiVersion);
       }
     }
+
     // Use skipRenewal: true because the session was just created above.
     // Retrying with clearAndRenewSid would create a duplicate session.
     // Transient errors (e.g. network timeout) are still retried.
@@ -257,6 +258,8 @@ class AddServerViewModel extends ChangeNotifier {
         serverObj.copyWith(defaultServer: req.defaultServer),
       );
     }
+
+    // Clean up the credentials saved for this attempt; the server was not added
     await _serversViewModel.deletePassword(req.url);
     await _serversViewModel.deleteToken(req.url);
     return CreateApiError(result.exceptionOrNull()!, req.apiVersion);
@@ -387,124 +390,192 @@ class AddServerViewModel extends ChangeNotifier {
     }
 
     final bundle = _createBundle(server: serverObj);
-    var sessionJustCreated = false;
-    if (serverObj.apiVersion == SupportedApiVersions.v6) {
-      if (isAddressChanged) {
-        // The new address has no existing session, so always create one.
-        final authResult = await bundle.auth.createSession(req.password);
-        if (authResult.isError()) {
-          await rollbackFailedSave(bundle: bundle, sessionCreated: false);
-          return handleSaveError(authResult.exceptionOrNull()!);
-        }
-        sessionJustCreated = true;
-      } else if (req.password != req.initPassword) {
-        // Same address but the password was edited. Validate it now by creating
-        // a session: an unverified (possibly wrong) password would otherwise
-        // silently overwrite the known-good one and lock the user out the
-        // moment the current SID is invalidated.
-        final authResult = await bundle.auth.createSession(req.password);
-        if (authResult.isError()) {
-          return handleSaveError(authResult.exceptionOrNull()!);
-        }
-        sessionJustCreated = true;
-      } else {
-        // Same address, unchanged password: reuse the existing session if it is
-        // still valid. Only re-authenticate on 401/SidNotFoundException to
-        // avoid session multiplication when the server is temporarily
-        // unreachable (503/504/timeout).
-        final preCheck = await bundle.dns.fetchBlockingStatus(
-          skipRenewal: true,
-        );
-        if (preCheck.isError()) {
-          final err = preCheck.exceptionOrNull();
-          if (!isReauthRequired(err)) {
-            return handleSaveError(err!);
-          }
-          final authResult = await bundle.auth.createSession(req.password);
-          if (authResult.isError()) {
-            return handleSaveError(authResult.exceptionOrNull()!);
-          }
-          sessionJustCreated = true;
-        }
+    final auth = await _authenticate(
+      bundle: bundle,
+      req: req,
+      isAddressChanged: isAddressChanged,
+    );
+    if (auth.error != null) {
+      // Only the address-changed branch wrote credentials under a new address,
+      // so it is the only one that needs a rollback before reporting the error.
+      if (auth.needsRollback) {
+        await rollbackFailedSave(bundle: bundle, sessionCreated: false);
       }
+      return handleSaveError(auth.error!);
     }
+    final sessionJustCreated = auth.sessionCreated;
     // skipRenewal: true only when a new session was just created above to avoid
     // creating a duplicate session on transient retry failures.
     final result = await bundle.dns.fetchBlockingStatus(
       skipRenewal: sessionJustCreated,
     );
 
-    if (result.isSuccess()) {
-      final server = serverObj.copyWith(defaultServer: req.defaultServer);
-
-      Object? cmdError;
-      try {
-        if (isAddressChanged) {
-          await _serversViewModel.replaceServer.runAsync((
-            oldAddress: oldAddress,
-            newServer: server,
-          ));
-          cmdError = _serversViewModel.replaceServer.errors.value;
-        } else {
-          await _serversViewModel.editServer.runAsync(server);
-          cmdError = _serversViewModel.editServer.errors.value;
-        }
-      } catch (e, s) {
-        logger.e('Failed to save server', error: e, stackTrace: s);
-        cmdError = e;
-      }
-
-      if (cmdError == null) {
-        // The old v6 session is orphaned on an address change or a switch away
-        // from v6 (e.g. v6 -> v5). Run only after the DB commit so a failed
-        // save can't kill a live session.
-        final oldWasV6 = oldServer.apiVersion == SupportedApiVersions.v6;
-        final newIsV6 = serverObj.apiVersion == SupportedApiVersions.v6;
-
-        // 1. Log out the old v6 session.
-        if (oldWasV6 && (isAddressChanged || !newIsV6)) {
-          try {
-            final oldBundle = _createBundle(server: oldServer);
-            await oldBundle.auth.deleteCurrentSession();
-          } catch (e, s) {
-            logger.w(
-              'Failed to delete old session on server',
-              error: e,
-              stackTrace: s,
-            );
-          }
-        }
-
-        // 2. Now safe to drop the old server's credentials.
-        if (isAddressChanged) {
-          // New credentials already live under the new address; remove the
-          // stale ones left behind under the old address.
-          await _serversViewModel.deleteToken(oldAddress);
-          await _serversViewModel.deletePassword(oldAddress);
-          await _serversViewModel.deleteSid(oldAddress);
-        } else if (oldWasV6 && !newIsV6) {
-          // Same address, v6 -> v5: the SID is now unused.
-          await _serversViewModel.deleteSid(targetAddress);
-        }
-        restartAutoRefresh();
-        return const UpdateSuccess();
-      } else {
-        // DB write failed: roll back this attempt's artifacts; the old server
-        // (row, credentials, session) is left fully intact.
-        await rollbackFailedSave(
-          bundle: bundle,
-          sessionCreated: sessionJustCreated,
-        );
-        restartAutoRefresh();
-        return const UpdateDbError();
-      }
-    } else {
+    if (result.isError()) {
       await rollbackFailedSave(
         bundle: bundle,
         sessionCreated: sessionJustCreated,
       );
       restartAutoRefresh();
       return UpdateApiError(result.exceptionOrNull()!, req.apiVersion);
+    }
+
+    final server = serverObj.copyWith(defaultServer: req.defaultServer);
+    final cmdError = await _commit(
+      server: server,
+      oldAddress: oldAddress,
+      isAddressChanged: isAddressChanged,
+    );
+    if (cmdError != null) {
+      // DB write failed: roll back this attempt's artifacts; the old server
+      // (row, credentials, session) is left fully intact.
+      await rollbackFailedSave(
+        bundle: bundle,
+        sessionCreated: sessionJustCreated,
+      );
+      restartAutoRefresh();
+      return const UpdateDbError();
+    }
+
+    await _cleanupAfterCommit(
+      oldServer: oldServer,
+      newApiVersion: req.apiVersion,
+      isAddressChanged: isAddressChanged,
+      oldAddress: oldAddress,
+      targetAddress: targetAddress,
+    );
+    restartAutoRefresh();
+    return const UpdateSuccess();
+  }
+
+  /// Ensures a valid v6 session exists before the connection test.
+  ///
+  /// - Non-v6: nothing to do.
+  /// - Address changed: the new host has no session, so always create one.
+  /// - Same address, password changed: validate the new password by creating a
+  ///   session (so an unverified password can't silently replace the good one).
+  /// - Same address, password unchanged: reuse the current session and only log
+  ///   in again on a 401/SID-missing (avoids duplicate sessions on 503/504).
+  ///
+  /// On failure returns the error and `needsRollback` (true only for the
+  /// address-changed branch, which already wrote new-address credentials).
+  Future<({bool sessionCreated, Exception? error, bool needsRollback})>
+  _authenticate({
+    required RepositoryBundle bundle,
+    required UpdateServerRequest req,
+    required bool isAddressChanged,
+  }) async {
+    // Non-v6
+    if (req.apiVersion != SupportedApiVersions.v6) {
+      return (sessionCreated: false, error: null, needsRollback: false);
+    }
+
+    // Address changed
+    if (isAddressChanged) {
+      final authResult = await bundle.auth.createSession(req.password);
+      if (authResult.isError()) {
+        return (
+          sessionCreated: false,
+          error: authResult.exceptionOrNull()!,
+          needsRollback: true,
+        );
+      }
+      return (sessionCreated: true, error: null, needsRollback: false);
+    }
+
+    // Same address, password changed
+    if (req.password != req.initPassword) {
+      final authResult = await bundle.auth.createSession(req.password);
+      if (authResult.isError()) {
+        return (
+          sessionCreated: false,
+          error: authResult.exceptionOrNull()!,
+          needsRollback: false,
+        );
+      }
+      return (sessionCreated: true, error: null, needsRollback: false);
+    }
+
+    // Same address, password unchanged
+    final preCheck = await bundle.dns.fetchBlockingStatus(skipRenewal: true);
+    if (preCheck.isError()) {
+      final err = preCheck.exceptionOrNull();
+      if (!isReauthRequired(err)) {
+        return (sessionCreated: false, error: err, needsRollback: false);
+      }
+      final authResult = await bundle.auth.createSession(req.password);
+      if (authResult.isError()) {
+        return (
+          sessionCreated: false,
+          error: authResult.exceptionOrNull()!,
+          needsRollback: false,
+        );
+      }
+      return (sessionCreated: true, error: null, needsRollback: false);
+    }
+
+    return (sessionCreated: false, error: null, needsRollback: false);
+  }
+
+  /// Writes [server] to the DB: replace when the address changed, otherwise edit
+  /// in place. Returns the command error, or null on success.
+  Future<Object?> _commit({
+    required Server server,
+    required String oldAddress,
+    required bool isAddressChanged,
+  }) async {
+    try {
+      if (isAddressChanged) {
+        await _serversViewModel.replaceServer.runAsync((
+          oldAddress: oldAddress,
+          newServer: server,
+        ));
+        return _serversViewModel.replaceServer.errors.value;
+      }
+      await _serversViewModel.editServer.runAsync(server);
+      return _serversViewModel.editServer.errors.value;
+    } catch (e, s) {
+      logger.e('Failed to save server', error: e, stackTrace: s);
+      return e;
+    }
+  }
+
+  /// After a successful commit, logs out the now-orphaned old v6 session and
+  /// drops the old server's stale credentials/SID. Runs only after the commit so
+  /// a failed save can't kill a live session.
+  Future<void> _cleanupAfterCommit({
+    required Server oldServer,
+    required String newApiVersion,
+    required bool isAddressChanged,
+    required String oldAddress,
+    required String targetAddress,
+  }) async {
+    final oldWasV6 = oldServer.apiVersion == SupportedApiVersions.v6;
+    final newIsV6 = newApiVersion == SupportedApiVersions.v6;
+
+    // 1. Log out the old v6 session (orphaned on address change or v6 -> v5).
+    if (oldWasV6 && (isAddressChanged || !newIsV6)) {
+      try {
+        final oldBundle = _createBundle(server: oldServer);
+        await oldBundle.auth.deleteCurrentSession();
+      } catch (e, s) {
+        logger.w(
+          'Failed to delete old session on server',
+          error: e,
+          stackTrace: s,
+        );
+      }
+    }
+
+    // 2. Now safe to drop the old server's credentials.
+    if (isAddressChanged) {
+      // New credentials already live under the new address; remove the stale
+      // ones left behind under the old address.
+      await _serversViewModel.deleteToken(oldAddress);
+      await _serversViewModel.deletePassword(oldAddress);
+      await _serversViewModel.deleteSid(oldAddress);
+    } else if (oldWasV6 && !newIsV6) {
+      // Same address, v6 -> v5: the SID is now unused.
+      await _serversViewModel.deleteSid(targetAddress);
     }
   }
 

--- a/lib/ui/servers/view_models/add_server_viewmodel.dart
+++ b/lib/ui/servers/view_models/add_server_viewmodel.dart
@@ -21,9 +21,9 @@ import 'package:pi_hole_client/utils/url.dart';
 /// widget; the view model only decides what to do with the result.
 typedef ResolveCertificate = Future<Server?> Function(Server server);
 
-/// Request for [AddServerViewModel.connect] (adding a new server).
-class ConnectRequest {
-  const ConnectRequest({
+/// Request for [AddServerViewModel.createServer] (adding a new server).
+class CreateServerRequest {
+  const CreateServerRequest({
     required this.url,
     required this.alias,
     required this.apiVersion,
@@ -48,9 +48,9 @@ class ConnectRequest {
   final ResolveCertificate resolveCertificate;
 }
 
-/// Request for [AddServerViewModel.save] (editing an existing server).
-class SaveRequest {
-  const SaveRequest({
+/// Request for [AddServerViewModel.updateServer] (editing an existing server).
+class UpdateServerRequest {
+  const UpdateServerRequest({
     required this.url,
     required this.alias,
     required this.apiVersion,
@@ -94,29 +94,29 @@ class SaveRequest {
 // ==================================================================
 // Outcome of [AddServerViewModel.connect], mapped to UI reactions by the widget.
 // ==================================================================
-sealed class ConnectOutcome {
-  const ConnectOutcome();
+sealed class CreateOutcome {
+  const CreateOutcome();
 }
 
-final class ConnectInitial extends ConnectOutcome {
-  const ConnectInitial();
+final class CreateInitial extends CreateOutcome {
+  const CreateInitial();
 }
 
-final class ConnectSuccess extends ConnectOutcome {
-  const ConnectSuccess(this.server);
+final class CreateSuccess extends CreateOutcome {
+  const CreateSuccess(this.server);
   final Server server;
 }
 
-final class ConnectDuplicateUrl extends ConnectOutcome {
-  const ConnectDuplicateUrl();
+final class CreateDuplicateUrl extends CreateOutcome {
+  const CreateDuplicateUrl();
 }
 
-final class ConnectUrlCheckFailed extends ConnectOutcome {
-  const ConnectUrlCheckFailed();
+final class CreateUrlCheckFailed extends CreateOutcome {
+  const CreateUrlCheckFailed();
 }
 
-final class ConnectApiError extends ConnectOutcome {
-  const ConnectApiError(this.error, this.version);
+final class CreateApiError extends CreateOutcome {
+  const CreateApiError(this.error, this.version);
   final Exception error;
   final String version;
 }
@@ -124,41 +124,42 @@ final class ConnectApiError extends ConnectOutcome {
 // ==================================================================
 // Outcome of [AddServerViewModel.save], mapped to UI reactions by the widget.
 // ==================================================================
-sealed class SaveOutcome {
-  const SaveOutcome();
+sealed class UpdateOutcome {
+  const UpdateOutcome();
 }
 
-final class SaveInitial extends SaveOutcome {
-  const SaveInitial();
+final class UpdateInitial extends UpdateOutcome {
+  const UpdateInitial();
 }
 
-final class SaveSuccess extends SaveOutcome {
-  const SaveSuccess();
+final class UpdateSuccess extends UpdateOutcome {
+  const UpdateSuccess();
 }
 
-final class SaveCancelled extends SaveOutcome {
-  const SaveCancelled();
+final class UpdateCancelled extends UpdateOutcome {
+  const UpdateCancelled();
 }
 
-final class SaveDuplicateUrl extends SaveOutcome {
-  const SaveDuplicateUrl();
+final class UpdateDuplicateUrl extends UpdateOutcome {
+  const UpdateDuplicateUrl();
 }
 
-final class SaveUrlCheckFailed extends SaveOutcome {
-  const SaveUrlCheckFailed();
+final class UpdateUrlCheckFailed extends UpdateOutcome {
+  const UpdateUrlCheckFailed();
 }
 
-final class SaveApiError extends SaveOutcome {
-  const SaveApiError(this.error, this.version);
+final class UpdateApiError extends UpdateOutcome {
+  const UpdateApiError(this.error, this.version);
   final Exception error;
   final String version;
 }
 
-final class SaveDbError extends SaveOutcome {
-  const SaveDbError();
+final class UpdateDbError extends UpdateOutcome {
+  const UpdateDbError();
 }
 
-/// Orchestrates adding ([connect]) and editing ([save]) a Pi-hole server.
+/// Orchestrates adding ([createServer]) and editing ([updateServer]) a Pi-hole
+/// server.
 ///
 /// The view model owns the pure orchestration (URL uniqueness check, credential
 /// storage, session creation/teardown, blocking-status probe, DB commit and
@@ -173,42 +174,42 @@ class AddServerViewModel extends ChangeNotifier {
   }) : _serversViewModel = serversViewModel,
        _statusViewModel = statusViewModel,
        _createBundle = createBundle {
-    connect = Command.createAsync<ConnectRequest, ConnectOutcome>(
-      _connect,
-      initialValue: const ConnectInitial(),
+    createServer = Command.createAsync<CreateServerRequest, CreateOutcome>(
+      _createServer,
+      initialValue: const CreateInitial(),
     );
-    save = Command.createAsync<SaveRequest, SaveOutcome>(
-      _save,
-      initialValue: const SaveInitial(),
+    updateServer = Command.createAsync<UpdateServerRequest, UpdateOutcome>(
+      _updateServer,
+      initialValue: const UpdateInitial(),
     );
-    connect.addListener(notifyListeners);
-    save.addListener(notifyListeners);
+    createServer.addListener(notifyListeners);
+    updateServer.addListener(notifyListeners);
   }
 
   final ServersViewModel _serversViewModel;
   final StatusViewModel _statusViewModel;
   final CreateRepositoryBundle _createBundle;
 
-  late final Command<ConnectRequest, ConnectOutcome> connect;
-  late final Command<SaveRequest, SaveOutcome> save;
+  late final Command<CreateServerRequest, CreateOutcome> createServer;
+  late final Command<UpdateServerRequest, UpdateOutcome> updateServer;
 
   /// Adds a new server: checks the URL is not in use, saves the credentials,
   /// resolves the certificate, creates a v6 session if needed and checks the
   /// blocking status. Credentials saved during the attempt are removed on
   /// failure.
   ///
-  /// A cancelled or blocked certificate does not stop connect here (unlike
-  /// [_save]): it keeps the original server and the connection test below
-  /// reports any error.
+  /// A cancelled or blocked certificate does not stop create here (unlike
+  /// [_updateServer]): it keeps the original server and the connection test
+  /// below reports any error.
   ///
-  /// Returns [ConnectSuccess] with the server for the widget to save, or
-  /// [ConnectDuplicateUrl] / [ConnectUrlCheckFailed] / [ConnectApiError].
-  Future<ConnectOutcome> _connect(ConnectRequest req) async {
+  /// Returns [CreateSuccess] with the server for the widget to save, or
+  /// [CreateDuplicateUrl] / [CreateUrlCheckFailed] / [CreateApiError].
+  Future<CreateOutcome> _createServer(CreateServerRequest req) async {
     final exists = await _serversViewModel.checkUrlExists(req.url);
     if (exists['result'] == 'success' && exists['exists'] == true) {
-      return const ConnectDuplicateUrl();
+      return const CreateDuplicateUrl();
     } else if (exists['result'] == 'fail') {
-      return const ConnectUrlCheckFailed();
+      return const CreateUrlCheckFailed();
     }
 
     var serverObj = Server(
@@ -232,7 +233,7 @@ class AddServerViewModel extends ChangeNotifier {
       if (authResult.isError()) {
         await _serversViewModel.deletePassword(req.url);
         await _serversViewModel.deleteToken(req.url);
-        return ConnectApiError(authResult.exceptionOrNull()!, req.apiVersion);
+        return CreateApiError(authResult.exceptionOrNull()!, req.apiVersion);
       }
     }
     // Use skipRenewal: true because the session was just created above.
@@ -240,13 +241,13 @@ class AddServerViewModel extends ChangeNotifier {
     // Transient errors (e.g. network timeout) are still retried.
     final result = await bundle.dns.fetchBlockingStatus(skipRenewal: true);
     if (result.isSuccess()) {
-      return ConnectSuccess(
+      return CreateSuccess(
         serverObj.copyWith(defaultServer: req.defaultServer),
       );
     }
     await _serversViewModel.deletePassword(req.url);
     await _serversViewModel.deleteToken(req.url);
-    return ConnectApiError(result.exceptionOrNull()!, req.apiVersion);
+    return CreateApiError(result.exceptionOrNull()!, req.apiVersion);
   }
 
   /// Edits an existing server, keeping the old server's row, credentials and
@@ -259,12 +260,12 @@ class AddServerViewModel extends ChangeNotifier {
   /// rollback/old-session cleanup. Auto refresh is stopped while it runs and
   /// started again on every exit path.
   ///
-  /// A cancelled or blocked certificate stops the save ([SaveCancelled]); the
-  /// message was already shown by [SaveRequest.resolveCertificate].
+  /// A cancelled or blocked certificate stops the save ([UpdateCancelled]); the
+  /// message was already shown by [UpdateServerRequest.resolveCertificate].
   ///
-  /// Returns [SaveSuccess], [SaveCancelled], [SaveDuplicateUrl],
-  /// [SaveUrlCheckFailed], [SaveApiError] or [SaveDbError].
-  Future<SaveOutcome> _save(SaveRequest req) async {
+  /// Returns [UpdateSuccess], [UpdateCancelled], [UpdateDuplicateUrl],
+  /// [UpdateUrlCheckFailed], [UpdateApiError] or [UpdateDbError].
+  Future<UpdateOutcome> _updateServer(UpdateServerRequest req) async {
     final oldServer = req.oldServer;
     final oldAddress = oldServer.address;
     final newUrl = req.url;
@@ -277,9 +278,9 @@ class AddServerViewModel extends ChangeNotifier {
     if (isAddressChanged) {
       final exists = await _serversViewModel.checkUrlExists(newUrl);
       if (exists['result'] == 'success' && exists['exists'] == true) {
-        return const SaveDuplicateUrl();
+        return const UpdateDuplicateUrl();
       } else if (exists['result'] == 'fail') {
-        return const SaveUrlCheckFailed();
+        return const UpdateUrlCheckFailed();
       }
     }
 
@@ -313,7 +314,7 @@ class AddServerViewModel extends ChangeNotifier {
     final updatedServer = await req.resolveCertificate(serverObj);
     if (updatedServer == null) {
       restartAutoRefresh();
-      return const SaveCancelled();
+      return const UpdateCancelled();
     }
     serverObj = updatedServer;
 
@@ -365,10 +366,10 @@ class AddServerViewModel extends ChangeNotifier {
       }
     }
 
-    Future<SaveOutcome> handleSaveError(Exception e) async {
+    Future<UpdateOutcome> handleSaveError(Exception e) async {
       await restoreSecrets();
       restartAutoRefresh();
-      return SaveApiError(e, req.apiVersion);
+      return UpdateApiError(e, req.apiVersion);
     }
 
     final bundle = _createBundle(server: serverObj);
@@ -472,7 +473,7 @@ class AddServerViewModel extends ChangeNotifier {
           await _serversViewModel.deleteSid(targetAddress);
         }
         restartAutoRefresh();
-        return const SaveSuccess();
+        return const UpdateSuccess();
       } else {
         // DB write failed: roll back this attempt's artifacts; the old server
         // (row, credentials, session) is left fully intact.
@@ -481,7 +482,7 @@ class AddServerViewModel extends ChangeNotifier {
           sessionCreated: sessionJustCreated,
         );
         restartAutoRefresh();
-        return const SaveDbError();
+        return const UpdateDbError();
       }
     } else {
       await rollbackFailedSave(
@@ -489,14 +490,14 @@ class AddServerViewModel extends ChangeNotifier {
         sessionCreated: sessionJustCreated,
       );
       restartAutoRefresh();
-      return SaveApiError(result.exceptionOrNull()!, req.apiVersion);
+      return UpdateApiError(result.exceptionOrNull()!, req.apiVersion);
     }
   }
 
   @override
   void dispose() {
-    connect.removeListener(notifyListeners);
-    save.removeListener(notifyListeners);
+    createServer.removeListener(notifyListeners);
+    updateServer.removeListener(notifyListeners);
     super.dispose();
   }
 }

--- a/lib/ui/servers/view_models/add_server_viewmodel.dart
+++ b/lib/ui/servers/view_models/add_server_viewmodel.dart
@@ -158,6 +158,9 @@ final class UpdateDbError extends UpdateOutcome {
   const UpdateDbError();
 }
 
+/// Result of a server-URL uniqueness check.
+enum _UrlCheck { available, duplicate, failed }
+
 /// Orchestrates adding ([createServer]) and editing ([updateServer]) a Pi-hole
 /// server.
 ///
@@ -193,6 +196,13 @@ class AddServerViewModel extends ChangeNotifier {
   late final Command<CreateServerRequest, CreateOutcome> createServer;
   late final Command<UpdateServerRequest, UpdateOutcome> updateServer;
 
+  /// Maps [ServersViewModel.checkUrlExists]'s map result to a typed [_UrlCheck].
+  Future<_UrlCheck> _checkUrl(String url) async {
+    final result = await _serversViewModel.checkUrlExists(url);
+    if (result['result'] == 'fail') return _UrlCheck.failed;
+    return result['exists'] == true ? _UrlCheck.duplicate : _UrlCheck.available;
+  }
+
   /// Adds a new server: checks the URL is not in use, saves the credentials,
   /// resolves the certificate, creates a v6 session if needed and checks the
   /// blocking status. Credentials saved during the attempt are removed on
@@ -205,11 +215,13 @@ class AddServerViewModel extends ChangeNotifier {
   /// Returns [CreateSuccess] with the server for the widget to save, or
   /// [CreateDuplicateUrl] / [CreateUrlCheckFailed] / [CreateApiError].
   Future<CreateOutcome> _createServer(CreateServerRequest req) async {
-    final exists = await _serversViewModel.checkUrlExists(req.url);
-    if (exists['result'] == 'success' && exists['exists'] == true) {
-      return const CreateDuplicateUrl();
-    } else if (exists['result'] == 'fail') {
-      return const CreateUrlCheckFailed();
+    switch (await _checkUrl(req.url)) {
+      case _UrlCheck.duplicate:
+        return const CreateDuplicateUrl();
+      case _UrlCheck.failed:
+        return const CreateUrlCheckFailed();
+      case _UrlCheck.available:
+        break;
     }
 
     var serverObj = Server(
@@ -276,11 +288,13 @@ class AddServerViewModel extends ChangeNotifier {
     // When the address (primary key) changes, make sure the new URL is not
     // already used by another server before doing anything destructive.
     if (isAddressChanged) {
-      final exists = await _serversViewModel.checkUrlExists(newUrl);
-      if (exists['result'] == 'success' && exists['exists'] == true) {
-        return const UpdateDuplicateUrl();
-      } else if (exists['result'] == 'fail') {
-        return const UpdateUrlCheckFailed();
+      switch (await _checkUrl(newUrl)) {
+        case _UrlCheck.duplicate:
+          return const UpdateDuplicateUrl();
+        case _UrlCheck.failed:
+          return const UpdateUrlCheckFailed();
+        case _UrlCheck.available:
+          break;
       }
     }
 

--- a/lib/ui/servers/view_models/add_server_viewmodel.dart
+++ b/lib/ui/servers/view_models/add_server_viewmodel.dart
@@ -303,41 +303,6 @@ class AddServerViewModel extends ChangeNotifier {
 
     final targetAddress = isAddressChanged ? newUrl : oldAddress;
 
-    var serverObj = Server(
-      address: targetAddress,
-      alias: req.alias,
-      apiVersion: req.apiVersion,
-      allowUntrustedCert: req.allowUntrustedCert,
-      ignoreCertificateErrors: req.ignoreCertificateErrors,
-      // When the address changes the target is effectively a different host, so
-      // any pinned certificate carried over from the old server is stale. Reset
-      // it to null so the certificate check re-runs against the new host.
-      pinnedCertificateSha256: isAddressChanged
-          ? null
-          : req.pinnedCertificateSha256,
-    );
-
-    if (_serversViewModel.selectedServer != null) {
-      _statusViewModel.stopAutoRefresh();
-    }
-
-    void restartAutoRefresh() {
-      if (_serversViewModel.selectedServer != null) {
-        _statusViewModel.startAutoRefresh();
-      }
-    }
-
-    // Validate certificate BEFORE connection test (same as connect()).
-    final updatedServer = await req.resolveCertificate(serverObj);
-    if (updatedServer == null) {
-      restartAutoRefresh();
-      return const UpdateCancelled();
-    }
-    serverObj = updatedServer;
-
-    await _serversViewModel.savePassword(targetAddress, req.password);
-    await _serversViewModel.saveToken(targetAddress, req.token);
-
     // Only restore when the original secrets were actually read. If the initial
     // load failed, initPassword/initToken are empty placeholders and writing
     // them back would wipe a credential that is still in secure storage.
@@ -346,6 +311,18 @@ class AddServerViewModel extends ChangeNotifier {
         await _serversViewModel.savePassword(oldAddress, req.initPassword);
         await _serversViewModel.saveToken(oldAddress, req.initToken);
       }
+    }
+
+    void restartAutoRefresh() {
+      if (_serversViewModel.selectedServer != null) {
+        _statusViewModel.startAutoRefresh();
+      }
+    }
+
+    Future<UpdateOutcome> handleSaveError(Exception e) async {
+      await restoreSecrets();
+      restartAutoRefresh();
+      return UpdateApiError(e, req.apiVersion);
     }
 
     // Rolls back everything written for THIS save attempt on failure, always
@@ -383,11 +360,34 @@ class AddServerViewModel extends ChangeNotifier {
       }
     }
 
-    Future<UpdateOutcome> handleSaveError(Exception e) async {
-      await restoreSecrets();
-      restartAutoRefresh();
-      return UpdateApiError(e, req.apiVersion);
+    var serverObj = Server(
+      address: targetAddress,
+      alias: req.alias,
+      apiVersion: req.apiVersion,
+      allowUntrustedCert: req.allowUntrustedCert,
+      ignoreCertificateErrors: req.ignoreCertificateErrors,
+      // When the address changes the target is effectively a different host, so
+      // any pinned certificate carried over from the old server is stale. Reset
+      // it to null so the certificate check re-runs against the new host.
+      pinnedCertificateSha256: isAddressChanged
+          ? null
+          : req.pinnedCertificateSha256,
+    );
+
+    if (_serversViewModel.selectedServer != null) {
+      _statusViewModel.stopAutoRefresh();
     }
+
+    // Validate certificate BEFORE connection test (same as connect()).
+    final updatedServer = await req.resolveCertificate(serverObj);
+    if (updatedServer == null) {
+      restartAutoRefresh();
+      return const UpdateCancelled();
+    }
+    serverObj = updatedServer;
+
+    await _serversViewModel.savePassword(targetAddress, req.password);
+    await _serversViewModel.saveToken(targetAddress, req.token);
 
     final bundle = _createBundle(server: serverObj);
     final auth = await _authenticate(
@@ -403,17 +403,16 @@ class AddServerViewModel extends ChangeNotifier {
       }
       return handleSaveError(auth.error!);
     }
-    final sessionJustCreated = auth.sessionCreated;
     // skipRenewal: true only when a new session was just created above to avoid
     // creating a duplicate session on transient retry failures.
     final result = await bundle.dns.fetchBlockingStatus(
-      skipRenewal: sessionJustCreated,
+      skipRenewal: auth.sessionCreated,
     );
 
     if (result.isError()) {
       await rollbackFailedSave(
         bundle: bundle,
-        sessionCreated: sessionJustCreated,
+        sessionCreated: auth.sessionCreated,
       );
       restartAutoRefresh();
       return UpdateApiError(result.exceptionOrNull()!, req.apiVersion);
@@ -430,7 +429,7 @@ class AddServerViewModel extends ChangeNotifier {
       // (row, credentials, session) is left fully intact.
       await rollbackFailedSave(
         bundle: bundle,
-        sessionCreated: sessionJustCreated,
+        sessionCreated: auth.sessionCreated,
       );
       restartAutoRefresh();
       return const UpdateDbError();

--- a/lib/ui/servers/view_models/add_server_viewmodel.dart
+++ b/lib/ui/servers/view_models/add_server_viewmodel.dart
@@ -1,0 +1,502 @@
+// NOTE: This view model intentionally depends on [ServersViewModel] and
+// [StatusViewModel] (a cross-view-model dependency). The server-list mutations
+// (addServer/editServer/replaceServer) are Commands whose notify/refresh side
+// effects must be preserved, so the orchestration reuses them rather than the
+// lower-level repositories. The certificate UI (pin dialog, ssl error snackbar)
+// stays in the widget and is injected per request via [resolveCertificate].
+import 'package:command_it/command_it.dart';
+import 'package:flutter/foundation.dart';
+import 'package:pi_hole_client/data/repositories/api/interfaces/repository_bundle.dart';
+import 'package:pi_hole_client/domain/model/server/api_versions.dart';
+import 'package:pi_hole_client/domain/model/server/server.dart';
+import 'package:pi_hole_client/ui/core/view_models/servers_viewmodel.dart';
+import 'package:pi_hole_client/ui/core/view_models/status_viewmodel.dart';
+import 'package:pi_hole_client/utils/exceptions.dart';
+import 'package:pi_hole_client/utils/logger.dart';
+import 'package:pi_hole_client/utils/url.dart';
+
+/// Resolves and validates the certificate for [server], returning the updated
+/// server (possibly with a pinned fingerprint) or `null` when the user cancels
+/// or the certificate is rejected. The dialog and ssl-error snackbar live in the
+/// widget; the view model only decides what to do with the result.
+typedef ResolveCertificate = Future<Server?> Function(Server server);
+
+/// Request for [AddServerViewModel.connect] (adding a new server).
+class ConnectRequest {
+  const ConnectRequest({
+    required this.url,
+    required this.alias,
+    required this.apiVersion,
+    required this.allowUntrustedCert,
+    required this.ignoreCertificateErrors,
+    required this.pinnedCertificateSha256,
+    required this.password,
+    required this.token,
+    required this.defaultServer,
+    required this.resolveCertificate,
+  });
+
+  final String url;
+  final String alias;
+  final String apiVersion;
+  final bool allowUntrustedCert;
+  final bool ignoreCertificateErrors;
+  final String? pinnedCertificateSha256;
+  final String password;
+  final String token;
+  final bool defaultServer;
+  final ResolveCertificate resolveCertificate;
+}
+
+/// Request for [AddServerViewModel.save] (editing an existing server).
+class SaveRequest {
+  const SaveRequest({
+    required this.url,
+    required this.alias,
+    required this.apiVersion,
+    required this.allowUntrustedCert,
+    required this.ignoreCertificateErrors,
+    required this.pinnedCertificateSha256,
+    required this.password,
+    required this.token,
+    required this.defaultServer,
+    required this.oldServer,
+    required this.initPassword,
+    required this.initToken,
+    required this.secretsLoadSucceeded,
+    required this.resolveCertificate,
+  });
+
+  final String url;
+  final String alias;
+  final String apiVersion;
+  final bool allowUntrustedCert;
+  final bool ignoreCertificateErrors;
+  final String? pinnedCertificateSha256;
+  final String password;
+  final String token;
+  final bool defaultServer;
+  final Server oldServer;
+
+  /// The credentials originally loaded for [oldServer]. Used to restore the old
+  /// secrets when a save attempt fails.
+  final String initPassword;
+  final String initToken;
+
+  /// Whether the stored secrets were actually read. When false the restore is
+  /// skipped so empty placeholders never overwrite a credential still in secure
+  /// storage.
+  final bool secretsLoadSucceeded;
+
+  final ResolveCertificate resolveCertificate;
+}
+
+// ==================================================================
+// Outcome of [AddServerViewModel.connect], mapped to UI reactions by the widget.
+// ==================================================================
+sealed class ConnectOutcome {
+  const ConnectOutcome();
+}
+
+final class ConnectInitial extends ConnectOutcome {
+  const ConnectInitial();
+}
+
+final class ConnectSuccess extends ConnectOutcome {
+  const ConnectSuccess(this.server);
+  final Server server;
+}
+
+final class ConnectDuplicateUrl extends ConnectOutcome {
+  const ConnectDuplicateUrl();
+}
+
+final class ConnectUrlCheckFailed extends ConnectOutcome {
+  const ConnectUrlCheckFailed();
+}
+
+final class ConnectApiError extends ConnectOutcome {
+  const ConnectApiError(this.error, this.version);
+  final Exception error;
+  final String version;
+}
+
+// ==================================================================
+// Outcome of [AddServerViewModel.save], mapped to UI reactions by the widget.
+// ==================================================================
+sealed class SaveOutcome {
+  const SaveOutcome();
+}
+
+final class SaveInitial extends SaveOutcome {
+  const SaveInitial();
+}
+
+final class SaveSuccess extends SaveOutcome {
+  const SaveSuccess();
+}
+
+final class SaveCancelled extends SaveOutcome {
+  const SaveCancelled();
+}
+
+final class SaveDuplicateUrl extends SaveOutcome {
+  const SaveDuplicateUrl();
+}
+
+final class SaveUrlCheckFailed extends SaveOutcome {
+  const SaveUrlCheckFailed();
+}
+
+final class SaveApiError extends SaveOutcome {
+  const SaveApiError(this.error, this.version);
+  final Exception error;
+  final String version;
+}
+
+final class SaveDbError extends SaveOutcome {
+  const SaveDbError();
+}
+
+/// Orchestrates adding ([connect]) and editing ([save]) a Pi-hole server.
+///
+/// The view model owns the pure orchestration (URL uniqueness check, credential
+/// storage, session creation/teardown, blocking-status probe, DB commit and
+/// rollback). UI reactions (snackbars, navigation, the certificate dialog and
+/// the connecting overlay) stay in the widget and are driven by the returned
+/// sealed outcomes and the Commands' [Command.isRunning].
+class AddServerViewModel extends ChangeNotifier {
+  AddServerViewModel({
+    required ServersViewModel serversViewModel,
+    required StatusViewModel statusViewModel,
+    required CreateRepositoryBundle createBundle,
+  }) : _serversViewModel = serversViewModel,
+       _statusViewModel = statusViewModel,
+       _createBundle = createBundle {
+    connect = Command.createAsync<ConnectRequest, ConnectOutcome>(
+      _connect,
+      initialValue: const ConnectInitial(),
+    );
+    save = Command.createAsync<SaveRequest, SaveOutcome>(
+      _save,
+      initialValue: const SaveInitial(),
+    );
+    connect.addListener(notifyListeners);
+    save.addListener(notifyListeners);
+  }
+
+  final ServersViewModel _serversViewModel;
+  final StatusViewModel _statusViewModel;
+  final CreateRepositoryBundle _createBundle;
+
+  late final Command<ConnectRequest, ConnectOutcome> connect;
+  late final Command<SaveRequest, SaveOutcome> save;
+
+  /// Adds a new server: checks the URL is not in use, saves the credentials,
+  /// resolves the certificate, creates a v6 session if needed and checks the
+  /// blocking status. Credentials saved during the attempt are removed on
+  /// failure.
+  ///
+  /// A cancelled or blocked certificate does not stop connect here (unlike
+  /// [_save]): it keeps the original server and the connection test below
+  /// reports any error.
+  ///
+  /// Returns [ConnectSuccess] with the server for the widget to save, or
+  /// [ConnectDuplicateUrl] / [ConnectUrlCheckFailed] / [ConnectApiError].
+  Future<ConnectOutcome> _connect(ConnectRequest req) async {
+    final exists = await _serversViewModel.checkUrlExists(req.url);
+    if (exists['result'] == 'success' && exists['exists'] == true) {
+      return const ConnectDuplicateUrl();
+    } else if (exists['result'] == 'fail') {
+      return const ConnectUrlCheckFailed();
+    }
+
+    var serverObj = Server(
+      address: req.url,
+      alias: req.alias,
+      apiVersion: req.apiVersion,
+      allowUntrustedCert: req.allowUntrustedCert,
+      ignoreCertificateErrors: req.ignoreCertificateErrors,
+      pinnedCertificateSha256: req.pinnedCertificateSha256,
+    );
+    await _serversViewModel.savePassword(req.url, req.password);
+    await _serversViewModel.saveToken(req.url, req.token);
+
+    // A cancelled/blocked certificate falls back to the original server; the
+    // connection test below reports the error (same as the old widget).
+    serverObj = await req.resolveCertificate(serverObj) ?? serverObj;
+
+    final bundle = _createBundle(server: serverObj);
+    if (serverObj.apiVersion == SupportedApiVersions.v6) {
+      final authResult = await bundle.auth.createSession(req.password);
+      if (authResult.isError()) {
+        await _serversViewModel.deletePassword(req.url);
+        await _serversViewModel.deleteToken(req.url);
+        return ConnectApiError(authResult.exceptionOrNull()!, req.apiVersion);
+      }
+    }
+    // Use skipRenewal: true because the session was just created above.
+    // Retrying with clearAndRenewSid would create a duplicate session.
+    // Transient errors (e.g. network timeout) are still retried.
+    final result = await bundle.dns.fetchBlockingStatus(skipRenewal: true);
+    if (result.isSuccess()) {
+      return ConnectSuccess(
+        serverObj.copyWith(defaultServer: req.defaultServer),
+      );
+    }
+    await _serversViewModel.deletePassword(req.url);
+    await _serversViewModel.deleteToken(req.url);
+    return ConnectApiError(result.exceptionOrNull()!, req.apiVersion);
+  }
+
+  /// Edits an existing server, keeping the old server's row, credentials and
+  /// session unchanged until this attempt fully succeeds.
+  ///
+  /// Handles the address-changed (replace) vs same-address (in-place edit) paths,
+  /// the v6 login branches (an address change always creates a session; a
+  /// changed password is checked by creating one; an unchanged password keeps
+  /// the current session and only logs in again on a 401), the DB save, and the
+  /// rollback/old-session cleanup. Auto refresh is stopped while it runs and
+  /// started again on every exit path.
+  ///
+  /// A cancelled or blocked certificate stops the save ([SaveCancelled]); the
+  /// message was already shown by [SaveRequest.resolveCertificate].
+  ///
+  /// Returns [SaveSuccess], [SaveCancelled], [SaveDuplicateUrl],
+  /// [SaveUrlCheckFailed], [SaveApiError] or [SaveDbError].
+  Future<SaveOutcome> _save(SaveRequest req) async {
+    final oldServer = req.oldServer;
+    final oldAddress = oldServer.address;
+    final newUrl = req.url;
+    // Normalised comparison: a host-case-only or trailing-slash difference is
+    // NOT an address change and must stay on the in-place editServer path.
+    final isAddressChanged = !isSameEndpoint(oldAddress, newUrl);
+
+    // When the address (primary key) changes, make sure the new URL is not
+    // already used by another server before doing anything destructive.
+    if (isAddressChanged) {
+      final exists = await _serversViewModel.checkUrlExists(newUrl);
+      if (exists['result'] == 'success' && exists['exists'] == true) {
+        return const SaveDuplicateUrl();
+      } else if (exists['result'] == 'fail') {
+        return const SaveUrlCheckFailed();
+      }
+    }
+
+    final targetAddress = isAddressChanged ? newUrl : oldAddress;
+
+    var serverObj = Server(
+      address: targetAddress,
+      alias: req.alias,
+      apiVersion: req.apiVersion,
+      allowUntrustedCert: req.allowUntrustedCert,
+      ignoreCertificateErrors: req.ignoreCertificateErrors,
+      // When the address changes the target is effectively a different host, so
+      // any pinned certificate carried over from the old server is stale. Reset
+      // it to null so the certificate check re-runs against the new host.
+      pinnedCertificateSha256: isAddressChanged
+          ? null
+          : req.pinnedCertificateSha256,
+    );
+
+    if (_serversViewModel.selectedServer != null) {
+      _statusViewModel.stopAutoRefresh();
+    }
+
+    void restartAutoRefresh() {
+      if (_serversViewModel.selectedServer != null) {
+        _statusViewModel.startAutoRefresh();
+      }
+    }
+
+    // Validate certificate BEFORE connection test (same as connect()).
+    final updatedServer = await req.resolveCertificate(serverObj);
+    if (updatedServer == null) {
+      restartAutoRefresh();
+      return const SaveCancelled();
+    }
+    serverObj = updatedServer;
+
+    await _serversViewModel.savePassword(targetAddress, req.password);
+    await _serversViewModel.saveToken(targetAddress, req.token);
+
+    // Only restore when the original secrets were actually read. If the initial
+    // load failed, initPassword/initToken are empty placeholders and writing
+    // them back would wipe a credential that is still in secure storage.
+    Future<void> restoreSecrets() async {
+      if (req.secretsLoadSucceeded) {
+        await _serversViewModel.savePassword(oldAddress, req.initPassword);
+        await _serversViewModel.saveToken(oldAddress, req.initToken);
+      }
+    }
+
+    // Rolls back everything written for THIS save attempt on failure, always
+    // leaving the old server (row, credentials, session) untouched.
+    //
+    // - Address change: remove the credentials and SID written under the new
+    //   address plus the freshly created remote session.
+    // - Same address: restore the old credentials and, when a new session was
+    //   created during this attempt, tear it down so it does not leak.
+    Future<void> rollbackFailedSave({
+      required RepositoryBundle bundle,
+      required bool sessionCreated,
+    }) async {
+      Future<void> deleteNewSession() async {
+        if (!sessionCreated) return;
+        try {
+          await bundle.auth.deleteCurrentSession();
+        } catch (e, s) {
+          logger.w(
+            'Failed to delete new session on server',
+            error: e,
+            stackTrace: s,
+          );
+        }
+      }
+
+      if (isAddressChanged) {
+        await _serversViewModel.deletePassword(targetAddress);
+        await _serversViewModel.deleteToken(targetAddress);
+        await _serversViewModel.deleteSid(targetAddress);
+        await deleteNewSession();
+      } else {
+        await deleteNewSession();
+        await restoreSecrets();
+      }
+    }
+
+    Future<SaveOutcome> handleSaveError(Exception e) async {
+      await restoreSecrets();
+      restartAutoRefresh();
+      return SaveApiError(e, req.apiVersion);
+    }
+
+    final bundle = _createBundle(server: serverObj);
+    var sessionJustCreated = false;
+    if (serverObj.apiVersion == SupportedApiVersions.v6) {
+      if (isAddressChanged) {
+        // The new address has no existing session, so always create one.
+        final authResult = await bundle.auth.createSession(req.password);
+        if (authResult.isError()) {
+          await rollbackFailedSave(bundle: bundle, sessionCreated: false);
+          return handleSaveError(authResult.exceptionOrNull()!);
+        }
+        sessionJustCreated = true;
+      } else if (req.password != req.initPassword) {
+        // Same address but the password was edited. Validate it now by creating
+        // a session: an unverified (possibly wrong) password would otherwise
+        // silently overwrite the known-good one and lock the user out the
+        // moment the current SID is invalidated.
+        final authResult = await bundle.auth.createSession(req.password);
+        if (authResult.isError()) {
+          return handleSaveError(authResult.exceptionOrNull()!);
+        }
+        sessionJustCreated = true;
+      } else {
+        // Same address, unchanged password: reuse the existing session if it is
+        // still valid. Only re-authenticate on 401/SidNotFoundException to
+        // avoid session multiplication when the server is temporarily
+        // unreachable (503/504/timeout).
+        final preCheck = await bundle.dns.fetchBlockingStatus(
+          skipRenewal: true,
+        );
+        if (preCheck.isError()) {
+          final err = preCheck.exceptionOrNull();
+          if (!isReauthRequired(err)) {
+            return handleSaveError(err!);
+          }
+          final authResult = await bundle.auth.createSession(req.password);
+          if (authResult.isError()) {
+            return handleSaveError(authResult.exceptionOrNull()!);
+          }
+          sessionJustCreated = true;
+        }
+      }
+    }
+    // skipRenewal: true only when a new session was just created above to avoid
+    // creating a duplicate session on transient retry failures.
+    final result = await bundle.dns.fetchBlockingStatus(
+      skipRenewal: sessionJustCreated,
+    );
+
+    if (result.isSuccess()) {
+      final server = serverObj.copyWith(defaultServer: req.defaultServer);
+
+      Object? cmdError;
+      try {
+        if (isAddressChanged) {
+          await _serversViewModel.replaceServer.runAsync((
+            oldAddress: oldAddress,
+            newServer: server,
+          ));
+          cmdError = _serversViewModel.replaceServer.errors.value;
+        } else {
+          await _serversViewModel.editServer.runAsync(server);
+          cmdError = _serversViewModel.editServer.errors.value;
+        }
+      } catch (e, s) {
+        logger.e('Failed to save server', error: e, stackTrace: s);
+        cmdError = e;
+      }
+
+      if (cmdError == null) {
+        // The old v6 session is orphaned on an address change or a switch away
+        // from v6 (e.g. v6 -> v5). Run only after the DB commit so a failed
+        // save can't kill a live session.
+        final oldWasV6 = oldServer.apiVersion == SupportedApiVersions.v6;
+        final newIsV6 = serverObj.apiVersion == SupportedApiVersions.v6;
+
+        // 1. Log out the old v6 session.
+        if (oldWasV6 && (isAddressChanged || !newIsV6)) {
+          try {
+            final oldBundle = _createBundle(server: oldServer);
+            await oldBundle.auth.deleteCurrentSession();
+          } catch (e, s) {
+            logger.w(
+              'Failed to delete old session on server',
+              error: e,
+              stackTrace: s,
+            );
+          }
+        }
+
+        // 2. Now safe to drop the old server's credentials.
+        if (isAddressChanged) {
+          // New credentials already live under the new address; remove the
+          // stale ones left behind under the old address.
+          await _serversViewModel.deleteToken(oldAddress);
+          await _serversViewModel.deletePassword(oldAddress);
+          await _serversViewModel.deleteSid(oldAddress);
+        } else if (oldWasV6 && !newIsV6) {
+          // Same address, v6 -> v5: the SID is now unused.
+          await _serversViewModel.deleteSid(targetAddress);
+        }
+        restartAutoRefresh();
+        return const SaveSuccess();
+      } else {
+        // DB write failed: roll back this attempt's artifacts; the old server
+        // (row, credentials, session) is left fully intact.
+        await rollbackFailedSave(
+          bundle: bundle,
+          sessionCreated: sessionJustCreated,
+        );
+        restartAutoRefresh();
+        return const SaveDbError();
+      }
+    } else {
+      await rollbackFailedSave(
+        bundle: bundle,
+        sessionCreated: sessionJustCreated,
+      );
+      restartAutoRefresh();
+      return SaveApiError(result.exceptionOrNull()!, req.apiVersion);
+    }
+  }
+
+  @override
+  void dispose() {
+    connect.removeListener(notifyListeners);
+    save.removeListener(notifyListeners);
+    super.dispose();
+  }
+}

--- a/lib/ui/servers/view_models/add_server_viewmodel.dart
+++ b/lib/ui/servers/view_models/add_server_viewmodel.dart
@@ -107,6 +107,10 @@ final class CreateSuccess extends CreateOutcome {
   final Server server;
 }
 
+final class CreateCancelled extends CreateOutcome {
+  const CreateCancelled();
+}
+
 final class CreateDuplicateUrl extends CreateOutcome {
   const CreateDuplicateUrl();
 }
@@ -203,17 +207,17 @@ class AddServerViewModel extends ChangeNotifier {
     return result['exists'] == true ? _UrlCheck.duplicate : _UrlCheck.available;
   }
 
-  /// Adds a new server: checks the URL is not in use, saves the credentials,
-  /// resolves the certificate, creates a v6 session if needed and checks the
+  /// Adds a new server: checks the URL is not in use, resolves the certificate,
+  /// saves the credentials, creates a v6 session if needed and checks the
   /// blocking status. Credentials saved during the attempt are removed on
   /// failure.
   ///
-  /// A cancelled or blocked certificate does not stop create here (unlike
-  /// [_updateServer]): it keeps the original server and the connection test
-  /// below reports any error.
+  /// A cancelled or blocked certificate aborts the add ([CreateCancelled])
+  /// before anything is saved.
   ///
   /// Returns [CreateSuccess] with the server for the widget to save, or
-  /// [CreateDuplicateUrl] / [CreateUrlCheckFailed] / [CreateApiError].
+  /// [CreateCancelled] / [CreateDuplicateUrl] / [CreateUrlCheckFailed] /
+  /// [CreateApiError].
   Future<CreateOutcome> _createServer(CreateServerRequest req) async {
     switch (await _checkUrl(req.url)) {
       case _UrlCheck.duplicate:
@@ -232,12 +236,17 @@ class AddServerViewModel extends ChangeNotifier {
       ignoreCertificateErrors: req.ignoreCertificateErrors,
       pinnedCertificateSha256: req.pinnedCertificateSha256,
     );
+
+    // Resolve the certificate before saving anything, so a cancel/block aborts
+    // cleanly with nothing to undo (same order as updateServer).
+    final resolved = await req.resolveCertificate(serverObj);
+    if (resolved == null) {
+      return const CreateCancelled();
+    }
+    serverObj = resolved;
+
     await _serversViewModel.savePassword(req.url, req.password);
     await _serversViewModel.saveToken(req.url, req.token);
-
-    // A cancelled/blocked certificate falls back to the original server; the
-    // connection test below reports the error (same as the old widget).
-    serverObj = await req.resolveCertificate(serverObj) ?? serverObj;
 
     final bundle = _createBundle(server: serverObj);
     if (serverObj.apiVersion == SupportedApiVersions.v6) {

--- a/lib/ui/servers/view_models/add_server_viewmodel.dart
+++ b/lib/ui/servers/view_models/add_server_viewmodel.dart
@@ -172,7 +172,7 @@ enum _UrlCheck { available, duplicate, failed }
 /// storage, session creation/teardown, blocking-status probe, DB commit and
 /// rollback). UI reactions (snackbars, navigation, the certificate dialog and
 /// the connecting overlay) stay in the widget and are driven by the returned
-/// sealed outcomes and the Commands' [Command.isRunning].
+/// sealed outcomes.
 class AddServerViewModel extends ChangeNotifier {
   AddServerViewModel({
     required ServersViewModel serversViewModel,

--- a/lib/ui/servers/widgets/add_server_fullscreen.dart
+++ b/lib/ui/servers/widgets/add_server_fullscreen.dart
@@ -133,62 +133,48 @@ class _AddServerFullscreenState extends State<AddServerFullscreen> {
     setState(() {});
   }
 
-  void validateAddress(String? value) {
+  /// Runs [isValid] on a non-empty [value] and stores the resulting error via
+  /// [setError]: [invalidMessage] when invalid, [emptyMessage] when empty.
+  void _validateField(
+    String? value, {
+    required bool Function(String) isValid,
+    required String invalidMessage,
+    required String? emptyMessage,
+    required void Function(String?) setError,
+  }) {
+    final String? error;
     if (value != null && value != '') {
-      if (isValidServerAddress(value)) {
-        setState(() {
-          addressFieldError = null;
-        });
-      } else {
-        setState(() {
-          addressFieldError = AppLocalizations.of(context)!.invalidAddress;
-        });
-      }
+      error = isValid(value) ? null : invalidMessage;
     } else {
-      setState(() {
-        addressFieldError = AppLocalizations.of(context)!.ipCannotEmpty;
-      });
+      error = emptyMessage;
     }
+    setState(() => setError(error));
     checkDataValid();
   }
 
-  void validateSubroute(String? value) {
-    if (value != null && value != '') {
-      if (isValidSubroute(value)) {
-        setState(() {
-          subrouteFieldError = null;
-        });
-      } else {
-        setState(() {
-          subrouteFieldError = AppLocalizations.of(context)!.invalidSubroute;
-        });
-      }
-    } else {
-      setState(() {
-        subrouteFieldError = null;
-      });
-    }
-    checkDataValid();
-  }
+  void validateAddress(String? value) => _validateField(
+    value,
+    isValid: isValidServerAddress,
+    invalidMessage: AppLocalizations.of(context)!.invalidAddress,
+    emptyMessage: AppLocalizations.of(context)!.ipCannotEmpty,
+    setError: (e) => addressFieldError = e,
+  );
 
-  void validatePort(String? value) {
-    if (value != null && value != '') {
-      if (isValidPort(value)) {
-        setState(() {
-          portFieldError = null;
-        });
-      } else {
-        setState(() {
-          portFieldError = AppLocalizations.of(context)!.invalidPort;
-        });
-      }
-    } else {
-      setState(() {
-        portFieldError = null;
-      });
-    }
-    checkDataValid();
-  }
+  void validateSubroute(String? value) => _validateField(
+    value,
+    isValid: isValidSubroute,
+    invalidMessage: AppLocalizations.of(context)!.invalidSubroute,
+    emptyMessage: null,
+    setError: (e) => subrouteFieldError = e,
+  );
+
+  void validatePort(String? value) => _validateField(
+    value,
+    isValid: isValidPort,
+    invalidMessage: AppLocalizations.of(context)!.invalidPort,
+    emptyMessage: null,
+    setError: (e) => portFieldError = e,
+  );
 
   Future<void> _loadSecrets() async {
     var password = '';
@@ -692,18 +678,20 @@ class _AddServerFullscreenState extends State<AddServerFullscreen> {
   }
 
   bool validData() {
-    if (addressFieldController.text != '' &&
+    final fieldsFilled =
+        addressFieldController.text != '' &&
         subrouteFieldError == null &&
         addressFieldError == null &&
         portFieldError == null &&
-        aliasFieldController.text != '') {
-      if (widget.server != null) {
-        if (!_secretsLoaded) return false;
-      }
-      return true;
-    } else {
-      return false;
-    }
+        aliasFieldController.text != '';
+    if (!fieldsFilled) return false;
+
+    // In edit mode the Save button stays disabled until the stored secrets have
+    // loaded, so a save can't overwrite credentials before they are ready.
+    final isEditMode = widget.server != null;
+    if (isEditMode && !_secretsLoaded) return false;
+
+    return true;
   }
 
   void openScanTokenModal() {

--- a/lib/ui/servers/widgets/add_server_fullscreen.dart
+++ b/lib/ui/servers/widgets/add_server_fullscreen.dart
@@ -60,12 +60,6 @@ class _AddServerFullscreenState extends State<AddServerFullscreen> {
   bool ignoreCertificateErrors = false;
   String? pinnedCertificateSha256;
 
-  bool allDataValid = false;
-
-  String errorMessage = 'Failed';
-
-  bool isTokenModalOpen = false;
-
   bool isConnecting = false;
 
   /// Created lazily on the first connect/save so that simply opening this
@@ -133,20 +127,9 @@ class _AddServerFullscreenState extends State<AddServerFullscreen> {
     );
   }
 
+  /// Rebuilds so the Save/Connect button re-evaluates [validData].
   void checkDataValid() {
-    if (addressFieldController.text != '' &&
-        addressFieldError == null &&
-        subrouteFieldError == null &&
-        portFieldError == null &&
-        aliasFieldController.text != '') {
-      setState(() {
-        allDataValid = true;
-      });
-    } else {
-      setState(() {
-        allDataValid = false;
-      });
-    }
+    setState(() {});
   }
 
   void validateAddress(String? value) {

--- a/lib/ui/servers/widgets/add_server_fullscreen.dart
+++ b/lib/ui/servers/widgets/add_server_fullscreen.dart
@@ -14,6 +14,7 @@ import 'package:pi_hole_client/ui/core/ui/modals/scan_token_modal.dart';
 import 'package:pi_hole_client/ui/core/view_models/app_config_viewmodel.dart';
 import 'package:pi_hole_client/ui/core/view_models/servers_viewmodel.dart';
 import 'package:pi_hole_client/ui/core/view_models/status_viewmodel.dart';
+import 'package:pi_hole_client/ui/servers/view_models/add_server_viewmodel.dart';
 import 'package:pi_hole_client/ui/servers/widgets/certificate_details_dialog.dart';
 import 'package:pi_hole_client/utils/exceptions.dart';
 import 'package:pi_hole_client/utils/logger.dart';
@@ -67,6 +68,11 @@ class _AddServerFullscreenState extends State<AddServerFullscreen> {
 
   bool isConnecting = false;
 
+  /// Created lazily on the first connect/save so that simply opening this
+  /// screen (e.g. the add-server dialog) does not require the repository-bundle
+  /// factory and status view model to be in scope.
+  AddServerViewModel? _viewModel;
+
   String? initToken;
   String? initPassword;
   bool _advancedOptionsExpanded = false;
@@ -77,8 +83,9 @@ class _AddServerFullscreenState extends State<AddServerFullscreen> {
   bool _secretsLoaded = true;
 
   /// Whether [_loadSecrets] actually read the stored secrets. Stays false when
-  /// the secure-storage read fails, so [_restoreSecrets] won't write back the
-  /// empty placeholders and wipe a credential that is still present.
+  /// the secure-storage read fails, so the save rollback won't write back the
+  /// empty placeholders and wipe a credential that is still present. Forwarded
+  /// to the view model via [SaveRequest.secretsLoadSucceeded].
   bool _secretsLoadSucceeded = false;
 
   @override
@@ -108,6 +115,22 @@ class _AddServerFullscreenState extends State<AddServerFullscreen> {
       _secretsLoaded = false;
       _loadSecrets();
     }
+  }
+
+  @override
+  void dispose() {
+    _viewModel?.dispose();
+    super.dispose();
+  }
+
+  /// Lazily builds the view model on first use, reading its dependencies from
+  /// the provider scope only when a connect/save is actually triggered.
+  AddServerViewModel _ensureViewModel() {
+    return _viewModel ??= AddServerViewModel(
+      serversViewModel: context.read<ServersViewModel>(),
+      statusViewModel: context.read<StatusViewModel>(),
+      createBundle: context.read<CreateRepositoryBundle>(),
+    );
   }
 
   void checkDataValid() {
@@ -225,1061 +248,9 @@ class _AddServerFullscreenState extends State<AddServerFullscreen> {
     }
   }
 
-  Future<void> _restoreSecrets() async {
-    // Only restore when the original secrets were actually read. If the initial
-    // load failed, initPassword/initToken are empty placeholders and writing
-    // them back would wipe a credential that is still in secure storage.
-    if (widget.server != null && _secretsLoadSucceeded) {
-      final serversViewModel = context.read<ServersViewModel>();
-      await serversViewModel.savePassword(
-        widget.server!.address,
-        initPassword ?? '',
-      );
-      await serversViewModel.saveToken(widget.server!.address, initToken ?? '');
-    }
-  }
-
   @override
   Widget build(BuildContext context) {
-    final serversViewModel = Provider.of<ServersViewModel>(context);
-    final appConfigViewModel = Provider.of<AppConfigViewModel>(context);
-    final statusViewModel = context.read<StatusViewModel>();
-    final appColors = Theme.of(context).extension<AppColors>()!;
-
     final mediaQuery = MediaQuery.of(context);
-
-    /// Shows a snackbar with an error message
-    void handleApiErrorResult({
-      required BuildContext context,
-      required AppConfigViewModel appConfigViewModel,
-      required Exception error,
-      required String version,
-    }) {
-      final loc = AppLocalizations.of(context)!;
-
-      String label;
-
-      if (error is HttpStatusCodeException) {
-        switch (error.statusCode) {
-          case 401:
-            // Authentication failure - distinct from a network problem.
-            label = version == SupportedApiVersions.v6
-                ? loc.loginPasswordIncorrect
-                : loc.loginTokenInvalid;
-          case 495:
-            label = loc.sslErrorLong;
-          case 503:
-            label = loc.checkAddress;
-          case 504:
-            label = loc.connectionTimeout;
-          default:
-            label = loc.cantReachServer;
-        }
-      } else {
-        label = loc.unknownError;
-      }
-
-      showErrorSnackBar(
-        context: context,
-        appConfigViewModel: appConfigViewModel,
-        label: label,
-      );
-
-      appConfigViewModel.addLog(
-        AppLog(
-          type: 'login',
-          dateTime: DateTime.now(),
-          message: error.toString(),
-        ),
-      );
-    }
-
-    Future<String?> ensurePinnedFingerprint({
-      required BuildContext context,
-      required Uri uri,
-      required String? existingPin,
-    }) async {
-      if (existingPin != null && existingPin.isNotEmpty) {
-        return existingPin;
-      }
-
-      try {
-        // If the certificate is trusted by the platform, pin it automatically.
-        final info = await widget.fetchTlsCertificate(
-          uri,
-          allowBadCertificates: false,
-        );
-        if (info != null) {
-          return info.sha256;
-        }
-        return '';
-      } on HandshakeException {
-        // Untrusted certificate (likely self-signed). Retrieve fingerprint for user verification.
-      } catch (_) {
-        // Fall back to existing behavior without pin prompt on non-TLS failures.
-        return '';
-      }
-
-      TlsCertificateInfo? certificateInfo;
-      try {
-        certificateInfo = await widget.fetchTlsCertificate(
-          uri,
-          allowBadCertificates: true,
-        );
-      } catch (_) {
-        // If we cannot obtain the fingerprint, block the connection.
-        // This typically happens with reverse proxies where certificate
-        // pinning cannot work reliably.
-        return null;
-      }
-      if (!context.mounted || certificateInfo == null) {
-        return null;
-      }
-
-      final info = certificateInfo;
-      final confirmed = await showDialog<bool>(
-        context: context,
-        builder: (dialogContext) => CertificateDetailsDialog(
-          title: AppLocalizations.of(dialogContext)!.allowUntrustedCert,
-          description: AppLocalizations.of(
-            dialogContext,
-          )!.serverCertificateUpdatePinHelp,
-          certificateInfo: info,
-          actions: [
-            TextButton(
-              onPressed: () => Navigator.pop(dialogContext, false),
-              child: Text(AppLocalizations.of(dialogContext)!.cancel),
-            ),
-            TextButton(
-              onPressed: () => Navigator.pop(dialogContext, true),
-              child: Text(AppLocalizations.of(dialogContext)!.confirm),
-            ),
-          ],
-        ),
-      );
-
-      return confirmed == true ? info.sha256 : null;
-    }
-
-    /// Validates and updates the server's certificate configuration.
-    ///
-    /// This method handles certificate validation and pinning for HTTPS connections.
-    /// It returns the updated Server object if validation succeeds, or null if the
-    /// user cancels or validation fails.
-    ///
-    /// Parameters:
-    /// - [serverObj]: The server object to validate
-    /// - [onValidationFailed]: Optional callback for handling additional cleanup on failure
-    Future<Server?> validateAndUpdateServerCertificate({
-      required Server serverObj,
-      VoidCallback? onValidationFailed,
-    }) async {
-      if (connectionType != ConnectionType.https || ignoreCertificateErrors) {
-        // ignore: avoid_redundant_argument_values
-        return serverObj.copyWith(pinnedCertificateSha256: null);
-      }
-
-      final uri = Uri.parse(serverObj.address);
-
-      if (allowUntrustedCert) {
-        // Allow self-signed: prompt user to pin the certificate
-        if (!context.mounted) return null;
-        final pin = await ensurePinnedFingerprint(
-          context: context,
-          uri: uri,
-          existingPin: serverObj.pinnedCertificateSha256,
-        );
-        if (!context.mounted) return null;
-        if (pin == null) {
-          onValidationFailed?.call();
-          return null;
-        }
-        return serverObj.copyWith(
-          pinnedCertificateSha256: pin.isEmpty ? null : pin,
-        );
-      } else {
-        // Strict mode: verify certificate is trusted by the platform
-        try {
-          await widget.fetchTlsCertificate(uri, allowBadCertificates: false);
-          // Certificate is trusted, proceed without pin
-          // ignore: avoid_redundant_argument_values
-          return serverObj.copyWith(pinnedCertificateSha256: null);
-        } on HandshakeException {
-          // Certificate not trusted - block connection
-          if (!context.mounted) return null;
-          onValidationFailed?.call();
-          if (!context.mounted) return null;
-          showErrorSnackBar(
-            context: context,
-            appConfigViewModel: appConfigViewModel,
-            label: AppLocalizations.of(context)!.sslErrorLong,
-          );
-          return null;
-        } catch (e) {
-          // Other network errors - let connection test handle them
-          // ignore: avoid_redundant_argument_values
-          return serverObj.copyWith(pinnedCertificateSha256: null);
-        }
-      }
-    }
-
-    Future<void> connect() async {
-      FocusManager.instance.primaryFocus?.unfocus();
-      setState(() {
-        isConnecting = true;
-      });
-      if (!allowUntrustedCert) {
-        pinnedCertificateSha256 = null;
-      }
-
-      final url = buildServerUrl(
-        scheme: connectionType.name,
-        host: addressFieldController.text,
-        port: portFieldController.text,
-        subroute: subrouteFieldController.text,
-      );
-      final exists = await serversViewModel.checkUrlExists(url);
-
-      if (!context.mounted) return;
-      final createBundle = context.read<CreateRepositoryBundle>();
-
-      if (exists['result'] == 'success' && exists['exists'] == true) {
-        setState(() {
-          isConnecting = false;
-        });
-        showErrorSnackBar(
-          context: context,
-          appConfigViewModel: appConfigViewModel,
-          label: AppLocalizations.of(context)!.connectionAlreadyExists,
-        );
-      } else if (exists['result'] == 'fail') {
-        setState(() {
-          isConnecting = false;
-        });
-        showErrorSnackBar(
-          context: context,
-          appConfigViewModel: appConfigViewModel,
-          label: AppLocalizations.of(context)!.cannotCheckUrlSaved,
-        );
-      } else {
-        var serverObj = Server(
-          address: url,
-          alias: aliasFieldController.text,
-          apiVersion: piHoleVersion,
-          allowUntrustedCert: allowUntrustedCert,
-          ignoreCertificateErrors: ignoreCertificateErrors,
-          pinnedCertificateSha256: pinnedCertificateSha256,
-        );
-        await serversViewModel.savePassword(url, passwordFieldController.text);
-        await serversViewModel.saveToken(url, tokenFieldController.text);
-
-        serverObj =
-            await validateAndUpdateServerCertificate(
-              serverObj: serverObj,
-              onValidationFailed: () {
-                setState(() {
-                  isConnecting = false;
-                });
-              },
-            ) ??
-            serverObj;
-
-        final bundle = createBundle(server: serverObj);
-        if (serverObj.apiVersion == SupportedApiVersions.v6) {
-          final authResult = await bundle.auth.createSession(
-            passwordFieldController.text,
-          );
-          if (authResult.isError()) {
-            if (mounted) {
-              setState(() {
-                isConnecting = false;
-              });
-              await _restoreSecrets();
-              await serversViewModel.deletePassword(url);
-              await serversViewModel.deleteToken(url);
-              if (!context.mounted) return;
-              handleApiErrorResult(
-                context: context,
-                appConfigViewModel: appConfigViewModel,
-                error: authResult.exceptionOrNull()!,
-                version: piHoleVersion,
-              );
-            }
-            return;
-          }
-        }
-        // Use skipRenewal: true because the session was just created above.
-        // Retrying with clearAndRenewSid would create a duplicate session.
-        // Transient errors (e.g. network timeout) are still retried.
-        final result = await bundle.dns.fetchBlockingStatus(skipRenewal: true);
-        if (!context.mounted) return;
-        if (result.isSuccess()) {
-          await Navigator.maybePop(context);
-          if (!context.mounted) return;
-          showSuccessSnackBar(
-            context: context,
-            appConfigViewModel: appConfigViewModel,
-            label: AppLocalizations.of(context)!.connectedSuccessfully,
-          );
-          try {
-            await serversViewModel.addServer.runAsync(
-              serverObj.copyWith(defaultServer: defaultCheckbox),
-            );
-          } catch (e, s) {
-            logger.e('Failed to save server', error: e, stackTrace: s);
-          }
-        } else {
-          if (mounted) {
-            setState(() {
-              isConnecting = false;
-            });
-            await _restoreSecrets();
-
-            await serversViewModel.deletePassword(url);
-            await serversViewModel.deleteToken(url);
-            if (!context.mounted) return;
-
-            handleApiErrorResult(
-              context: context,
-              appConfigViewModel: appConfigViewModel,
-              error: result.exceptionOrNull()!,
-              version: piHoleVersion,
-            );
-          } else {
-            isConnecting = false;
-          }
-        }
-      }
-    }
-
-    Future<void> save() async {
-      FocusManager.instance.primaryFocus?.unfocus();
-      final saveCreateBundle = context.read<CreateRepositoryBundle>();
-      setState(() {
-        isConnecting = true;
-      });
-
-      if (!allowUntrustedCert) {
-        pinnedCertificateSha256 = null;
-      }
-
-      final oldServer = widget.server!;
-      final oldAddress = oldServer.address;
-      final newUrl = buildServerUrl(
-        scheme: connectionType.name,
-        host: addressFieldController.text,
-        port: portFieldController.text,
-        subroute: subrouteFieldController.text,
-      );
-      // Normalised comparison: a host-case-only or trailing-slash difference is
-      // NOT an address change and must stay on the in-place editServer path.
-      final isAddressChanged = !isSameEndpoint(oldAddress, newUrl);
-
-      // When the address (primary key) changes, make sure the new URL is not
-      // already used by another server before doing anything destructive.
-      if (isAddressChanged) {
-        final exists = await serversViewModel.checkUrlExists(newUrl);
-        if (!context.mounted) return;
-        if (exists['result'] == 'success' && exists['exists'] == true) {
-          setState(() {
-            isConnecting = false;
-          });
-          showErrorSnackBar(
-            context: context,
-            appConfigViewModel: appConfigViewModel,
-            label: AppLocalizations.of(context)!.connectionAlreadyExists,
-          );
-          return;
-        } else if (exists['result'] == 'fail') {
-          setState(() {
-            isConnecting = false;
-          });
-          showErrorSnackBar(
-            context: context,
-            appConfigViewModel: appConfigViewModel,
-            label: AppLocalizations.of(context)!.cannotCheckUrlSaved,
-          );
-          return;
-        }
-      }
-
-      final targetAddress = isAddressChanged ? newUrl : oldAddress;
-
-      // When the address changes the target is effectively a different host, so
-      // any pinned certificate carried over from the old server is stale. Reset
-      // it to null so the certificate check re-runs against the new host
-      // instead of silently reusing the old fingerprint.
-      if (isAddressChanged) {
-        pinnedCertificateSha256 = null;
-      }
-
-      var serverObj = Server(
-        address: targetAddress,
-        alias: aliasFieldController.text,
-        apiVersion: piHoleVersion,
-        allowUntrustedCert: allowUntrustedCert,
-        ignoreCertificateErrors: ignoreCertificateErrors,
-        pinnedCertificateSha256: pinnedCertificateSha256,
-      );
-      if (serversViewModel.selectedServer != null) {
-        statusViewModel.stopAutoRefresh();
-      }
-
-      // Validate certificate BEFORE connection test (same as connect())
-      final updatedServer = await validateAndUpdateServerCertificate(
-        serverObj: serverObj,
-        onValidationFailed: () {
-          setState(() {
-            isConnecting = false;
-          });
-          if (serversViewModel.selectedServer != null) {
-            statusViewModel.startAutoRefresh();
-          }
-        },
-      );
-
-      if (updatedServer == null) {
-        return;
-      }
-
-      serverObj = updatedServer;
-
-      await serversViewModel.savePassword(
-        targetAddress,
-        passwordFieldController.text,
-      );
-      await serversViewModel.saveToken(
-        targetAddress,
-        tokenFieldController.text,
-      );
-
-      // Rolls back everything written for THIS save attempt on failure, always
-      // leaving the old server (row, credentials, session) untouched.
-      //
-      // - Address change: remove the credentials and SID written under the new
-      //   address plus the freshly created remote session.
-      // - Same address: restore the old credentials and, when a new session was
-      //   created during this attempt, tear it down so it does not leak.
-      Future<void> rollbackFailedSave({
-        required RepositoryBundle bundle,
-        required bool sessionCreated,
-      }) async {
-        Future<void> deleteNewSession() async {
-          if (!sessionCreated) return;
-          try {
-            await bundle.auth.deleteCurrentSession();
-          } catch (e, s) {
-            logger.w(
-              'Failed to delete new session on server',
-              error: e,
-              stackTrace: s,
-            );
-          }
-        }
-
-        if (isAddressChanged) {
-          await serversViewModel.deletePassword(targetAddress);
-          await serversViewModel.deleteToken(targetAddress);
-          await serversViewModel.deleteSid(targetAddress);
-          await deleteNewSession();
-        } else {
-          await deleteNewSession();
-          await _restoreSecrets();
-        }
-      }
-
-      Future<void> handleSaveError(Exception e) async {
-        if (context.mounted) {
-          setState(() {
-            isConnecting = false;
-          });
-          await _restoreSecrets();
-          if (context.mounted) {
-            handleApiErrorResult(
-              context: context,
-              appConfigViewModel: appConfigViewModel,
-              error: e,
-              version: piHoleVersion,
-            );
-          }
-        }
-        if (serversViewModel.selectedServer != null) {
-          statusViewModel.startAutoRefresh();
-        }
-      }
-
-      final bundle = saveCreateBundle(server: serverObj);
-      var sessionJustCreated = false;
-      if (serverObj.apiVersion == SupportedApiVersions.v6) {
-        if (isAddressChanged) {
-          // The new address has no existing session, so always create one.
-          final authResult = await bundle.auth.createSession(
-            passwordFieldController.text,
-          );
-          if (authResult.isError()) {
-            await rollbackFailedSave(bundle: bundle, sessionCreated: false);
-            await handleSaveError(authResult.exceptionOrNull()!);
-            return;
-          }
-          sessionJustCreated = true;
-        } else if (passwordFieldController.text != (initPassword ?? '')) {
-          // Same address but the password was edited. Validate it now by
-          // creating a session: an unverified (possibly wrong) password would
-          // otherwise silently overwrite the known-good one and lock the user
-          // out the moment the current SID is invalidated.
-          final authResult = await bundle.auth.createSession(
-            passwordFieldController.text,
-          );
-          if (authResult.isError()) {
-            await handleSaveError(authResult.exceptionOrNull()!);
-            return;
-          }
-          sessionJustCreated = true;
-        } else {
-          // Same address, unchanged password: reuse the existing session if it
-          // is still valid. Only re-authenticate on 401/SidNotFoundException to
-          // avoid session multiplication when the server is temporarily
-          // unreachable (503/504/timeout).
-          final preCheck = await bundle.dns.fetchBlockingStatus(
-            skipRenewal: true,
-          );
-          if (preCheck.isError()) {
-            final err = preCheck.exceptionOrNull();
-            if (!isReauthRequired(err)) {
-              await handleSaveError(err!);
-              return;
-            }
-            final authResult = await bundle.auth.createSession(
-              passwordFieldController.text,
-            );
-            if (authResult.isError()) {
-              await handleSaveError(authResult.exceptionOrNull()!);
-              return;
-            }
-            sessionJustCreated = true;
-          }
-        }
-      }
-      // skipRenewal: true only when a new session was just created above to
-      // avoid creating a duplicate session on transient retry failures.
-      final result = await bundle.dns.fetchBlockingStatus(
-        skipRenewal: sessionJustCreated,
-      );
-
-      if (result.isSuccess()) {
-        final server = serverObj.copyWith(defaultServer: defaultCheckbox);
-
-        Object? cmdError;
-        try {
-          if (isAddressChanged) {
-            await serversViewModel.replaceServer.runAsync((
-              oldAddress: oldAddress,
-              newServer: server,
-            ));
-            cmdError = serversViewModel.replaceServer.errors.value;
-          } else {
-            await serversViewModel.editServer.runAsync(server);
-            cmdError = serversViewModel.editServer.errors.value;
-          }
-        } catch (e, s) {
-          logger.e('Failed to save server', error: e, stackTrace: s);
-          cmdError = e;
-        }
-
-        if (cmdError == null) {
-          // The old v6 session is orphaned on an address change or a switch
-          // away from v6 (e.g. v6 -> v5). Run only after the DB commit so a
-          // failed save can't kill a live session.
-          final oldWasV6 = oldServer.apiVersion == SupportedApiVersions.v6;
-          final newIsV6 = serverObj.apiVersion == SupportedApiVersions.v6;
-
-          // 1. Log out the old v6 session.
-          if (oldWasV6 && (isAddressChanged || !newIsV6)) {
-            try {
-              final oldBundle = saveCreateBundle(server: oldServer);
-              await oldBundle.auth.deleteCurrentSession();
-            } catch (e, s) {
-              logger.w(
-                'Failed to delete old session on server',
-                error: e,
-                stackTrace: s,
-              );
-            }
-          }
-
-          // 2. Now safe to drop the old server's credentials.
-          if (isAddressChanged) {
-            // New credentials already live under the new address; remove the
-            // stale ones left behind under the old address.
-            await serversViewModel.deleteToken(oldAddress);
-            await serversViewModel.deletePassword(oldAddress);
-            await serversViewModel.deleteSid(oldAddress);
-          } else if (oldWasV6 && !newIsV6) {
-            // Same address, v6 -> v5: the SID is now unused.
-            await serversViewModel.deleteSid(targetAddress);
-          }
-          if (context.mounted) {
-            await Navigator.maybePop(context);
-            if (!context.mounted) return;
-
-            showSuccessSnackBar(
-              context: context,
-              appConfigViewModel: appConfigViewModel,
-              label: AppLocalizations.of(context)!.editServerSuccessfully,
-            );
-          }
-        } else {
-          // DB write failed: roll back this attempt's artifacts; the old
-          // server (row, credentials, session) is left fully intact.
-          await rollbackFailedSave(
-            bundle: bundle,
-            sessionCreated: sessionJustCreated,
-          );
-          if (context.mounted) {
-            setState(() {
-              isConnecting = false;
-            });
-            showErrorSnackBar(
-              context: context,
-              appConfigViewModel: appConfigViewModel,
-              label: AppLocalizations.of(context)!.cantSaveConnectionData,
-            );
-          }
-        }
-      } else {
-        await rollbackFailedSave(
-          bundle: bundle,
-          sessionCreated: sessionJustCreated,
-        );
-        if (context.mounted) {
-          setState(() {
-            isConnecting = false;
-          });
-
-          handleApiErrorResult(
-            context: context,
-            appConfigViewModel: appConfigViewModel,
-            error: result.exceptionOrNull()!,
-            version: piHoleVersion,
-          );
-        } else {
-          isConnecting = false;
-        }
-      }
-
-      if (serversViewModel.selectedServer != null) {
-        statusViewModel.startAutoRefresh();
-      }
-    }
-
-    bool validData() {
-      if (addressFieldController.text != '' &&
-          subrouteFieldError == null &&
-          addressFieldError == null &&
-          portFieldError == null &&
-          aliasFieldController.text != '') {
-        if (widget.server != null) {
-          if (!_secretsLoaded) return false;
-        }
-        return true;
-      } else {
-        return false;
-      }
-    }
-
-    void openScanTokenModal() {
-      showDialog(
-        context: context,
-        useRootNavigator:
-            false, // Prevents unexpected app exit on mobile when pressing back
-        builder: (context) => ScanTokenModal(
-          qrScanned: (value) =>
-              setState(() => tokenFieldController.text = value),
-        ),
-      );
-    }
-
-    Widget buildV5Settings(BuildContext context) {
-      return Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Padding(
-            padding: const EdgeInsets.symmetric(vertical: 20),
-            child: Row(
-              mainAxisAlignment: MainAxisAlignment.spaceBetween,
-              children: [
-                Expanded(
-                  child: TextField(
-                    obscureText: true,
-                    keyboardType: TextInputType.visiblePassword,
-                    controller: tokenFieldController,
-                    onChanged: (value) => checkDataValid(),
-                    decoration: InputDecoration(
-                      prefixIcon: const Icon(Icons.key_rounded),
-                      border: const OutlineInputBorder(
-                        borderRadius: BorderRadius.all(Radius.circular(10)),
-                      ),
-                      labelText: AppLocalizations.of(context)!.token,
-                    ),
-                  ),
-                ),
-                if (Platform.isAndroid || Platform.isIOS) ...[
-                  const SizedBox(width: 16),
-                  IconButton(
-                    onPressed: openScanTokenModal,
-                    icon: const Icon(Icons.qr_code_rounded),
-                    tooltip: AppLocalizations.of(context)!.scanQrCode,
-                  ),
-                ],
-              ],
-            ),
-          ),
-          Card(
-            margin: const EdgeInsets.only(top: 10, bottom: 10),
-            child: Padding(
-              padding: const EdgeInsets.all(16),
-              child: Row(
-                children: [
-                  Icon(
-                    Icons.info_rounded,
-                    color: Theme.of(context).colorScheme.onSurfaceVariant,
-                  ),
-                  const SizedBox(width: 16),
-                  Flexible(
-                    child: Text(
-                      AppLocalizations.of(context)!.tokenInstructions,
-                    ),
-                  ),
-                ],
-              ),
-            ),
-          ),
-        ],
-      );
-    }
-
-    Widget buildV6Settings(BuildContext context) {
-      return Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Padding(
-            padding: const EdgeInsets.symmetric(vertical: 20),
-            child: Row(
-              mainAxisAlignment: MainAxisAlignment.spaceBetween,
-              children: [
-                Expanded(
-                  child: TextField(
-                    obscureText: true,
-                    keyboardType: TextInputType.visiblePassword,
-                    controller: passwordFieldController,
-                    onChanged: (value) => checkDataValid(),
-                    decoration: InputDecoration(
-                      prefixIcon: const Icon(Icons.key_rounded),
-                      border: const OutlineInputBorder(
-                        borderRadius: BorderRadius.all(Radius.circular(10)),
-                      ),
-                      labelText: AppLocalizations.of(context)!.password,
-                    ),
-                  ),
-                ),
-              ],
-            ),
-          ),
-        ],
-      );
-    }
-
-    Widget formItems() {
-      return ListView(
-        children: [
-          Padding(
-            padding: const EdgeInsets.all(24),
-            child: Column(
-              children: [
-                Container(
-                  padding: const EdgeInsets.symmetric(
-                    horizontal: 15,
-                    vertical: 10,
-                  ),
-                  margin: const EdgeInsets.only(bottom: 10),
-                  decoration: BoxDecoration(
-                    borderRadius: BorderRadius.circular(50),
-                    border: Border.all(
-                      color: Theme.of(context).colorScheme.primary,
-                    ),
-                    color: Theme.of(
-                      context,
-                    ).colorScheme.primary.withValues(alpha: 0.05),
-                  ),
-                  child: Column(
-                    children: [
-                      Text(
-                        buildServerUrl(
-                          scheme: connectionType.name,
-                          host: addressFieldController.text,
-                          port: portFieldController.text,
-                          subroute: subrouteFieldController.text,
-                        ),
-                        style: TextStyle(
-                          fontWeight: FontWeight.bold,
-                          color: Theme.of(context).colorScheme.primary,
-                        ),
-                      ),
-                    ],
-                  ),
-                ),
-                SectionLabel(
-                  label: AppLocalizations.of(context)!.connection,
-                  padding: const EdgeInsets.symmetric(vertical: 16),
-                ),
-                Padding(
-                  padding: const EdgeInsets.only(bottom: 20),
-                  child: TextField(
-                    controller: aliasFieldController,
-                    onChanged: (value) => checkDataValid(),
-                    decoration: InputDecoration(
-                      prefixIcon: const Icon(Icons.badge_outlined),
-                      border: const OutlineInputBorder(
-                        borderRadius: BorderRadius.all(Radius.circular(10)),
-                      ),
-                      labelText: AppLocalizations.of(context)!.serverName,
-                    ),
-                  ),
-                ),
-                Container(
-                  padding: const EdgeInsets.symmetric(vertical: 10),
-                  width: double.maxFinite,
-                  child: SegmentedButton<ConnectionType>(
-                    segments: const [
-                      ButtonSegment(
-                        value: ConnectionType.http,
-                        label: Text('HTTP'),
-                      ),
-                      ButtonSegment(
-                        value: ConnectionType.https,
-                        label: Text('HTTPS'),
-                      ),
-                    ],
-                    selected: <ConnectionType>{connectionType},
-                    onSelectionChanged: (value) => setState(() {
-                      connectionType = value.first;
-                      // Expand Advanced Options when HTTPS is selected, collapse for HTTP
-                      _advancedOptionsExpanded =
-                          connectionType == ConnectionType.https;
-                    }),
-                  ),
-                ),
-                Padding(
-                  padding: const EdgeInsets.only(top: 20),
-                  child: TextFormField(
-                    onChanged: validateAddress,
-                    controller: addressFieldController,
-                    decoration: InputDecoration(
-                      errorText: addressFieldError,
-                      prefixIcon: const Icon(Icons.link),
-                      border: const OutlineInputBorder(
-                        borderRadius: BorderRadius.all(Radius.circular(10)),
-                      ),
-                      labelText: AppLocalizations.of(context)!.address,
-                    ),
-                  ),
-                ),
-                Padding(
-                  padding: const EdgeInsets.only(top: 30),
-                  child: TextFormField(
-                    onChanged: validatePort,
-                    controller: portFieldController,
-                    keyboardType: TextInputType.number,
-                    decoration: InputDecoration(
-                      errorText: portFieldError,
-                      prefixIcon: const Icon(Icons.numbers),
-                      border: const OutlineInputBorder(
-                        borderRadius: BorderRadius.all(Radius.circular(10)),
-                      ),
-                      labelText: AppLocalizations.of(context)!.port,
-                    ),
-                  ),
-                ),
-                Theme(
-                  data: Theme.of(context).copyWith(
-                    dividerColor: Colors.transparent,
-                    hoverColor: Colors.transparent,
-                    splashColor: Colors.transparent,
-                    highlightColor: Colors.transparent,
-                  ),
-                  child: ExpansionTile(
-                    key: ValueKey(_advancedOptionsExpanded),
-                    tilePadding: EdgeInsets.zero,
-                    initiallyExpanded: _advancedOptionsExpanded,
-                    onExpansionChanged: (expanded) {
-                      setState(() {
-                        _advancedOptionsExpanded = expanded;
-                      });
-                    },
-                    title: SectionLabel(
-                      label: AppLocalizations.of(context)!.advancedOptions,
-                      padding: const EdgeInsets.symmetric(vertical: 16),
-                    ),
-                    children: [
-                      TextFormField(
-                        onChanged: validateSubroute,
-                        controller: subrouteFieldController,
-                        decoration: InputDecoration(
-                          errorText: subrouteFieldError,
-                          prefixIcon: const Icon(Icons.route_rounded),
-                          border: const OutlineInputBorder(
-                            borderRadius: BorderRadius.all(Radius.circular(10)),
-                          ),
-                          labelText: AppLocalizations.of(
-                            context,
-                          )!.subrouteField,
-                          hintText: AppLocalizations.of(
-                            context,
-                          )!.subrouteExample,
-                          helperText: AppLocalizations.of(
-                            context,
-                          )!.subrouteHelper,
-                        ),
-                      ),
-                      const SizedBox(height: 12),
-                      CheckboxListTile(
-                        contentPadding: const EdgeInsets.only(right: 8),
-                        value: allowUntrustedCert,
-                        onChanged:
-                            connectionType == ConnectionType.https &&
-                                !ignoreCertificateErrors
-                            ? (v) => setState(() {
-                                allowUntrustedCert = v!;
-                                if (!allowUntrustedCert) {
-                                  pinnedCertificateSha256 = null;
-                                }
-                              })
-                            : null,
-                        title: Row(
-                          children: [
-                            Expanded(
-                              child: Text(
-                                AppLocalizations.of(
-                                  context,
-                                )!.allowUntrustedCert,
-                              ),
-                            ),
-                            IconButton(
-                              icon: const Icon(Icons.help_outline_rounded),
-                              onPressed: () => openUrl(Urls.certConfigGuide),
-                              tooltip: AppLocalizations.of(
-                                context,
-                              )!.learnMoreAboutCertificates,
-                              padding: EdgeInsets.zero,
-                              constraints: const BoxConstraints(
-                                minWidth: 40,
-                                minHeight: 40,
-                              ),
-                            ),
-                          ],
-                        ),
-                        subtitle: Text(
-                          AppLocalizations.of(
-                            context,
-                          )!.allowUntrustedCertDescription,
-                          style: TextStyle(
-                            fontSize: 12,
-                            color: appColors.queryOrange,
-                          ),
-                        ),
-                      ),
-                      CheckboxListTile(
-                        contentPadding: const EdgeInsets.only(right: 8),
-                        value: ignoreCertificateErrors,
-                        onChanged: connectionType == ConnectionType.https
-                            ? (v) =>
-                                  setState(() => ignoreCertificateErrors = v!)
-                            : null,
-                        title: Text(
-                          AppLocalizations.of(context)!.dontCheckCertificate,
-                        ),
-                        subtitle: Text(
-                          AppLocalizations.of(
-                            context,
-                          )!.dontCheckCertificateDescription,
-                          style: TextStyle(
-                            fontSize: 12,
-                            color: appColors.queryRed,
-                          ),
-                        ),
-                      ),
-                      const SizedBox(height: 20),
-                    ],
-                  ),
-                ),
-                SectionLabel(
-                  label: AppLocalizations.of(context)!.version,
-                  padding: const EdgeInsets.only(top: 10, bottom: 10),
-                ),
-                Align(
-                  alignment: Alignment.centerLeft,
-                  child: Text(
-                    AppLocalizations.of(context)!.versionDescription,
-                    style: Theme.of(context).textTheme.bodySmall,
-                  ),
-                ),
-                Container(
-                  padding: const EdgeInsets.symmetric(vertical: 10),
-                  width: double.maxFinite,
-                  child: SegmentedButton<String>(
-                    segments: const [
-                      ButtonSegment(
-                        value: SupportedApiVersions.v5,
-                        label: Text(SupportedApiVersions.v5),
-                      ),
-                      ButtonSegment(
-                        value: SupportedApiVersions.v6,
-                        label: Text(SupportedApiVersions.v6),
-                      ),
-                    ],
-                    selected: <String>{piHoleVersion},
-                    onSelectionChanged: (value) =>
-                        setState(() => piHoleVersion = value.first),
-                  ),
-                ),
-                SectionLabel(
-                  label: AppLocalizations.of(context)!.authentication,
-                  padding: const EdgeInsets.only(top: 20),
-                ),
-                Padding(
-                  padding: const EdgeInsets.only(bottom: 10),
-                  child: piHoleVersion == SupportedApiVersions.v5
-                      ? buildV5Settings(context)
-                      : buildV6Settings(context),
-                ),
-                Row(
-                  mainAxisAlignment: MainAxisAlignment.center,
-                  children: [
-                    Checkbox(
-                      value: defaultCheckbox,
-                      onChanged: (value) => {
-                        setState(() => defaultCheckbox = !defaultCheckbox),
-                      },
-                      shape: RoundedRectangleBorder(
-                        borderRadius: BorderRadius.circular(5),
-                      ),
-                    ),
-                    GestureDetector(
-                      onTap: () => {
-                        setState(() => defaultCheckbox = !defaultCheckbox),
-                      },
-                      child: Text(
-                        AppLocalizations.of(context)!.defaultConnection,
-                      ),
-                    ),
-                  ],
-                ),
-              ],
-            ),
-          ),
-        ],
-      );
-    }
 
     if (widget.window == true) {
       return Dialog(
@@ -1371,11 +342,11 @@ class _AddServerFullscreenState extends State<AddServerFullscreen> {
             body: formItems(),
           ),
           AnimatedOpacity(
-            opacity: isConnecting == true ? 1 : 0,
+            opacity: isConnecting ? 1 : 0,
             duration: const Duration(milliseconds: 250),
             curve: Curves.easeInOut,
             child: IgnorePointer(
-              ignoring: isConnecting == true ? false : true,
+              ignoring: !isConnecting,
               child: Scaffold(
                 backgroundColor: Colors.transparent,
                 body: Container(
@@ -1404,5 +375,741 @@ class _AddServerFullscreenState extends State<AddServerFullscreen> {
         ],
       );
     }
+  }
+
+  /// Shows a snackbar with an error message
+  void handleApiErrorResult({
+    required BuildContext context,
+    required AppConfigViewModel appConfigViewModel,
+    required Exception error,
+    required String version,
+  }) {
+    final loc = AppLocalizations.of(context)!;
+
+    String label;
+
+    if (error is HttpStatusCodeException) {
+      switch (error.statusCode) {
+        case 401:
+          // Authentication failure - distinct from a network problem.
+          label = version == SupportedApiVersions.v6
+              ? loc.loginPasswordIncorrect
+              : loc.loginTokenInvalid;
+        case 495:
+          label = loc.sslErrorLong;
+        case 503:
+          label = loc.checkAddress;
+        case 504:
+          label = loc.connectionTimeout;
+        default:
+          label = loc.cantReachServer;
+      }
+    } else {
+      label = loc.unknownError;
+    }
+
+    showErrorSnackBar(
+      context: context,
+      appConfigViewModel: appConfigViewModel,
+      label: label,
+    );
+
+    appConfigViewModel.addLog(
+      AppLog(
+        type: 'login',
+        dateTime: DateTime.now(),
+        message: error.toString(),
+      ),
+    );
+  }
+
+  Future<String?> ensurePinnedFingerprint({
+    required BuildContext context,
+    required Uri uri,
+    required String? existingPin,
+  }) async {
+    if (existingPin != null && existingPin.isNotEmpty) {
+      return existingPin;
+    }
+
+    try {
+      // If the certificate is trusted by the platform, pin it automatically.
+      final info = await widget.fetchTlsCertificate(
+        uri,
+        allowBadCertificates: false,
+      );
+      if (info != null) {
+        return info.sha256;
+      }
+      return '';
+    } on HandshakeException {
+      // Untrusted certificate (likely self-signed). Retrieve fingerprint for user verification.
+    } catch (_) {
+      // Fall back to existing behavior without pin prompt on non-TLS failures.
+      return '';
+    }
+
+    TlsCertificateInfo? certificateInfo;
+    try {
+      certificateInfo = await widget.fetchTlsCertificate(
+        uri,
+        allowBadCertificates: true,
+      );
+    } catch (_) {
+      // If we cannot obtain the fingerprint, block the connection.
+      // This typically happens with reverse proxies where certificate
+      // pinning cannot work reliably.
+      return null;
+    }
+    if (!context.mounted || certificateInfo == null) {
+      return null;
+    }
+
+    final info = certificateInfo;
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (dialogContext) => CertificateDetailsDialog(
+        title: AppLocalizations.of(dialogContext)!.allowUntrustedCert,
+        description: AppLocalizations.of(
+          dialogContext,
+        )!.serverCertificateUpdatePinHelp,
+        certificateInfo: info,
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(dialogContext, false),
+            child: Text(AppLocalizations.of(dialogContext)!.cancel),
+          ),
+          TextButton(
+            onPressed: () => Navigator.pop(dialogContext, true),
+            child: Text(AppLocalizations.of(dialogContext)!.confirm),
+          ),
+        ],
+      ),
+    );
+
+    return confirmed == true ? info.sha256 : null;
+  }
+
+  /// Validates and updates the server's certificate configuration.
+  ///
+  /// This method handles certificate validation and pinning for HTTPS connections.
+  /// It returns the updated Server object if validation succeeds, or null if the
+  /// user cancels or validation fails.
+  ///
+  /// Parameters:
+  /// - [serverObj]: The server object to validate
+  /// - [onValidationFailed]: Optional callback for handling additional cleanup on failure
+  Future<Server?> validateAndUpdateServerCertificate({
+    required Server serverObj,
+    VoidCallback? onValidationFailed,
+  }) async {
+    final appConfigViewModel = context.read<AppConfigViewModel>();
+    if (connectionType != ConnectionType.https || ignoreCertificateErrors) {
+      // ignore: avoid_redundant_argument_values
+      return serverObj.copyWith(pinnedCertificateSha256: null);
+    }
+
+    final uri = Uri.parse(serverObj.address);
+
+    if (allowUntrustedCert) {
+      // Allow self-signed: prompt user to pin the certificate
+      if (!mounted) return null;
+      final pin = await ensurePinnedFingerprint(
+        context: context,
+        uri: uri,
+        existingPin: serverObj.pinnedCertificateSha256,
+      );
+      if (!mounted) return null;
+      if (pin == null) {
+        onValidationFailed?.call();
+        return null;
+      }
+      return serverObj.copyWith(
+        pinnedCertificateSha256: pin.isEmpty ? null : pin,
+      );
+    } else {
+      // Strict mode: verify certificate is trusted by the platform
+      try {
+        await widget.fetchTlsCertificate(uri, allowBadCertificates: false);
+        // Certificate is trusted, proceed without pin
+        // ignore: avoid_redundant_argument_values
+        return serverObj.copyWith(pinnedCertificateSha256: null);
+      } on HandshakeException {
+        // Certificate not trusted - block connection
+        if (!mounted) return null;
+        onValidationFailed?.call();
+        if (!mounted) return null;
+        showErrorSnackBar(
+          context: context,
+          appConfigViewModel: appConfigViewModel,
+          label: AppLocalizations.of(context)!.sslErrorLong,
+        );
+        return null;
+      } catch (e) {
+        // Other network errors - let connection test handle them
+        // ignore: avoid_redundant_argument_values
+        return serverObj.copyWith(pinnedCertificateSha256: null);
+      }
+    }
+  }
+
+  Future<void> connect() async {
+    final serversViewModel = context.read<ServersViewModel>();
+    final appConfigViewModel = context.read<AppConfigViewModel>();
+    final viewModel = _ensureViewModel();
+    FocusManager.instance.primaryFocus?.unfocus();
+    setState(() {
+      isConnecting = true;
+    });
+    if (!allowUntrustedCert) {
+      pinnedCertificateSha256 = null;
+    }
+
+    final url = buildServerUrl(
+      scheme: connectionType.name,
+      host: addressFieldController.text,
+      port: portFieldController.text,
+      subroute: subrouteFieldController.text,
+    );
+
+    final outcome = await viewModel.connect.runAsync(
+      ConnectRequest(
+        url: url,
+        alias: aliasFieldController.text,
+        apiVersion: piHoleVersion,
+        allowUntrustedCert: allowUntrustedCert,
+        ignoreCertificateErrors: ignoreCertificateErrors,
+        pinnedCertificateSha256: pinnedCertificateSha256,
+        password: passwordFieldController.text,
+        token: tokenFieldController.text,
+        defaultServer: defaultCheckbox,
+        resolveCertificate: (serverObj) =>
+            validateAndUpdateServerCertificate(serverObj: serverObj),
+      ),
+    );
+
+    if (!mounted) return;
+    setState(() {
+      isConnecting = false;
+    });
+    switch (outcome) {
+      case ConnectInitial():
+        break;
+      case ConnectDuplicateUrl():
+        showErrorSnackBar(
+          context: context,
+          appConfigViewModel: appConfigViewModel,
+          label: AppLocalizations.of(context)!.connectionAlreadyExists,
+        );
+      case ConnectUrlCheckFailed():
+        showErrorSnackBar(
+          context: context,
+          appConfigViewModel: appConfigViewModel,
+          label: AppLocalizations.of(context)!.cannotCheckUrlSaved,
+        );
+      case ConnectApiError(:final error, :final version):
+        handleApiErrorResult(
+          context: context,
+          appConfigViewModel: appConfigViewModel,
+          error: error,
+          version: version,
+        );
+      case ConnectSuccess(:final server):
+        await Navigator.maybePop(context);
+        if (!mounted) return;
+        showSuccessSnackBar(
+          context: context,
+          appConfigViewModel: appConfigViewModel,
+          label: AppLocalizations.of(context)!.connectedSuccessfully,
+        );
+        try {
+          await serversViewModel.addServer.runAsync(server);
+        } catch (e, s) {
+          logger.e('Failed to save server', error: e, stackTrace: s);
+        }
+    }
+  }
+
+  Future<void> save() async {
+    final appConfigViewModel = context.read<AppConfigViewModel>();
+    final viewModel = _ensureViewModel();
+    FocusManager.instance.primaryFocus?.unfocus();
+    setState(() {
+      isConnecting = true;
+    });
+
+    if (!allowUntrustedCert) {
+      pinnedCertificateSha256 = null;
+    }
+
+    final newUrl = buildServerUrl(
+      scheme: connectionType.name,
+      host: addressFieldController.text,
+      port: portFieldController.text,
+      subroute: subrouteFieldController.text,
+    );
+
+    final outcome = await viewModel.save.runAsync(
+      SaveRequest(
+        url: newUrl,
+        alias: aliasFieldController.text,
+        apiVersion: piHoleVersion,
+        allowUntrustedCert: allowUntrustedCert,
+        ignoreCertificateErrors: ignoreCertificateErrors,
+        pinnedCertificateSha256: pinnedCertificateSha256,
+        password: passwordFieldController.text,
+        token: tokenFieldController.text,
+        defaultServer: defaultCheckbox,
+        oldServer: widget.server!,
+        initPassword: initPassword ?? '',
+        initToken: initToken ?? '',
+        secretsLoadSucceeded: _secretsLoadSucceeded,
+        resolveCertificate: (serverObj) =>
+            validateAndUpdateServerCertificate(serverObj: serverObj),
+      ),
+    );
+
+    if (!mounted) return;
+    setState(() {
+      isConnecting = false;
+    });
+    switch (outcome) {
+      case SaveInitial():
+      case SaveCancelled():
+        break;
+      case SaveDuplicateUrl():
+        showErrorSnackBar(
+          context: context,
+          appConfigViewModel: appConfigViewModel,
+          label: AppLocalizations.of(context)!.connectionAlreadyExists,
+        );
+      case SaveUrlCheckFailed():
+        showErrorSnackBar(
+          context: context,
+          appConfigViewModel: appConfigViewModel,
+          label: AppLocalizations.of(context)!.cannotCheckUrlSaved,
+        );
+      case SaveApiError(:final error, :final version):
+        handleApiErrorResult(
+          context: context,
+          appConfigViewModel: appConfigViewModel,
+          error: error,
+          version: version,
+        );
+      case SaveDbError():
+        showErrorSnackBar(
+          context: context,
+          appConfigViewModel: appConfigViewModel,
+          label: AppLocalizations.of(context)!.cantSaveConnectionData,
+        );
+      case SaveSuccess():
+        await Navigator.maybePop(context);
+        if (!mounted) return;
+        showSuccessSnackBar(
+          context: context,
+          appConfigViewModel: appConfigViewModel,
+          label: AppLocalizations.of(context)!.editServerSuccessfully,
+        );
+    }
+  }
+
+  bool validData() {
+    if (addressFieldController.text != '' &&
+        subrouteFieldError == null &&
+        addressFieldError == null &&
+        portFieldError == null &&
+        aliasFieldController.text != '') {
+      if (widget.server != null) {
+        if (!_secretsLoaded) return false;
+      }
+      return true;
+    } else {
+      return false;
+    }
+  }
+
+  void openScanTokenModal() {
+    showDialog(
+      context: context,
+      useRootNavigator:
+          false, // Prevents unexpected app exit on mobile when pressing back
+      builder: (context) => ScanTokenModal(
+        qrScanned: (value) => setState(() => tokenFieldController.text = value),
+      ),
+    );
+  }
+
+  Widget buildV5Settings(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Padding(
+          padding: const EdgeInsets.symmetric(vertical: 20),
+          child: Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              Expanded(
+                child: TextField(
+                  obscureText: true,
+                  keyboardType: TextInputType.visiblePassword,
+                  controller: tokenFieldController,
+                  onChanged: (value) => checkDataValid(),
+                  decoration: InputDecoration(
+                    prefixIcon: const Icon(Icons.key_rounded),
+                    border: const OutlineInputBorder(
+                      borderRadius: BorderRadius.all(Radius.circular(10)),
+                    ),
+                    labelText: AppLocalizations.of(context)!.token,
+                  ),
+                ),
+              ),
+              if (Platform.isAndroid || Platform.isIOS) ...[
+                const SizedBox(width: 16),
+                IconButton(
+                  onPressed: openScanTokenModal,
+                  icon: const Icon(Icons.qr_code_rounded),
+                  tooltip: AppLocalizations.of(context)!.scanQrCode,
+                ),
+              ],
+            ],
+          ),
+        ),
+        Card(
+          margin: const EdgeInsets.only(top: 10, bottom: 10),
+          child: Padding(
+            padding: const EdgeInsets.all(16),
+            child: Row(
+              children: [
+                Icon(
+                  Icons.info_rounded,
+                  color: Theme.of(context).colorScheme.onSurfaceVariant,
+                ),
+                const SizedBox(width: 16),
+                Flexible(
+                  child: Text(AppLocalizations.of(context)!.tokenInstructions),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget buildV6Settings(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Padding(
+          padding: const EdgeInsets.symmetric(vertical: 20),
+          child: Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              Expanded(
+                child: TextField(
+                  obscureText: true,
+                  keyboardType: TextInputType.visiblePassword,
+                  controller: passwordFieldController,
+                  onChanged: (value) => checkDataValid(),
+                  decoration: InputDecoration(
+                    prefixIcon: const Icon(Icons.key_rounded),
+                    border: const OutlineInputBorder(
+                      borderRadius: BorderRadius.all(Radius.circular(10)),
+                    ),
+                    labelText: AppLocalizations.of(context)!.password,
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget formItems() {
+    final appColors = Theme.of(context).extension<AppColors>()!;
+    return ListView(
+      children: [
+        Padding(
+          padding: const EdgeInsets.all(24),
+          child: Column(
+            children: [
+              Container(
+                padding: const EdgeInsets.symmetric(
+                  horizontal: 15,
+                  vertical: 10,
+                ),
+                margin: const EdgeInsets.only(bottom: 10),
+                decoration: BoxDecoration(
+                  borderRadius: BorderRadius.circular(50),
+                  border: Border.all(
+                    color: Theme.of(context).colorScheme.primary,
+                  ),
+                  color: Theme.of(
+                    context,
+                  ).colorScheme.primary.withValues(alpha: 0.05),
+                ),
+                child: Column(
+                  children: [
+                    Text(
+                      buildServerUrl(
+                        scheme: connectionType.name,
+                        host: addressFieldController.text,
+                        port: portFieldController.text,
+                        subroute: subrouteFieldController.text,
+                      ),
+                      style: TextStyle(
+                        fontWeight: FontWeight.bold,
+                        color: Theme.of(context).colorScheme.primary,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+              SectionLabel(
+                label: AppLocalizations.of(context)!.connection,
+                padding: const EdgeInsets.symmetric(vertical: 16),
+              ),
+              Padding(
+                padding: const EdgeInsets.only(bottom: 20),
+                child: TextField(
+                  controller: aliasFieldController,
+                  onChanged: (value) => checkDataValid(),
+                  decoration: InputDecoration(
+                    prefixIcon: const Icon(Icons.badge_outlined),
+                    border: const OutlineInputBorder(
+                      borderRadius: BorderRadius.all(Radius.circular(10)),
+                    ),
+                    labelText: AppLocalizations.of(context)!.serverName,
+                  ),
+                ),
+              ),
+              Container(
+                padding: const EdgeInsets.symmetric(vertical: 10),
+                width: double.maxFinite,
+                child: SegmentedButton<ConnectionType>(
+                  segments: const [
+                    ButtonSegment(
+                      value: ConnectionType.http,
+                      label: Text('HTTP'),
+                    ),
+                    ButtonSegment(
+                      value: ConnectionType.https,
+                      label: Text('HTTPS'),
+                    ),
+                  ],
+                  selected: <ConnectionType>{connectionType},
+                  onSelectionChanged: (value) => setState(() {
+                    connectionType = value.first;
+                    // Expand Advanced Options when HTTPS is selected, collapse for HTTP
+                    _advancedOptionsExpanded =
+                        connectionType == ConnectionType.https;
+                  }),
+                ),
+              ),
+              Padding(
+                padding: const EdgeInsets.only(top: 20),
+                child: TextFormField(
+                  onChanged: validateAddress,
+                  controller: addressFieldController,
+                  decoration: InputDecoration(
+                    errorText: addressFieldError,
+                    prefixIcon: const Icon(Icons.link),
+                    border: const OutlineInputBorder(
+                      borderRadius: BorderRadius.all(Radius.circular(10)),
+                    ),
+                    labelText: AppLocalizations.of(context)!.address,
+                  ),
+                ),
+              ),
+              Padding(
+                padding: const EdgeInsets.only(top: 30),
+                child: TextFormField(
+                  onChanged: validatePort,
+                  controller: portFieldController,
+                  keyboardType: TextInputType.number,
+                  decoration: InputDecoration(
+                    errorText: portFieldError,
+                    prefixIcon: const Icon(Icons.numbers),
+                    border: const OutlineInputBorder(
+                      borderRadius: BorderRadius.all(Radius.circular(10)),
+                    ),
+                    labelText: AppLocalizations.of(context)!.port,
+                  ),
+                ),
+              ),
+              Theme(
+                data: Theme.of(context).copyWith(
+                  dividerColor: Colors.transparent,
+                  hoverColor: Colors.transparent,
+                  splashColor: Colors.transparent,
+                  highlightColor: Colors.transparent,
+                ),
+                child: ExpansionTile(
+                  key: ValueKey(_advancedOptionsExpanded),
+                  tilePadding: EdgeInsets.zero,
+                  initiallyExpanded: _advancedOptionsExpanded,
+                  onExpansionChanged: (expanded) {
+                    setState(() {
+                      _advancedOptionsExpanded = expanded;
+                    });
+                  },
+                  title: SectionLabel(
+                    label: AppLocalizations.of(context)!.advancedOptions,
+                    padding: const EdgeInsets.symmetric(vertical: 16),
+                  ),
+                  children: [
+                    TextFormField(
+                      onChanged: validateSubroute,
+                      controller: subrouteFieldController,
+                      decoration: InputDecoration(
+                        errorText: subrouteFieldError,
+                        prefixIcon: const Icon(Icons.route_rounded),
+                        border: const OutlineInputBorder(
+                          borderRadius: BorderRadius.all(Radius.circular(10)),
+                        ),
+                        labelText: AppLocalizations.of(context)!.subrouteField,
+                        hintText: AppLocalizations.of(context)!.subrouteExample,
+                        helperText: AppLocalizations.of(
+                          context,
+                        )!.subrouteHelper,
+                      ),
+                    ),
+                    const SizedBox(height: 12),
+                    CheckboxListTile(
+                      contentPadding: const EdgeInsets.only(right: 8),
+                      value: allowUntrustedCert,
+                      onChanged:
+                          connectionType == ConnectionType.https &&
+                              !ignoreCertificateErrors
+                          ? (v) => setState(() {
+                              allowUntrustedCert = v!;
+                              if (!allowUntrustedCert) {
+                                pinnedCertificateSha256 = null;
+                              }
+                            })
+                          : null,
+                      title: Row(
+                        children: [
+                          Expanded(
+                            child: Text(
+                              AppLocalizations.of(context)!.allowUntrustedCert,
+                            ),
+                          ),
+                          IconButton(
+                            icon: const Icon(Icons.help_outline_rounded),
+                            onPressed: () => openUrl(Urls.certConfigGuide),
+                            tooltip: AppLocalizations.of(
+                              context,
+                            )!.learnMoreAboutCertificates,
+                            padding: EdgeInsets.zero,
+                            constraints: const BoxConstraints(
+                              minWidth: 40,
+                              minHeight: 40,
+                            ),
+                          ),
+                        ],
+                      ),
+                      subtitle: Text(
+                        AppLocalizations.of(
+                          context,
+                        )!.allowUntrustedCertDescription,
+                        style: TextStyle(
+                          fontSize: 12,
+                          color: appColors.queryOrange,
+                        ),
+                      ),
+                    ),
+                    CheckboxListTile(
+                      contentPadding: const EdgeInsets.only(right: 8),
+                      value: ignoreCertificateErrors,
+                      onChanged: connectionType == ConnectionType.https
+                          ? (v) => setState(() => ignoreCertificateErrors = v!)
+                          : null,
+                      title: Text(
+                        AppLocalizations.of(context)!.dontCheckCertificate,
+                      ),
+                      subtitle: Text(
+                        AppLocalizations.of(
+                          context,
+                        )!.dontCheckCertificateDescription,
+                        style: TextStyle(
+                          fontSize: 12,
+                          color: appColors.queryRed,
+                        ),
+                      ),
+                    ),
+                    const SizedBox(height: 20),
+                  ],
+                ),
+              ),
+              SectionLabel(
+                label: AppLocalizations.of(context)!.version,
+                padding: const EdgeInsets.only(top: 10, bottom: 10),
+              ),
+              Align(
+                alignment: Alignment.centerLeft,
+                child: Text(
+                  AppLocalizations.of(context)!.versionDescription,
+                  style: Theme.of(context).textTheme.bodySmall,
+                ),
+              ),
+              Container(
+                padding: const EdgeInsets.symmetric(vertical: 10),
+                width: double.maxFinite,
+                child: SegmentedButton<String>(
+                  segments: const [
+                    ButtonSegment(
+                      value: SupportedApiVersions.v5,
+                      label: Text(SupportedApiVersions.v5),
+                    ),
+                    ButtonSegment(
+                      value: SupportedApiVersions.v6,
+                      label: Text(SupportedApiVersions.v6),
+                    ),
+                  ],
+                  selected: <String>{piHoleVersion},
+                  onSelectionChanged: (value) =>
+                      setState(() => piHoleVersion = value.first),
+                ),
+              ),
+              SectionLabel(
+                label: AppLocalizations.of(context)!.authentication,
+                padding: const EdgeInsets.only(top: 20),
+              ),
+              Padding(
+                padding: const EdgeInsets.only(bottom: 10),
+                child: piHoleVersion == SupportedApiVersions.v5
+                    ? buildV5Settings(context)
+                    : buildV6Settings(context),
+              ),
+              Row(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  Checkbox(
+                    value: defaultCheckbox,
+                    onChanged: (value) => {
+                      setState(() => defaultCheckbox = !defaultCheckbox),
+                    },
+                    shape: RoundedRectangleBorder(
+                      borderRadius: BorderRadius.circular(5),
+                    ),
+                  ),
+                  GestureDetector(
+                    onTap: () => {
+                      setState(() => defaultCheckbox = !defaultCheckbox),
+                    },
+                    child: Text(
+                      AppLocalizations.of(context)!.defaultConnection,
+                    ),
+                  ),
+                ],
+              ),
+            ],
+          ),
+        ),
+      ],
+    );
   }
 }

--- a/lib/ui/servers/widgets/add_server_fullscreen.dart
+++ b/lib/ui/servers/widgets/add_server_fullscreen.dart
@@ -176,6 +176,13 @@ class _AddServerFullscreenState extends State<AddServerFullscreen> {
     setError: (e) => portFieldError = e,
   );
 
+  String _serverUrlFromForm() => buildServerUrl(
+    scheme: connectionType.name,
+    host: addressFieldController.text,
+    port: portFieldController.text,
+    subroute: subrouteFieldController.text,
+  );
+
   Future<void> _loadSecrets() async {
     var password = '';
     var token = '';
@@ -528,12 +535,7 @@ class _AddServerFullscreenState extends State<AddServerFullscreen> {
       pinnedCertificateSha256 = null;
     }
 
-    final url = buildServerUrl(
-      scheme: connectionType.name,
-      host: addressFieldController.text,
-      port: portFieldController.text,
-      subroute: subrouteFieldController.text,
-    );
+    final url = _serverUrlFromForm();
 
     final outcome = await viewModel.createServer.runAsync(
       CreateServerRequest(
@@ -606,12 +608,7 @@ class _AddServerFullscreenState extends State<AddServerFullscreen> {
       pinnedCertificateSha256 = null;
     }
 
-    final newUrl = buildServerUrl(
-      scheme: connectionType.name,
-      host: addressFieldController.text,
-      port: portFieldController.text,
-      subroute: subrouteFieldController.text,
-    );
+    final newUrl = _serverUrlFromForm();
 
     final outcome = await viewModel.updateServer.runAsync(
       UpdateServerRequest(
@@ -819,12 +816,7 @@ class _AddServerFullscreenState extends State<AddServerFullscreen> {
                 child: Column(
                   children: [
                     Text(
-                      buildServerUrl(
-                        scheme: connectionType.name,
-                        host: addressFieldController.text,
-                        port: portFieldController.text,
-                        subroute: subrouteFieldController.text,
-                      ),
+                      _serverUrlFromForm(),
                       style: TextStyle(
                         fontWeight: FontWeight.bold,
                         color: Theme.of(context).colorScheme.primary,

--- a/lib/ui/servers/widgets/add_server_fullscreen.dart
+++ b/lib/ui/servers/widgets/add_server_fullscreen.dart
@@ -85,7 +85,7 @@ class _AddServerFullscreenState extends State<AddServerFullscreen> {
   /// Whether [_loadSecrets] actually read the stored secrets. Stays false when
   /// the secure-storage read fails, so the save rollback won't write back the
   /// empty placeholders and wipe a credential that is still present. Forwarded
-  /// to the view model via [SaveRequest.secretsLoadSucceeded].
+  /// to the view model via [UpdateServerRequest.secretsLoadSucceeded].
   bool _secretsLoadSucceeded = false;
 
   @override
@@ -291,8 +291,8 @@ class _AddServerFullscreenState extends State<AddServerFullscreen> {
                               : AppLocalizations.of(context)!.connect,
                           onPressed: validData()
                               ? widget.server != null
-                                    ? save
-                                    : connect
+                                    ? updateServer
+                                    : createServer
                               : null,
                           icon: widget.server != null
                               ? const Icon(Icons.save_rounded)
@@ -328,8 +328,8 @@ class _AddServerFullscreenState extends State<AddServerFullscreen> {
                         : AppLocalizations.of(context)!.connect,
                     onPressed: validData()
                         ? widget.server != null
-                              ? save
-                              : connect
+                              ? updateServer
+                              : createServer
                         : null,
                     icon: widget.server != null
                         ? const Icon(Icons.save_rounded)
@@ -553,7 +553,7 @@ class _AddServerFullscreenState extends State<AddServerFullscreen> {
     }
   }
 
-  Future<void> connect() async {
+  Future<void> createServer() async {
     final serversViewModel = context.read<ServersViewModel>();
     final appConfigViewModel = context.read<AppConfigViewModel>();
     final viewModel = _ensureViewModel();
@@ -572,8 +572,8 @@ class _AddServerFullscreenState extends State<AddServerFullscreen> {
       subroute: subrouteFieldController.text,
     );
 
-    final outcome = await viewModel.connect.runAsync(
-      ConnectRequest(
+    final outcome = await viewModel.createServer.runAsync(
+      CreateServerRequest(
         url: url,
         alias: aliasFieldController.text,
         apiVersion: piHoleVersion,
@@ -593,28 +593,28 @@ class _AddServerFullscreenState extends State<AddServerFullscreen> {
       isConnecting = false;
     });
     switch (outcome) {
-      case ConnectInitial():
+      case CreateInitial():
         break;
-      case ConnectDuplicateUrl():
+      case CreateDuplicateUrl():
         showErrorSnackBar(
           context: context,
           appConfigViewModel: appConfigViewModel,
           label: AppLocalizations.of(context)!.connectionAlreadyExists,
         );
-      case ConnectUrlCheckFailed():
+      case CreateUrlCheckFailed():
         showErrorSnackBar(
           context: context,
           appConfigViewModel: appConfigViewModel,
           label: AppLocalizations.of(context)!.cannotCheckUrlSaved,
         );
-      case ConnectApiError(:final error, :final version):
+      case CreateApiError(:final error, :final version):
         handleApiErrorResult(
           context: context,
           appConfigViewModel: appConfigViewModel,
           error: error,
           version: version,
         );
-      case ConnectSuccess(:final server):
+      case CreateSuccess(:final server):
         await Navigator.maybePop(context);
         if (!mounted) return;
         showSuccessSnackBar(
@@ -630,7 +630,7 @@ class _AddServerFullscreenState extends State<AddServerFullscreen> {
     }
   }
 
-  Future<void> save() async {
+  Future<void> updateServer() async {
     final appConfigViewModel = context.read<AppConfigViewModel>();
     final viewModel = _ensureViewModel();
     FocusManager.instance.primaryFocus?.unfocus();
@@ -649,8 +649,8 @@ class _AddServerFullscreenState extends State<AddServerFullscreen> {
       subroute: subrouteFieldController.text,
     );
 
-    final outcome = await viewModel.save.runAsync(
-      SaveRequest(
+    final outcome = await viewModel.updateServer.runAsync(
+      UpdateServerRequest(
         url: newUrl,
         alias: aliasFieldController.text,
         apiVersion: piHoleVersion,
@@ -674,35 +674,35 @@ class _AddServerFullscreenState extends State<AddServerFullscreen> {
       isConnecting = false;
     });
     switch (outcome) {
-      case SaveInitial():
-      case SaveCancelled():
+      case UpdateInitial():
+      case UpdateCancelled():
         break;
-      case SaveDuplicateUrl():
+      case UpdateDuplicateUrl():
         showErrorSnackBar(
           context: context,
           appConfigViewModel: appConfigViewModel,
           label: AppLocalizations.of(context)!.connectionAlreadyExists,
         );
-      case SaveUrlCheckFailed():
+      case UpdateUrlCheckFailed():
         showErrorSnackBar(
           context: context,
           appConfigViewModel: appConfigViewModel,
           label: AppLocalizations.of(context)!.cannotCheckUrlSaved,
         );
-      case SaveApiError(:final error, :final version):
+      case UpdateApiError(:final error, :final version):
         handleApiErrorResult(
           context: context,
           appConfigViewModel: appConfigViewModel,
           error: error,
           version: version,
         );
-      case SaveDbError():
+      case UpdateDbError():
         showErrorSnackBar(
           context: context,
           appConfigViewModel: appConfigViewModel,
           label: AppLocalizations.of(context)!.cantSaveConnectionData,
         );
-      case SaveSuccess():
+      case UpdateSuccess():
         await Navigator.maybePop(context);
         if (!mounted) return;
         showSuccessSnackBar(

--- a/lib/ui/servers/widgets/add_server_fullscreen.dart
+++ b/lib/ui/servers/widgets/add_server_fullscreen.dart
@@ -21,6 +21,7 @@ import 'package:pi_hole_client/utils/logger.dart';
 import 'package:pi_hole_client/utils/open_url.dart';
 import 'package:pi_hole_client/utils/tls_certificate.dart';
 import 'package:pi_hole_client/utils/url.dart';
+import 'package:pi_hole_client/utils/validators.dart';
 import 'package:provider/provider.dart';
 
 class AddServerFullscreen extends StatefulWidget {
@@ -134,13 +135,7 @@ class _AddServerFullscreenState extends State<AddServerFullscreen> {
 
   void validateAddress(String? value) {
     if (value != null && value != '') {
-      final ipAddress = RegExp(
-        r'^((25[0-5]|(2[0-4]|1\d|[1-9]|)\d)(\.(?!$)|$)){4}$',
-      );
-      final domain = RegExp(
-        r'^(([a-z0-9|-]+\.)*[a-z0-9|-]+\.[a-z]+)|((\w|-)+)$',
-      );
-      if (ipAddress.hasMatch(value) == true || domain.hasMatch(value) == true) {
+      if (isValidServerAddress(value)) {
         setState(() {
           addressFieldError = null;
         });
@@ -159,8 +154,7 @@ class _AddServerFullscreenState extends State<AddServerFullscreen> {
 
   void validateSubroute(String? value) {
     if (value != null && value != '') {
-      final subrouteRegexp = RegExp(r'^\/\b([A-Za-z0-9_\-~/]*)[^\/|\.|\:]$');
-      if (subrouteRegexp.hasMatch(value) == true) {
+      if (isValidSubroute(value)) {
         setState(() {
           subrouteFieldError = null;
         });
@@ -179,7 +173,7 @@ class _AddServerFullscreenState extends State<AddServerFullscreen> {
 
   void validatePort(String? value) {
     if (value != null && value != '') {
-      if (int.tryParse(value) != null && int.parse(value) <= 65535) {
+      if (isValidPort(value)) {
         setState(() {
           portFieldError = null;
         });

--- a/lib/ui/servers/widgets/add_server_fullscreen.dart
+++ b/lib/ui/servers/widgets/add_server_fullscreen.dart
@@ -473,6 +473,7 @@ class _AddServerFullscreenState extends State<AddServerFullscreen> {
     required Server serverObj,
     VoidCallback? onValidationFailed,
   }) async {
+    if (!mounted) return null;
     final appConfigViewModel = context.read<AppConfigViewModel>();
     if (connectionType != ConnectionType.https || ignoreCertificateErrors) {
       // ignore: avoid_redundant_argument_values

--- a/lib/ui/servers/widgets/add_server_fullscreen.dart
+++ b/lib/ui/servers/widgets/add_server_fullscreen.dart
@@ -571,6 +571,7 @@ class _AddServerFullscreenState extends State<AddServerFullscreen> {
     });
     switch (outcome) {
       case CreateInitial():
+      case CreateCancelled():
         break;
       case CreateDuplicateUrl():
         showErrorSnackBar(

--- a/lib/ui/servers/widgets/add_server_fullscreen.dart
+++ b/lib/ui/servers/widgets/add_server_fullscreen.dart
@@ -432,8 +432,12 @@ class _AddServerFullscreenState extends State<AddServerFullscreen> {
         pinnedCertificateSha256 = null;
       }
 
-      final url =
-          '${connectionType.name}://${addressFieldController.text}${portFieldController.text != '' ? ':${portFieldController.text}' : ''}${subrouteFieldController.text}';
+      final url = buildServerUrl(
+        scheme: connectionType.name,
+        host: addressFieldController.text,
+        port: portFieldController.text,
+        subroute: subrouteFieldController.text,
+      );
       final exists = await serversViewModel.checkUrlExists(url);
 
       if (!context.mounted) return;
@@ -561,8 +565,12 @@ class _AddServerFullscreenState extends State<AddServerFullscreen> {
 
       final oldServer = widget.server!;
       final oldAddress = oldServer.address;
-      final newUrl =
-          '${connectionType.name}://${addressFieldController.text}${portFieldController.text != '' ? ':${portFieldController.text}' : ''}${subrouteFieldController.text}';
+      final newUrl = buildServerUrl(
+        scheme: connectionType.name,
+        host: addressFieldController.text,
+        port: portFieldController.text,
+        subroute: subrouteFieldController.text,
+      );
       // Normalised comparison: a host-case-only or trailing-slash difference is
       // NOT an address change and must stay on the in-place editServer path.
       final isAddressChanged = !isSameEndpoint(oldAddress, newUrl);
@@ -1006,7 +1014,12 @@ class _AddServerFullscreenState extends State<AddServerFullscreen> {
                   child: Column(
                     children: [
                       Text(
-                        '${connectionType.name}://${addressFieldController.text}${portFieldController.text != '' ? ':${portFieldController.text}' : ''}${subrouteFieldController.text}',
+                        buildServerUrl(
+                          scheme: connectionType.name,
+                          host: addressFieldController.text,
+                          port: portFieldController.text,
+                          subroute: subrouteFieldController.text,
+                        ),
                         style: TextStyle(
                           fontWeight: FontWeight.bold,
                           color: Theme.of(context).colorScheme.primary,

--- a/lib/utils/url.dart
+++ b/lib/utils/url.dart
@@ -1,3 +1,14 @@
+/// Builds a server URL from its component parts.
+String buildServerUrl({
+  required String scheme,
+  required String host,
+  String port = '',
+  String subroute = '',
+}) {
+  final portSegment = port != '' ? ':$port' : '';
+  return '$scheme://$host$portSegment$subroute';
+}
+
 /// Compares two server URLs ignoring scheme/host case, a trailing slash and a
 /// scheme's default port.
 ///

--- a/lib/utils/validators.dart
+++ b/lib/utils/validators.dart
@@ -14,7 +14,7 @@ bool isValidServerAddress(String value) =>
 /// Whether [value] is a valid port number (an integer in 0..65535).
 bool isValidPort(String value) {
   final port = int.tryParse(value);
-  return port != null && port <= 65535;
+  return port != null && port >= 0 && port <= 65535;
 }
 
 /// Whether [value] is a valid subroute (leading slash, allowed characters,

--- a/lib/utils/validators.dart
+++ b/lib/utils/validators.dart
@@ -1,0 +1,22 @@
+// Pure form-field validators for the add/edit server screen.
+//
+// These hold only the format rules. The widget keeps the error messages and
+// state updates; it calls these to decide whether a value is valid.
+
+final _ipAddress = RegExp(r'^((25[0-5]|(2[0-4]|1\d|[1-9]|)\d)(\.(?!$)|$)){4}$');
+final _domain = RegExp(r'^(([a-z0-9|-]+\.)*[a-z0-9|-]+\.[a-z]+)|((\w|-)+)$');
+final _subroute = RegExp(r'^\/\b([A-Za-z0-9_\-~/]*)[^\/|\.|\:]$');
+
+/// Whether [value] is a valid IPv4 address or host/domain name.
+bool isValidServerAddress(String value) =>
+    _ipAddress.hasMatch(value) || _domain.hasMatch(value);
+
+/// Whether [value] is a valid port number (an integer in 0..65535).
+bool isValidPort(String value) {
+  final port = int.tryParse(value);
+  return port != null && port <= 65535;
+}
+
+/// Whether [value] is a valid subroute (leading slash, allowed characters,
+/// no trailing slash/dot/colon).
+bool isValidSubroute(String value) => _subroute.hasMatch(value);

--- a/test/ui/servers/view_models/add_server_viewmodel_test.dart
+++ b/test/ui/servers/view_models/add_server_viewmodel_test.dart
@@ -200,21 +200,16 @@ void main() {
         },
       );
 
-      test(
-        'a cancelled certificate does not stop create (legacy behaviour)',
-        () async {
-          final vm = buildViewModel();
+      test('a cancelled certificate aborts with CreateCancelled', () async {
+        final vm = buildViewModel();
 
-          // resolveCertificate returns null (user cancelled). create keeps the
-          // original server and the connection test still runs, so a reachable
-          // server still succeeds.
-          final outcome = await vm.createServer.runAsync(
-            createReq(resolveCertificate: (_) async => null),
-          );
+        final outcome = await vm.createServer.runAsync(
+          createReq(resolveCertificate: (_) async => null),
+        );
 
-          expect(outcome, isA<CreateSuccess>());
-        },
-      );
+        expect(outcome, isA<CreateCancelled>());
+        expect(authRepository.createSessionCallCount, 0);
+      });
     });
 
     group('updateServer', () {

--- a/test/ui/servers/view_models/add_server_viewmodel_test.dart
+++ b/test/ui/servers/view_models/add_server_viewmodel_test.dart
@@ -1,0 +1,376 @@
+import 'package:command_it/command_it.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pi_hole_client/domain/model/dns/dns.dart';
+import 'package:pi_hole_client/domain/model/server/api_versions.dart';
+import 'package:pi_hole_client/domain/model/server/server.dart';
+import 'package:pi_hole_client/ui/servers/view_models/add_server_viewmodel.dart';
+import 'package:pi_hole_client/utils/exceptions.dart';
+import 'package:result_dart/result_dart.dart';
+
+import '../../../../testing/fakes/repositories/api/fake_auth_repository.dart';
+import '../../../../testing/fakes/repositories/api/fake_dns_repository.dart';
+import '../../../../testing/fakes/viewmodels/fake_servers_viewmodel.dart';
+import '../../../../testing/fakes/viewmodels/fake_status_viewmodel.dart';
+import '../../../../testing/test_app.dart';
+
+/// A [FakeDnsRepository] whose [fetchBlockingStatus] fails for the first calls
+/// according to [_failExceptions] (one entry per call; `null` = success), then
+/// succeeds. Lets a test drive the "preCheck fails -> re-auth -> retry"
+/// sequence with a single repository instance.
+class _SeqDns extends FakeDnsRepository {
+  _SeqDns(this._failExceptions);
+
+  final List<Exception?> _failExceptions;
+  int _call = 0;
+
+  @override
+  Future<Result<Blocking>> fetchBlockingStatus({bool skipRenewal = false}) {
+    final index = _call++;
+    final ex = index < _failExceptions.length ? _failExceptions[index] : null;
+    if (ex != null) return Future.value(Failure(ex));
+    return super.fetchBlockingStatus(skipRenewal: skipRenewal);
+  }
+}
+
+const _oldServer = Server(
+  address: 'http://localhost:8081',
+  alias: 'old',
+  apiVersion: SupportedApiVersions.v6,
+  defaultServer: false,
+  allowUntrustedCert: true,
+  ignoreCertificateErrors: false,
+);
+
+void main() {
+  group('AddServerViewModel', () {
+    late FakeServersViewModel serversViewModel;
+    late FakeStatusViewModel statusViewModel;
+    late FakeAuthRepository authRepository;
+    late FakeDnsRepository dnsRepository;
+
+    setUp(() {
+      Command.globalExceptionHandler = (_, _) {};
+      serversViewModel = FakeServersViewModel()..selectedServer = _oldServer;
+      statusViewModel = FakeStatusViewModel();
+      authRepository = FakeAuthRepository();
+      dnsRepository = FakeDnsRepository();
+    });
+
+    tearDown(() {
+      Command.globalExceptionHandler = null;
+    });
+
+    AddServerViewModel buildViewModel() {
+      final vm = AddServerViewModel(
+        serversViewModel: serversViewModel,
+        statusViewModel: statusViewModel,
+        createBundle: ({required server}) => createFakeRepositoryBundle(
+          auth: authRepository,
+          dns: dnsRepository,
+          serverAddress: server.address,
+          apiVersion: server.apiVersion,
+        ),
+      );
+      addTearDown(vm.dispose);
+      return vm;
+    }
+
+    CreateServerRequest createReq({
+      String url = 'http://localhost:8081',
+      String apiVersion = SupportedApiVersions.v6,
+      String password = 'pass',
+      bool defaultServer = false,
+      ResolveCertificate? resolveCertificate,
+    }) {
+      return CreateServerRequest(
+        url: url,
+        alias: 'alias',
+        apiVersion: apiVersion,
+        allowUntrustedCert: true,
+        ignoreCertificateErrors: false,
+        pinnedCertificateSha256: null,
+        password: password,
+        token: 'token',
+        defaultServer: defaultServer,
+        resolveCertificate: resolveCertificate ?? (server) async => server,
+      );
+    }
+
+    UpdateServerRequest updateReq({
+      String? url,
+      String apiVersion = SupportedApiVersions.v6,
+      String password = 'pass',
+      String? initPassword,
+      bool secretsLoadSucceeded = true,
+      Server oldServer = _oldServer,
+      ResolveCertificate? resolveCertificate,
+    }) {
+      return UpdateServerRequest(
+        url: url ?? oldServer.address,
+        alias: 'alias',
+        apiVersion: apiVersion,
+        allowUntrustedCert: true,
+        ignoreCertificateErrors: false,
+        pinnedCertificateSha256: null,
+        password: password,
+        token: 'token',
+        defaultServer: false,
+        oldServer: oldServer,
+        initPassword: initPassword ?? password,
+        initToken: 'token',
+        secretsLoadSucceeded: secretsLoadSucceeded,
+        resolveCertificate: resolveCertificate ?? (server) async => server,
+      );
+    }
+
+    group('createServer', () {
+      test(
+        'v6 success returns CreateSuccess with the server to persist',
+        () async {
+          final vm = buildViewModel();
+
+          final outcome = await vm.createServer.runAsync(
+            createReq(defaultServer: true),
+          );
+
+          expect(outcome, isA<CreateSuccess>());
+          final server = (outcome as CreateSuccess).server;
+          expect(server.address, 'http://localhost:8081');
+          expect(server.defaultServer, isTrue);
+          expect(authRepository.createSessionCallCount, 1);
+          expect(serversViewModel.savePasswordCallCount, 1);
+          expect(serversViewModel.saveTokenCallCount, 1);
+        },
+      );
+
+      test('v5 success does not create a session', () async {
+        final vm = buildViewModel();
+
+        final outcome = await vm.createServer.runAsync(
+          createReq(apiVersion: SupportedApiVersions.v5),
+        );
+
+        expect(outcome, isA<CreateSuccess>());
+        expect(authRepository.createSessionCallCount, 0);
+      });
+
+      test('returns CreateDuplicateUrl when the URL already exists', () async {
+        serversViewModel.urlExistsResult = true;
+        final vm = buildViewModel();
+
+        final outcome = await vm.createServer.runAsync(createReq());
+
+        expect(outcome, isA<CreateDuplicateUrl>());
+        expect(serversViewModel.savePasswordCallCount, 0);
+      });
+
+      test(
+        'returns CreateUrlCheckFailed when the check is inconclusive',
+        () async {
+          serversViewModel.checkUrlExistsFails = true;
+          final vm = buildViewModel();
+
+          final outcome = await vm.createServer.runAsync(createReq());
+
+          expect(outcome, isA<CreateUrlCheckFailed>());
+        },
+      );
+
+      test('returns CreateApiError when session creation fails', () async {
+        authRepository.shouldFail = true;
+        final vm = buildViewModel();
+
+        final outcome = await vm.createServer.runAsync(createReq());
+
+        expect(outcome, isA<CreateApiError>());
+        expect((outcome as CreateApiError).version, SupportedApiVersions.v6);
+      });
+
+      test(
+        'returns CreateApiError when the blocking-status probe fails',
+        () async {
+          dnsRepository
+            ..shouldFail = true
+            ..failureException = HttpStatusCodeException(503);
+          final vm = buildViewModel();
+
+          final outcome = await vm.createServer.runAsync(createReq());
+
+          expect(outcome, isA<CreateApiError>());
+        },
+      );
+
+      test(
+        'a cancelled certificate does not stop create (legacy behaviour)',
+        () async {
+          final vm = buildViewModel();
+
+          // resolveCertificate returns null (user cancelled). create keeps the
+          // original server and the connection test still runs, so a reachable
+          // server still succeeds.
+          final outcome = await vm.createServer.runAsync(
+            createReq(resolveCertificate: (_) async => null),
+          );
+
+          expect(outcome, isA<CreateSuccess>());
+        },
+      );
+    });
+
+    group('updateServer', () {
+      test('same-address edit reuses the session and edits in place', () async {
+        final vm = buildViewModel();
+
+        final outcome = await vm.updateServer.runAsync(updateReq());
+
+        expect(outcome, isA<UpdateSuccess>());
+        expect(serversViewModel.editServerCallCount, 1);
+        expect(serversViewModel.replaceServerCallCount, 0);
+        // Unchanged password -> existing session reused, no new login.
+        expect(authRepository.createSessionCallCount, 0);
+        expect(statusViewModel.stopAutoRefreshCallCount, 1);
+        expect(statusViewModel.startAutoRefreshCallCount, 1);
+      });
+
+      test(
+        'address change replaces the server and cleans up the old one',
+        () async {
+          final vm = buildViewModel();
+
+          final outcome = await vm.updateServer.runAsync(
+            updateReq(url: 'http://other.host:9999'),
+          );
+
+          expect(outcome, isA<UpdateSuccess>());
+          expect(serversViewModel.replaceServerCallCount, 1);
+          expect(serversViewModel.editServerCallCount, 0);
+          // New address always creates a session; old v6 session is logged out.
+          expect(authRepository.createSessionCallCount, 1);
+          expect(authRepository.deleteCurrentSessionCallCount, 1);
+          // Old address SID is dropped after the commit.
+          expect(serversViewModel.deleteSidCallCount, 1);
+        },
+      );
+
+      test('a cancelled certificate aborts with UpdateCancelled', () async {
+        final vm = buildViewModel();
+
+        final outcome = await vm.updateServer.runAsync(
+          updateReq(resolveCertificate: (_) async => null),
+        );
+
+        expect(outcome, isA<UpdateCancelled>());
+        // No commit, no new credentials written for the attempt.
+        expect(serversViewModel.editServerCallCount, 0);
+        expect(serversViewModel.savePasswordCallCount, 0);
+        // Auto refresh was stopped then restarted.
+        expect(statusViewModel.stopAutoRefreshCallCount, 1);
+        expect(statusViewModel.startAutoRefreshCallCount, 1);
+      });
+
+      test(
+        'returns UpdateDuplicateUrl when the new address already exists',
+        () async {
+          serversViewModel.urlExistsResult = true;
+          final vm = buildViewModel();
+
+          final outcome = await vm.updateServer.runAsync(
+            updateReq(url: 'http://other.host:9999'),
+          );
+
+          expect(outcome, isA<UpdateDuplicateUrl>());
+          expect(serversViewModel.replaceServerCallCount, 0);
+        },
+      );
+
+      test(
+        'returns UpdateUrlCheckFailed when the new-address check fails',
+        () async {
+          serversViewModel.checkUrlExistsFails = true;
+          final vm = buildViewModel();
+
+          final outcome = await vm.updateServer.runAsync(
+            updateReq(url: 'http://other.host:9999'),
+          );
+
+          expect(outcome, isA<UpdateUrlCheckFailed>());
+        },
+      );
+
+      test(
+        'address-change auth failure rolls back and restarts auto refresh',
+        () async {
+          authRepository.shouldFail = true;
+          final vm = buildViewModel();
+
+          final outcome = await vm.updateServer.runAsync(
+            updateReq(url: 'http://other.host:9999'),
+          );
+
+          expect(outcome, isA<UpdateApiError>());
+          expect(serversViewModel.replaceServerCallCount, 0);
+          // Rollback drops the SID written under the new address.
+          expect(serversViewModel.deleteSidCallCount, 1);
+          expect(statusViewModel.startAutoRefreshCallCount, 1);
+        },
+      );
+
+      test('same-address password change validates the new password', () async {
+        authRepository.shouldFail = true;
+        final vm = buildViewModel();
+
+        final outcome = await vm.updateServer.runAsync(
+          updateReq(password: 'new-pass', initPassword: 'old-pass'),
+        );
+
+        expect(outcome, isA<UpdateApiError>());
+        expect(authRepository.createSessionCallCount, 1);
+        expect(serversViewModel.editServerCallCount, 0);
+      });
+
+      test(
+        'same-address unchanged password re-authenticates on a 401',
+        () async {
+          // preCheck (call 1) returns 401 -> re-auth -> retry (call 2) succeeds.
+          dnsRepository = _SeqDns([HttpStatusCodeException(401), null]);
+          final vm = buildViewModel();
+
+          final outcome = await vm.updateServer.runAsync(updateReq());
+
+          expect(outcome, isA<UpdateSuccess>());
+          expect(authRepository.createSessionCallCount, 1);
+          expect(serversViewModel.editServerCallCount, 1);
+        },
+      );
+
+      test(
+        'same-address unchanged password does not re-auth on a 503',
+        () async {
+          dnsRepository
+            ..shouldFail = true
+            ..failureException = HttpStatusCodeException(503);
+          final vm = buildViewModel();
+
+          final outcome = await vm.updateServer.runAsync(updateReq());
+
+          expect(outcome, isA<UpdateApiError>());
+          // 503 is transient -> no re-auth to avoid duplicate sessions.
+          expect(authRepository.createSessionCallCount, 0);
+        },
+      );
+
+      test(
+        'returns UpdateDbError and rolls back when the DB write fails',
+        () async {
+          serversViewModel.shouldFailEditServer = true;
+          final vm = buildViewModel();
+
+          final outcome = await vm.updateServer.runAsync(updateReq());
+
+          expect(outcome, isA<UpdateDbError>());
+          expect(statusViewModel.startAutoRefreshCallCount, 1);
+        },
+      );
+    });
+  });
+}

--- a/test/utils/url_test.dart
+++ b/test/utils/url_test.dart
@@ -2,6 +2,45 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:pi_hole_client/utils/url.dart';
 
 void main() {
+  group('buildServerUrl', () {
+    test('builds a bare scheme://host when port and subroute are empty', () {
+      expect(buildServerUrl(scheme: 'http', host: 'pi.hole'), 'http://pi.hole');
+    });
+
+    test('includes the port with a colon when provided', () {
+      expect(
+        buildServerUrl(scheme: 'http', host: 'pi.hole', port: '8080'),
+        'http://pi.hole:8080',
+      );
+    });
+
+    test('omits the colon entirely for an empty port', () {
+      expect(
+        buildServerUrl(scheme: 'https', host: 'pi.hole', port: ''),
+        'https://pi.hole',
+      );
+    });
+
+    test('appends the subroute as-is', () {
+      expect(
+        buildServerUrl(scheme: 'https', host: 'pi.hole', subroute: '/admin'),
+        'https://pi.hole/admin',
+      );
+    });
+
+    test('combines scheme, host, port and subroute', () {
+      expect(
+        buildServerUrl(
+          scheme: 'https',
+          host: 'pi.hole',
+          port: '443',
+          subroute: '/api/v1',
+        ),
+        'https://pi.hole:443/api/v1',
+      );
+    });
+  });
+
   group('isSameEndpoint', () {
     test('returns true for identical URLs', () {
       expect(isSameEndpoint('https://pi.hole', 'https://pi.hole'), isTrue);

--- a/test/utils/validators_test.dart
+++ b/test/utils/validators_test.dart
@@ -1,0 +1,61 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pi_hole_client/utils/validators.dart';
+
+void main() {
+  group('isValidServerAddress', () {
+    test('accepts an IPv4 address', () {
+      expect(isValidServerAddress('192.168.1.10'), isTrue);
+      expect(isValidServerAddress('10.0.0.1'), isTrue);
+    });
+
+    test('accepts a hostname and a domain', () {
+      expect(isValidServerAddress('pi.hole'), isTrue);
+      expect(isValidServerAddress('localhost'), isTrue);
+      expect(isValidServerAddress('my-server.example.com'), isTrue);
+    });
+
+    test('rejects an empty value', () {
+      expect(isValidServerAddress(''), isFalse);
+    });
+
+    test('rejects a value with no host-like characters', () {
+      expect(isValidServerAddress('!!!'), isFalse);
+    });
+  });
+
+  group('isValidPort', () {
+    test('accepts ports within range', () {
+      expect(isValidPort('0'), isTrue);
+      expect(isValidPort('8080'), isTrue);
+      expect(isValidPort('65535'), isTrue);
+    });
+
+    test('rejects ports above the maximum', () {
+      expect(isValidPort('65536'), isFalse);
+      expect(isValidPort('99999'), isFalse);
+    });
+
+    test('rejects non-numeric values', () {
+      expect(isValidPort('abc'), isFalse);
+      expect(isValidPort('80a'), isFalse);
+      expect(isValidPort(''), isFalse);
+    });
+  });
+
+  group('isValidSubroute', () {
+    test('accepts a leading-slash path', () {
+      expect(isValidSubroute('/admin'), isTrue);
+      expect(isValidSubroute('/api/v1'), isTrue);
+    });
+
+    test('rejects a path without a leading slash', () {
+      expect(isValidSubroute('admin'), isFalse);
+    });
+
+    test('rejects a trailing slash, dot or colon', () {
+      expect(isValidSubroute('/admin/'), isFalse);
+      expect(isValidSubroute('/admin.'), isFalse);
+      expect(isValidSubroute('/admin:'), isFalse);
+    });
+  });
+}

--- a/test/utils/validators_test.dart
+++ b/test/utils/validators_test.dart
@@ -35,6 +35,10 @@ void main() {
       expect(isValidPort('99999'), isFalse);
     });
 
+    test('rejects ports below the minimum', () {
+      expect(isValidPort('-1'), isFalse);
+    });
+
     test('rejects non-numeric values', () {
       expect(isValidPort('abc'), isFalse);
       expect(isValidPort('80a'), isFalse);


### PR DESCRIPTION
## Overview
This PR moves the add/edit server connection workflow out of AddServerFullscreen into a dedicated AddServerViewModel. The refactor separates UI reactions from connection orchestration while preserving certificate handling, credential persistence, session lifecycle, and rollback behavior.

## Changes
- Extracted create and update server orchestration into a testable view model with typed request and outcome models.
- Kept certificate dialogs, snackbars, navigation, and loading state in the widget while delegating connection flow decisions to the view model.
- Added shared URL-building and form-validation helpers for the add/edit server form.
- Improved v6 session handling to avoid unnecessary duplicate sessions and to roll back credentials or sessions on failed saves.
- Added unit coverage for server creation, server updates, URL helpers, and validation helpers.
- Documented the add/edit server connection flow, including certificate handling, session behavior, rollback paths, and UI outcome mapping.

## Summary by Sourcery

Refactor the add/edit server connection workflow into a dedicated view model, centralizing orchestration logic while keeping UI concerns in the widget.

Enhancements:
- Introduce AddServerViewModel to encapsulate add and edit server orchestration including URL uniqueness checks, credential persistence, v6 session lifecycle, and rollback behavior.
- Extract reusable URL-building and validation helpers for server address, port, and subroute fields and integrate them into the add/edit server form.
- Simplify AddServerFullscreen by delegating connection flow decisions to the view model while retaining certificate dialogs, loading overlays, navigation, and snackbars in the UI layer.

Documentation:
- Document the server connection flow, including add/edit behavior, certificate handling, session management, rollback paths, and outcome-to-UI mapping.

Tests:
- Add unit tests for AddServerViewModel create/update flows, covering v5/v6 behavior, URL uniqueness, authentication branches, and rollback semantics.
- Add tests for the new URL-building helper and form-field validators used by the add/edit server screen.