### PR TITLE
fix(servers): clear previous version's credential when switching API version

### DIFF
--- a/lib/ui/servers/widgets/add_server_fullscreen.dart
+++ b/lib/ui/servers/widgets/add_server_fullscreen.dart
@@ -1034,8 +1034,17 @@ class _AddServerFullscreenState extends State<AddServerFullscreen> {
                     ),
                   ],
                   selected: <String>{piHoleVersion},
-                  onSelectionChanged: (value) =>
-                      setState(() => piHoleVersion = value.first),
+                  onSelectionChanged: (value) {
+                    final newVersion = value.first;
+                    setState(() {
+                      piHoleVersion = newVersion;
+                      if (newVersion == SupportedApiVersions.v5) {
+                        passwordFieldController.clear();
+                      } else {
+                        tokenFieldController.clear();
+                      }
+                    });
+                  },
                 ),
               ),
               SectionLabel(

--- a/test/ui/servers/add_server_fullscreen_test.dart
+++ b/test/ui/servers/add_server_fullscreen_test.dart
@@ -1788,6 +1788,75 @@ void main() async {
     );
 
     testWidgets(
+      'switching v5 -> v6 -> v5 clears the v5 token so it does not reappear',
+      (WidgetTester tester) async {
+        useLargeView(tester);
+
+        await tester.pumpWidget(
+          buildWidget(
+            const AddServerFullscreen(
+              window: false,
+              title: 'test',
+              server: _serverV5,
+            ),
+          ),
+        );
+        // Let the stored credentials load into the fields.
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 500));
+
+        TextField authField() =>
+            tester.widget<TextField>(find.byType(TextField).at(3));
+
+        // v5 loads with its stored token populated.
+        expect(authField().controller!.text, 'stored-token');
+
+        // Leaving v5 for v6 clears the v5 token.
+        await tester.tap(apiVersionSegment('v6'));
+        await tester.pump();
+
+        // Returning to v5 must show an empty token, not the previous value.
+        await tester.tap(apiVersionSegment('v5'));
+        await tester.pump();
+        expect(authField().controller!.text, '');
+      },
+    );
+
+    testWidgets(
+      'switching v6 -> v5 -> v6 clears the v6 password so it does not reappear',
+      (WidgetTester tester) async {
+        useLargeView(tester);
+
+        await tester.pumpWidget(
+          buildWidget(
+            const AddServerFullscreen(
+              window: false,
+              title: 'test',
+              server: _serverV6,
+            ),
+          ),
+        );
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 500));
+
+        TextField authField() =>
+            tester.widget<TextField>(find.byType(TextField).at(3));
+
+        // v6 loads with its stored password populated.
+        expect(authField().controller!.text, 'stored-pass');
+
+        // Leaving v6 for v5 clears the v6 password.
+        await tester.tap(apiVersionSegment('v5'));
+        await tester.pump();
+
+        // Returning to v6 must show an empty password, not the previous value.
+        await tester.tap(apiVersionSegment('v6'));
+        await tester.pump();
+        expect(authField().controller!.text, '');
+      },
+    );
+
+    testWidgets(
       'switching HTTPS to HTTP changes the address, clears the pin and '
       'replaces the server',
       (WidgetTester tester) async {


### PR DESCRIPTION
## Overview
On the server edit screen, switching the Pi-hole API version (v5 <-> v6) left the previous version's credential populated, so switching back re-displayed the old token or password. This change clears the credential of the version being left so stale secrets no longer reappear and are removed on save.

## Changes
- Clear the inactive credential field (v5 token / v6 password) when the API version is switched, so the previous version's secret is not carried over or re-displayed.
- Add widget tests covering v5→v6→v5 and v6→v5→v6 switches.

## Summary by Sourcery

Ensure server credential fields are cleared when switching Pi-hole API versions to prevent stale secrets from reappearing.

Bug Fixes:
- Clear the inactive credential field when changing between v5 and v6 so previous tokens or passwords are not retained or redisplayed.

Tests:
- Add widget tests verifying credentials are cleared when switching v5→v6→v5 and v6→v5→v6 on the server edit screen.