### PR TITLE
chore(config): disable experimental router option in Docusaurus config

### DIFF
--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -32,7 +32,7 @@ const config: Config = {
       ssgWorkerThreads: true,
       mdxCrossCompilerCache: true,
     },
-    experimental_router: "hash",
+    // experimental_router: "hash",
   },
 
   // Set the production url of your site here


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Disable the experimental hash router option in the Docusaurus configuration by commenting it out.