### PR TITLE
test(e2e): add end-to-end and unit tests

### DIFF
--- a/e2e/Caddyfile
+++ b/e2e/Caddyfile
@@ -1,0 +1,35 @@
+# Caddy config for the e2e test stack (see e2e/docker-compose.yml).
+{
+	admin off
+}
+
+# :81 - plain pass-through to the v6 Pi-hole.
+:81 {
+	reverse_proxy pihole-v6-test:80
+}
+
+# :82 - fault injection: /api/auth passes through (a real session is created),
+# but the blocking-status probe returns 503.
+:82 {
+	@blocking path /api/dns/blocking*
+	respond @blocking 503
+	reverse_proxy pihole-v6-test:80
+}
+
+# :443 - self-signed HTTPS (Caddy internal CA, untrusted by the device) for the
+# allowUntrustedCert / pinned-certificate scenarios.
+:443 {
+	tls internal
+	reverse_proxy pihole-v6-test:80
+}
+
+# :83 - otherwise-normal pass-through
+:83 {
+	@deleteAuth {
+		method DELETE
+		path /api/auth*
+	}
+	respond @deleteAuth 401
+
+	reverse_proxy pihole-v6-test:80
+}

--- a/e2e/docker-compose.yml
+++ b/e2e/docker-compose.yml
@@ -1,0 +1,70 @@
+# Dedicated Pi-hole stack for the integration / e2e tests.
+#
+# This is SEPARATE from the development stack at the repo root
+# (`docker-compose.yaml`). Ports use the 19xxx range so both can run at once.
+# 2FA is left disabled (TOTP flows are covered by the fake-server layer).
+#
+#   docker compose -f e2e/docker-compose.yml up -d
+#   docker compose -f e2e/docker-compose.yml down
+#
+# From an Android emulator the host is reachable at 10.0.2.2:
+#   http://10.0.2.2:19080    v6 (direct)              pass: test001
+#   http://10.0.2.2:19085    v5 (direct)              WEBPASSWORD: test123
+#   http://10.0.2.2:19081    caddy pass         -> v6
+#   http://10.0.2.2:19082    caddy fault        -> v6  (/api/dns/blocking = 503)
+#   http://10.0.2.2:19086    caddy fault-delete -> v6  (DELETE /api/auth* = 401)
+#   https://10.0.2.2:19443   caddy TLS (self-signed, untrusted) -> v6
+services:
+  pihole-v6-test:
+    container_name: pihole-v6-test
+    image: pihole/pihole:latest
+    environment:
+      TZ: "Asia/Tokyo"
+      FTLCONF_webserver_api_password: "test001"
+    ports:
+      - "19080:80"
+    restart: unless-stopped
+
+  pihole-v5-test:
+    container_name: pihole-v5-test
+    image: pihole/pihole:2024.07.0
+    environment:
+      TZ: "Asia/Tokyo"
+      WEBPASSWORD: "test123"
+    ports:
+      - "19083:80"
+    restart: unless-stopped
+
+  pihole-v6-nopass-test:
+    container_name: pihole-v6-nopass-test
+    image: pihole/pihole:latest
+    environment:
+      TZ: "Asia/Tokyo"
+      FTLCONF_webserver_api_password: ""
+    ports:
+      - "19084:80"
+    restart: unless-stopped
+
+  pihole-v5-nopass-test:
+    container_name: pihole-v5-nopass-test
+    image: pihole/pihole:2024.07.0
+    environment:
+      TZ: "Asia/Tokyo"
+      WEBPASSWORD: ""
+    ports:
+      - "19085:80"
+    restart: unless-stopped
+
+  caddy-test:
+    container_name: caddy-test
+    image: caddy:2
+    depends_on:
+      - pihole-v6-test
+    volumes:
+      - ./Caddyfile:/etc/caddy/Caddyfile:ro
+    ports:
+      - "19081:81"
+      - "19082:82"
+      - "19086:83"
+      - "19443:443"
+    restart: unless-stopped

--- a/integration_test/KNOWN_FAILURES.md
+++ b/integration_test/KNOWN_FAILURES.md
@@ -1,0 +1,119 @@
+# Known-failing tests (TODO FIX)
+
+These 6 tests are intentionally red: each asserts the *correct* spec behavior
+for a known app bug, not the app's current (buggy) behavior. They exist so
+the bug isn't silently reintroduced and so the fix can be verified by
+flipping the test to green. Do not "fix" them by loosening the assertion —
+fix the underlying app code, or ask before touching the assertion.
+
+Run with:
+
+```bash
+flutter test integration_test/fake/edit_fake_test.dart \
+  integration_test/real/edit_real_test.dart \
+  integration_test/real/add_real_test.dart \
+  -d <device> \
+  --name '\(E3\)|\(E8\)|\(E9\)|\(X6\)|\(X3\) the old v6 session|\(C13\)'
+```
+
+Last run: 2026-07-07, emulator-5554, against the `e2e/docker-compose.yml`
+stack. Result: 0 passed / 6 failed, all at their intended assertions (see
+below).
+
+## E3 — `integration_test/fake/edit_fake_test.dart`
+
+### (E3) a failed password change restores the old sid, not the stale new one
+
+```text
+Expected: 'fake-sid-1'
+  Actual: 'fake-sid-2'
+   Which: is different.
+          Expected: fake-sid-1
+            Actual: fake-sid-2
+                             ^
+           Differ at offset 9
+a failed password change must restore the sid that was valid before the attempt
+```
+
+## E9 — `integration_test/fake/edit_fake_test.dart`
+
+### (E9) a successful edit clears a previously-declined TOTP reauth
+
+```text
+Expected: false
+  Actual: <true>
+a successful edit must clear a declined TOTP reauth
+```
+
+## E8 — `integration_test/fake/edit_fake_test.dart`
+
+### (E8) cancelling the TOTP prompt during an edit marks reauth declined
+
+```text
+Expected: true
+  Actual: <false>
+cancelling a TOTP prompt during an edit must decline reauth the same way
+cancelling one during connect does
+```
+
+## X6 — `integration_test/fake/edit_fake_test.dart`
+
+### (X6) replacing a server clears the old address's declined TOTP reauth
+
+```text
+Expected: false
+  Actual: <true>
+replacing a server must clear the old address's declined TOTP reauth
+```
+
+## C13 — `integration_test/real/add_real_test.dart`
+
+### (C13) a failed connection check after successful auth does not leave a sid behind
+
+```text
+Expected: empty
+  Actual: WhereIterable<String>:['http://10.0.2.2:19082_sid']
+a failed add must clean up the sid saved during login
+```
+
+## X3 — `integration_test/real/edit_real_test.dart`
+
+### (X3) the old v6 session is logged out even when the first delete attempt fails
+
+**Fixed on 2026-07-07** (was a test-harness bug, not the app bug — see below
+for the original symptom). `connectServer()` leaves the app on `HomeScreen`,
+and while a server is selected the bottom nav has no "connect" tab back to
+the servers list — that list only lives under Settings > Servers
+(`AppLocalizations.servers`, route `Routes.settingsAppServers`; see
+`lib/ui/settings/widgets/settings_screen.dart`). The test now navigates
+Settings → Servers before calling `editServer()`. With that fix, it fails at
+the intended assertion:
+
+```text
+Expected: false
+  Actual: <true>
+the old v6 session must be logged out on version switch
+```
+
+<details>
+<summary>Original symptom (test-harness bug, now fixed)</summary>
+
+Unlike the other 5, this one did not originally fail at the documented
+assertion. It crashed earlier, inside the shared `app.editServer()` helper,
+before the save step even ran, because `openEditServer()` assumes the
+servers list screen and instead found the `HomeScreen`'s app bar menu (which
+has no "Edit" entry):
+
+```text
+The following assertion was thrown running a test:
+The finder "Found 0 widgets with text "Edit": []" (used in a call to "tap()")
+could not find any matching widgets.
+
+#3      AppHarness.openEditServer (integration_test/support/app_harness.dart:293:18)
+#4      AppHarness.editServer (integration_test/support/app_harness.dart:355:7)
+#5      edit_real_test.dart:304
+```
+
+Reproduced identically on an isolated re-run (not flaky) before being fixed.
+
+</details>

--- a/integration_test/fake/edit_fake_test.dart
+++ b/integration_test/fake/edit_fake_test.dart
@@ -1,0 +1,499 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+
+import '../support/app_harness.dart';
+import '../support/fake_pihole_server.dart';
+
+/// Fake-server tests for editing a server: session/credential/declined-state
+/// cleanup edge cases that need deterministic control not practical against
+/// a real Pi-hole (session expiry, rejecting one specific request).
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  group('same-address password change', () {
+    testWidgets(
+      '(E2) changing the password to a new value re-authenticates and '
+      'issues a new sid',
+      (tester) async {
+        final app = AppHarness(tester);
+        await app.boot();
+
+        final fakeServer = FakePiholeServer(password: 'pw1');
+        addTearDown(fakeServer.close);
+        final uri = Uri.parse(await fakeServer.start());
+
+        await app.openAddServer();
+        await app.addV6ServerViaUi(
+          host: uri.host,
+          port: '${uri.port}',
+          password: 'pw1',
+          alias: 'pw-change-success',
+        );
+        expect(find.text(app.l10n.connectedSuccessfully), findsOneWidget);
+        final address = app.servers.getServersList.single.address;
+        final sidBefore = await app.sidOf(address);
+        expect(sidBefore, isNotNull);
+
+        // The server's own password also changes, so the new value the
+        // form submits is the one that must now succeed.
+        fakeServer.password = 'pw2';
+        await app.editServer(password: 'pw2');
+        expect(find.text(app.l10n.editServerSuccessfully), findsOneWidget);
+
+        expect(await app.passwordOf(address), 'pw2');
+        expect(
+          await app.sidOf(address),
+          isNot(equals(sidBefore)),
+          reason:
+              'a password change must validate the new password by '
+              'creating a new session',
+        );
+      },
+    );
+  });
+
+  group('same-address password change rollback', () {
+    testWidgets(
+      '(E3) a failed password change restores the old sid, not the stale new one (TODO FIX)',
+      (tester) async {
+        final app = AppHarness(tester);
+        await app.boot();
+
+        final fakeServer = FakePiholeServer(password: 'pw1');
+        addTearDown(fakeServer.close);
+        final uri = Uri.parse(await fakeServer.start());
+
+        await app.openAddServer();
+        await app.addV6ServerViaUi(
+          host: uri.host,
+          port: '${uri.port}',
+          password: 'pw1',
+          alias: 'pw-rollback',
+        );
+        expect(find.text(app.l10n.connectedSuccessfully), findsOneWidget);
+        final address = app.servers.getServersList.single.address;
+        final sid1 = await app.sidOf(address);
+        expect(sid1, isNotNull);
+
+        // Accept the new password (as if it had also changed on the real
+        // Pi-hole), but fail the post-login connection check once, forcing
+        // a rollback.
+        fakeServer.password = 'pw2';
+        fakeServer.failNextBlockingCheck = true;
+        await app.editServer(password: 'pw2');
+
+        expect(
+          await app.sidOf(address),
+          equals(sid1),
+          reason:
+              'a failed password change must restore the sid that was valid '
+              'before the attempt',
+        );
+      },
+    );
+  });
+
+  group('edit success clears a declined TOTP reauth', () {
+    testWidgets(
+      '(E9) a successful edit clears a previously-declined TOTP reauth (TODO FIX)',
+      (tester) async {
+        final app = AppHarness(tester);
+        await app.boot();
+
+        final fakeServer = FakePiholeServer(password: 'pw');
+        addTearDown(fakeServer.close);
+        final uri = Uri.parse(await fakeServer.start());
+
+        await app.openAddServer();
+        await app.addV6ServerViaUi(
+          host: uri.host,
+          port: '${uri.port}',
+          password: 'pw',
+          alias: 'declined-edit',
+        );
+        expect(find.text(app.l10n.connectedSuccessfully), findsOneWidget);
+        final address = app.servers.getServersList.single.address;
+
+        // Arrange the precondition directly rather than driving a full
+        // expired-session/cancel flow.
+        app.servers.markTotpReauthDeclined(address);
+
+        await app.editServer(alias: 'declined-edit-renamed');
+        expect(find.text(app.l10n.editServerSuccessfully), findsOneWidget);
+
+        expect(
+          app.servers.isTotpReauthDeclined(address),
+          isFalse,
+          reason: 'a successful edit must clear a declined TOTP reauth',
+        );
+      },
+    );
+  });
+
+  group('edit-time TOTP cancel', () {
+    testWidgets(
+      '(E8) cancelling the TOTP prompt during an edit marks reauth declined (TODO FIX)',
+      (tester) async {
+        final app = AppHarness(tester);
+        await app.boot();
+
+        final fakeServer = FakePiholeServer(password: 'pw');
+        addTearDown(fakeServer.close);
+        final uri = Uri.parse(await fakeServer.start());
+
+        // Add/connect while 2FA is off, then enable it and expire the
+        // session so only the edit's re-login needs a code.
+        await app.openAddServer();
+        await app.addV6ServerViaUi(
+          host: uri.host,
+          port: '${uri.port}',
+          password: 'pw',
+          alias: 'cancel-edit',
+        );
+        expect(find.text(app.l10n.connectedSuccessfully), findsOneWidget);
+        final address = app.servers.getServersList.single.address;
+
+        fakeServer.totpRequired = true;
+        fakeServer.totpCode = 654321;
+        fakeServer.invalidateSession();
+
+        await app.openEditServer();
+        final fields = find.byType(EditableText);
+        await tester.enterText(fields.at(0), 'cancel-edit-renamed');
+        await app.settle(frames: 3);
+        await tester.tap(find.byIcon(Icons.save_rounded));
+        await app.waitForTotpPrompt();
+        await app.settle(frames: 3);
+        await app.cancelTotpPrompt();
+
+        expect(
+          app.servers.isTotpReauthDeclined(address),
+          isTrue,
+          reason:
+              'cancelling a TOTP prompt during an edit must decline reauth '
+              'the same way cancelling one during connect does',
+        );
+      },
+    );
+  });
+
+  group('replace to a new MFA-required host', () {
+    testWidgets(
+      '(X13) address change to an MFA-required host prompts for a code, '
+      'then succeeds',
+      (tester) async {
+        final app = AppHarness(tester);
+        await app.boot();
+
+        final oldServer = FakePiholeServer(password: 'pw');
+        addTearDown(oldServer.close);
+        final oldUri = Uri.parse(await oldServer.start());
+
+        final newServer = FakePiholeServer(password: 'pw')
+          ..totpRequired = true
+          ..totpCode = 135790;
+        addTearDown(newServer.close);
+        final newUri = Uri.parse(await newServer.start());
+
+        await app.openAddServer();
+        await app.addV6ServerViaUi(
+          host: oldUri.host,
+          port: '${oldUri.port}',
+          password: 'pw',
+          alias: 'replace-totp-success',
+        );
+        expect(find.text(app.l10n.connectedSuccessfully), findsOneWidget);
+
+        await app.openEditServer();
+        final fields = find.byType(EditableText);
+        await tester.enterText(fields.at(1), newUri.host);
+        await tester.enterText(fields.at(2), '${newUri.port}');
+        await app.settle(frames: 3);
+        await tester.tap(find.byIcon(Icons.save_rounded));
+        await app.waitForTotpPrompt();
+        await app.settle(frames: 3);
+        await app.completeTotpPrompt('135790');
+
+        expect(find.text(app.l10n.editServerSuccessfully), findsOneWidget);
+        expect(
+          app.servers.getServersList.single.address.contains(newUri.host),
+          isTrue,
+        );
+      },
+    );
+
+    testWidgets(
+      '(X14) cancelling the TOTP prompt during a replace keeps the old '
+      'server',
+      (tester) async {
+        final app = AppHarness(tester);
+        await app.boot();
+
+        final oldServer = FakePiholeServer(password: 'pw');
+        addTearDown(oldServer.close);
+        final oldUri = Uri.parse(await oldServer.start());
+
+        final newServer = FakePiholeServer(password: 'pw')
+          ..totpRequired = true
+          ..totpCode = 246810;
+        addTearDown(newServer.close);
+        final newUri = Uri.parse(await newServer.start());
+
+        await app.openAddServer();
+        await app.addV6ServerViaUi(
+          host: oldUri.host,
+          port: '${oldUri.port}',
+          password: 'pw',
+          alias: 'replace-totp-cancel',
+        );
+        expect(find.text(app.l10n.connectedSuccessfully), findsOneWidget);
+        final oldAddress = app.servers.getServersList.single.address;
+
+        await app.openEditServer();
+        final fields = find.byType(EditableText);
+        await tester.enterText(fields.at(1), newUri.host);
+        await tester.enterText(fields.at(2), '${newUri.port}');
+        await app.settle(frames: 3);
+        await tester.tap(find.byIcon(Icons.save_rounded));
+        await app.waitForTotpPrompt();
+        await app.settle(frames: 3);
+        await app.cancelTotpPrompt();
+
+        expect(
+          app.servers.getServersList,
+          hasLength(1),
+          reason: 'a cancelled replace must not create a second server',
+        );
+        expect(
+          app.servers.getServersList.single.address,
+          oldAddress,
+          reason: 'a cancelled replace must keep the old server unchanged',
+        );
+      },
+    );
+
+    testWidgets(
+      '(X15) a wrong code re-prompts during a replace, then the correct '
+      'code succeeds',
+      (tester) async {
+        final app = AppHarness(tester);
+        await app.boot();
+
+        final oldServer = FakePiholeServer(password: 'pw');
+        addTearDown(oldServer.close);
+        final oldUri = Uri.parse(await oldServer.start());
+
+        final newServer = FakePiholeServer(password: 'pw')
+          ..totpRequired = true
+          ..totpCode = 975310;
+        addTearDown(newServer.close);
+        final newUri = Uri.parse(await newServer.start());
+
+        await app.openAddServer();
+        await app.addV6ServerViaUi(
+          host: oldUri.host,
+          port: '${oldUri.port}',
+          password: 'pw',
+          alias: 'replace-totp-retry',
+        );
+        expect(find.text(app.l10n.connectedSuccessfully), findsOneWidget);
+
+        await app.openEditServer();
+        final fields = find.byType(EditableText);
+        await tester.enterText(fields.at(1), newUri.host);
+        await tester.enterText(fields.at(2), '${newUri.port}');
+        await app.settle(frames: 3);
+        await tester.tap(find.byIcon(Icons.save_rounded));
+        await app.waitForTotpPrompt();
+        await app.settle(frames: 3);
+
+        await app.submitTotpCode('000000');
+        await app.waitForTotpPrompt();
+        await app.settle(frames: 3);
+        expect(find.text(app.l10n.mfaInvalidCode), findsOneWidget);
+
+        await app.completeTotpPrompt('975310');
+        expect(find.text(app.l10n.editServerSuccessfully), findsOneWidget);
+        expect(
+          app.servers.getServersList.single.address.contains(newUri.host),
+          isTrue,
+        );
+      },
+    );
+  });
+
+  group('same-address password change with MFA required', () {
+    testWidgets(
+      '(E17) changing the password on an MFA-required server prompts for a '
+      'code, then succeeds',
+      (tester) async {
+        final app = AppHarness(tester);
+        await app.boot();
+
+        final fakeServer = FakePiholeServer(password: 'pw1');
+        addTearDown(fakeServer.close);
+        final uri = Uri.parse(await fakeServer.start());
+
+        await app.openAddServer();
+        await app.addV6ServerViaUi(
+          host: uri.host,
+          port: '${uri.port}',
+          password: 'pw1',
+          alias: 'inplace-pw-totp-success',
+        );
+        expect(find.text(app.l10n.connectedSuccessfully), findsOneWidget);
+        final address = app.servers.getServersList.single.address;
+
+        // The server now requires 2FA (e.g. the admin just enabled it) at
+        // the same time the password changes. Every previous test used its
+        // own totp code, since the fake server permanently rejects a code
+        // as "reused" the second time it succeeds -- so this uses a fresh
+        // one, not the (unused) one from the initial add.
+        fakeServer
+          ..password = 'pw2'
+          ..totpRequired = true
+          ..totpCode = 314159;
+        await app.openEditServer();
+        final fields = find.byType(EditableText);
+        await tester.enterText(fields.at(3), 'pw2');
+        await app.settle(frames: 3);
+        await tester.tap(find.byIcon(Icons.save_rounded));
+        await app.waitForTotpPrompt();
+        await app.settle(frames: 3);
+        await app.completeTotpPrompt('314159');
+
+        expect(find.text(app.l10n.editServerSuccessfully), findsOneWidget);
+        expect(await app.passwordOf(address), 'pw2');
+      },
+    );
+
+    testWidgets(
+      '(E18) cancelling that TOTP prompt restores the old password',
+      (tester) async {
+        final app = AppHarness(tester);
+        await app.boot();
+
+        final fakeServer = FakePiholeServer(password: 'pw1');
+        addTearDown(fakeServer.close);
+        final uri = Uri.parse(await fakeServer.start());
+
+        await app.openAddServer();
+        await app.addV6ServerViaUi(
+          host: uri.host,
+          port: '${uri.port}',
+          password: 'pw1',
+          alias: 'inplace-pw-totp-cancel',
+        );
+        expect(find.text(app.l10n.connectedSuccessfully), findsOneWidget);
+        final address = app.servers.getServersList.single.address;
+        final sidBefore = await app.sidOf(address);
+
+        fakeServer
+          ..password = 'pw2'
+          ..totpRequired = true
+          ..totpCode = 271828;
+        await app.openEditServer();
+        final fields = find.byType(EditableText);
+        await tester.enterText(fields.at(3), 'pw2');
+        await app.settle(frames: 3);
+        await tester.tap(find.byIcon(Icons.save_rounded));
+        await app.waitForTotpPrompt();
+        await app.settle(frames: 3);
+        await app.cancelTotpPrompt();
+
+        expect(
+          await app.passwordOf(address),
+          'pw1',
+          reason: 'cancelling the reauth must restore the old password',
+        );
+        expect(
+          await app.sidOf(address),
+          sidBefore,
+          reason: 'cancelling the reauth must not touch the existing session',
+        );
+      },
+    );
+  });
+
+  group('delete fake', () {
+    testWidgets(
+      '(DEL1) deleting the selected server does not close its remote '
+      'session',
+      (tester) async {
+        final app = AppHarness(tester);
+        await app.boot();
+
+        final fakeServer = FakePiholeServer(password: 'pw');
+        addTearDown(fakeServer.close);
+        final uri = Uri.parse(await fakeServer.start());
+
+        await app.openAddServer();
+        await app.addV6ServerViaUi(
+          host: uri.host,
+          port: '${uri.port}',
+          password: 'pw',
+          alias: 'delete-me',
+        );
+        expect(find.text(app.l10n.connectedSuccessfully), findsOneWidget);
+        expect(fakeServer.currentSid, isNotNull);
+
+        await app.deleteServer();
+
+        expect(app.servers.getServersList, isEmpty);
+        expect(
+          fakeServer.currentSid,
+          isNotNull,
+          reason:
+              'this documents the current spec: deleting a server only '
+              'removes local DB/secure-storage state -- it never sends a '
+              'DELETE /api/auth, so the remote session stays alive until it '
+              'times out server-side',
+        );
+      },
+    );
+  });
+
+  group('address replace and declined TOTP reauth', () {
+    testWidgets(
+      "(X6) replacing a server clears the old address's declined TOTP reauth (TODO FIX)",
+      (tester) async {
+        final app = AppHarness(tester);
+        await app.boot();
+
+        final oldServer = FakePiholeServer(password: 'pw');
+        addTearDown(oldServer.close);
+        final oldUri = Uri.parse(await oldServer.start());
+
+        final newServer = FakePiholeServer(password: 'pw');
+        addTearDown(newServer.close);
+        final newUri = Uri.parse(await newServer.start());
+
+        await app.openAddServer();
+        await app.addV6ServerViaUi(
+          host: oldUri.host,
+          port: '${oldUri.port}',
+          password: 'pw',
+          alias: 'replace-declined',
+        );
+        expect(find.text(app.l10n.connectedSuccessfully), findsOneWidget);
+        final oldAddress = app.servers.getServersList.single.address;
+
+        app.servers.markTotpReauthDeclined(oldAddress);
+
+        // Point the server at a different fake instance -- an address
+        // change, which replaces rather than edits in place.
+        await app.editServer(host: newUri.host, port: '${newUri.port}');
+        expect(find.text(app.l10n.editServerSuccessfully), findsOneWidget);
+
+        expect(
+          app.servers.isTotpReauthDeclined(oldAddress),
+          isFalse,
+          reason:
+              "replacing a server must clear the old address's declined "
+              'TOTP reauth',
+        );
+      },
+    );
+  });
+}

--- a/integration_test/fake/totp_fake_test.dart
+++ b/integration_test/fake/totp_fake_test.dart
@@ -1,0 +1,269 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+
+import '../support/app_harness.dart';
+import '../support/fake_pihole_server.dart';
+
+/// Fake-server TOTP (2FA) flow coverage — required/invalid/reused/rate-limit
+/// on connect, and cancelling the prompt. Exercises the exact JSON error
+/// shapes `PiholeV6ApiClient._parseTotpError` expects (see
+/// `fake_pihole_server.dart`).
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  /// Opens the add-server form and fills alias/host/port/password, leaving
+  /// the "Connect" tap to the caller (unlike `addV6ServerViaUi`, which
+  /// assumes no TOTP prompt follows).
+  Future<void> fillAddV6Form(
+    WidgetTester tester,
+    AppHarness app, {
+    required String host,
+    required String port,
+    required String password,
+    required String alias,
+  }) async {
+    await app.openAddServer();
+    final fields = find.byType(EditableText);
+    await tester.enterText(fields.at(0), alias);
+    await tester.enterText(fields.at(1), host);
+    await tester.enterText(fields.at(2), port);
+    await tester.enterText(fields.at(3), password);
+    await app.settle(frames: 3);
+    await tester.tap(find.byIcon(Icons.login_rounded));
+    await app.waitForTotpPrompt();
+    await app.settle(frames: 3);
+  }
+
+  group('totp fake - connect', () {
+    testWidgets('(C5) the correct code connects a 2FA-enabled server', (
+      tester,
+    ) async {
+      final app = AppHarness(tester);
+      await app.boot();
+
+      final fakeServer = FakePiholeServer(password: 'pw')
+        ..totpRequired = true
+        ..totpCode = 111111;
+      addTearDown(fakeServer.close);
+      final uri = Uri.parse(await fakeServer.start());
+
+      await fillAddV6Form(
+        tester,
+        app,
+        host: uri.host,
+        port: '${uri.port}',
+        password: 'pw',
+        alias: 'totp-required',
+      );
+
+      await app.completeTotpPrompt('111111');
+
+      expect(find.text(app.l10n.connectedSuccessfully), findsOneWidget);
+      expect(app.servers.getServersList, isNotEmpty);
+    });
+
+    testWidgets('(C6) a wrong code re-prompts with an error, then the correct '
+        'code succeeds', (tester) async {
+      final app = AppHarness(tester);
+      await app.boot();
+
+      final fakeServer = FakePiholeServer(password: 'pw')
+        ..totpRequired = true
+        ..totpCode = 222222;
+      addTearDown(fakeServer.close);
+      final uri = Uri.parse(await fakeServer.start());
+
+      await fillAddV6Form(
+        tester,
+        app,
+        host: uri.host,
+        port: '${uri.port}',
+        password: 'pw',
+        alias: 'totp-invalid',
+      );
+
+      await app.submitTotpCode('000000');
+      await app.waitForTotpPrompt(); // re-prompt with error
+      await app.settle(frames: 3);
+      expect(find.text(app.l10n.mfaInvalidCode), findsOneWidget);
+
+      await app.completeTotpPrompt('222222');
+      expect(find.text(app.l10n.connectedSuccessfully), findsOneWidget);
+    });
+
+    testWidgets('(C7) a reused code is rejected', (tester) async {
+      final app = AppHarness(tester);
+      await app.boot();
+
+      final fakeServer = FakePiholeServer(password: 'pw')
+        ..totpRequired = true
+        ..totpCode = 333333;
+      // Simulate the code having already been consumed (e.g. a concurrent
+      // login) before the app ever submits it.
+      fakeServer.markTotpCodeUsed(333333);
+      addTearDown(fakeServer.close);
+      final uri = Uri.parse(await fakeServer.start());
+
+      await fillAddV6Form(
+        tester,
+        app,
+        host: uri.host,
+        port: '${uri.port}',
+        password: 'pw',
+        alias: 'totp-reused',
+      );
+
+      await app.submitTotpCode('333333');
+      await app.waitForTotpPrompt(); // re-prompt with error
+      await app.settle(frames: 3);
+      expect(find.text(app.l10n.mfaReusedCode), findsOneWidget);
+      expect(app.servers.getServersList, isEmpty);
+    });
+
+    testWidgets('(C8) rate-limiting shows the rate-limit message and does not '
+        'save the server', (tester) async {
+      final app = AppHarness(tester);
+      await app.boot();
+
+      final fakeServer = FakePiholeServer(password: 'pw')
+        ..totpRequired = true
+        ..totpCode = 444444
+        ..rateLimitNextAuth = true;
+      addTearDown(fakeServer.close);
+      final uri = Uri.parse(await fakeServer.start());
+
+      await fillAddV6Form(
+        tester,
+        app,
+        host: uri.host,
+        port: '${uri.port}',
+        password: 'pw',
+        alias: 'totp-rate-limit',
+      );
+
+      // The rate-limit response comes from the *first* code submission (the
+      // fake server rejects it before checking the code).
+      await app.submitTotpCode('444444');
+      await app.waitFor(find.text(app.l10n.mfaRateLimited));
+
+      expect(find.text(app.l10n.mfaRateLimited), findsOneWidget);
+      expect(app.servers.getServersList, isEmpty);
+    });
+
+    testWidgets('(C9) cancelling the prompt does not save the server', (
+      tester,
+    ) async {
+      final app = AppHarness(tester);
+      await app.boot();
+
+      final fakeServer = FakePiholeServer(password: 'pw')
+        ..totpRequired = true
+        ..totpCode = 555555;
+      addTearDown(fakeServer.close);
+      final uri = Uri.parse(await fakeServer.start());
+
+      await fillAddV6Form(
+        tester,
+        app,
+        host: uri.host,
+        port: '${uri.port}',
+        password: 'pw',
+        alias: 'totp-cancel',
+      );
+
+      await app.cancelTotpPrompt();
+
+      expect(app.servers.getServersList, isEmpty);
+    });
+  });
+
+  group('totp fake - edit', () {
+    testWidgets(
+      '(E6) the correct code completes an edit that requires reauth',
+      (tester) async {
+        final app = AppHarness(tester);
+        await app.boot();
+
+        final fakeServer = FakePiholeServer(password: 'pw');
+        addTearDown(fakeServer.close);
+        final uri = Uri.parse(await fakeServer.start());
+
+        await app.openAddServer();
+        await app.addV6ServerViaUi(
+          host: uri.host,
+          port: '${uri.port}',
+          password: 'pw',
+          alias: 'edit-totp-success',
+        );
+        expect(find.text(app.l10n.connectedSuccessfully), findsOneWidget);
+        final address = app.servers.getServersList.single.address;
+
+        fakeServer.totpRequired = true;
+        fakeServer.totpCode = 777777;
+        fakeServer.invalidateSession();
+
+        await app.openEditServer();
+        final fields = find.byType(EditableText);
+        await tester.enterText(fields.at(0), 'edit-totp-success-renamed');
+        await app.settle(frames: 3);
+        await tester.tap(find.byIcon(Icons.save_rounded));
+        await app.waitForTotpPrompt();
+        await app.settle(frames: 3);
+        await app.completeTotpPrompt('777777');
+
+        expect(find.text(app.l10n.editServerSuccessfully), findsOneWidget);
+        expect(
+          app.servers.getServersList.single.alias,
+          'edit-totp-success-renamed',
+        );
+        expect(app.servers.isTotpReauthDeclined(address), isFalse);
+      },
+    );
+
+    testWidgets('(E7) a wrong code re-prompts during an edit, then the correct '
+        'code succeeds', (tester) async {
+      final app = AppHarness(tester);
+      await app.boot();
+
+      final fakeServer = FakePiholeServer(password: 'pw');
+      addTearDown(fakeServer.close);
+      final uri = Uri.parse(await fakeServer.start());
+
+      await app.openAddServer();
+      await app.addV6ServerViaUi(
+        host: uri.host,
+        port: '${uri.port}',
+        password: 'pw',
+        alias: 'edit-totp-retry',
+      );
+      expect(find.text(app.l10n.connectedSuccessfully), findsOneWidget);
+      final address = app.servers.getServersList.single.address;
+
+      fakeServer.totpRequired = true;
+      fakeServer.totpCode = 888888;
+      fakeServer.invalidateSession();
+
+      await app.openEditServer();
+      final fields = find.byType(EditableText);
+      await tester.enterText(fields.at(0), 'edit-totp-retry-renamed');
+      await app.settle(frames: 3);
+      await tester.tap(find.byIcon(Icons.save_rounded));
+      await app.waitForTotpPrompt();
+      await app.settle(frames: 3);
+
+      await app.submitTotpCode('000000');
+      await app.waitForTotpPrompt();
+      await app.settle(frames: 3);
+      expect(find.text(app.l10n.mfaInvalidCode), findsOneWidget);
+
+      await app.completeTotpPrompt('888888');
+      expect(find.text(app.l10n.editServerSuccessfully), findsOneWidget);
+      expect(
+        app.servers.getServersList.single.alias,
+        'edit-totp-retry-renamed',
+      );
+      expect(app.servers.isTotpReauthDeclined(address), isFalse);
+    });
+  });
+}

--- a/integration_test/real/add_real_test.dart
+++ b/integration_test/real/add_real_test.dart
@@ -1,0 +1,332 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_dotenv/flutter_dotenv.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+import 'package:pi_hole_client/ui/servers/widgets/add_server_fullscreen.dart';
+import 'package:pi_hole_client/ui/servers/widgets/servers_screen.dart';
+
+import '../support/app_harness.dart';
+import '../support/real_pihole_env.dart';
+
+/// Real-Pi-hole tests for adding/connecting a server: happy paths, abnormal
+/// inputs, password-less auth, and cleanup on a failed post-auth check.
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  setUpAll(() async {
+    if (!dotenv.isInitialized) {
+      try {
+        await dotenv.load();
+      } catch (_) {
+        // .env is optional (Sentry/biometrics disabled in tests).
+      }
+    }
+  });
+
+  group('add (v6, HTTP)', () {
+    testWidgets('boots to the servers screen when no server is configured', (
+      tester,
+    ) async {
+      final app = AppHarness(tester);
+      await app.boot();
+
+      expect(find.byType(ServersScreen), findsOneWidget);
+      expect(find.byIcon(Icons.add), findsOneWidget);
+      expect(app.servers.getServersList, isEmpty);
+    });
+
+    testWidgets('(C1) add + connect a real v6 server saves it to the list', (
+      tester,
+    ) async {
+      final app = AppHarness(tester);
+      await app.boot();
+
+      final uri = Uri.parse(RealPiholeEnv.v6Base);
+
+      await app.openAddServer();
+      expect(find.byType(AddServerFullscreen), findsOneWidget);
+
+      await app.addV6ServerViaUi(
+        host: uri.host,
+        port: uri.hasPort ? '${uri.port}' : '',
+        password: RealPiholeEnv.v6Password,
+        alias: 'e2e-v6',
+      );
+
+      expect(
+        find.text(app.l10n.connectedSuccessfully),
+        findsOneWidget,
+        reason: 'a successful login shows the success snackbar',
+      );
+      expect(
+        app.servers.getServersList,
+        isNotEmpty,
+        reason: 'a successful real login should save the server',
+      );
+      expect(
+        app.servers.getServersList.any((s) => s.address.contains(uri.host)),
+        isTrue,
+      );
+      final saved = app.servers.getServersList.first;
+      expect(await app.passwordOf(saved.address), RealPiholeEnv.v6Password);
+      final sid = await app.sidOf(saved.address);
+      expect(
+        sid != null,
+        isTrue,
+        reason: 'a successful real login should persist a session ID',
+      );
+    });
+
+    testWidgets('(C11) wrong password does not save the server', (
+      tester,
+    ) async {
+      final app = AppHarness(tester);
+      await app.boot();
+      final uri = Uri.parse(RealPiholeEnv.v6Base);
+
+      await app.openAddServer();
+      await app.addV6ServerViaUi(
+        host: uri.host,
+        port: uri.hasPort ? '${uri.port}' : '',
+        password: 'definitely-wrong-password',
+        alias: 'bad-pw',
+      );
+
+      expect(
+        find.text(app.l10n.loginPasswordIncorrect),
+        findsOneWidget,
+        reason: 'a 401 on a v6 login shows the wrong-password snackbar',
+      );
+      expect(app.servers.getServersList, isEmpty);
+      expect(find.byType(AddServerFullscreen), findsOneWidget);
+    });
+
+    testWidgets('(C12) unreachable host does not save the server', (
+      tester,
+    ) async {
+      final app = AppHarness(tester);
+      await app.boot();
+
+      await app.openAddServer();
+      await app.addV6ServerViaUi(
+        host: '10.0.2.2',
+        port: '19999',
+        password: RealPiholeEnv.v6Password,
+        alias: 'unreachable',
+      );
+
+      expect(
+        find.text(app.l10n.checkAddress),
+        findsOneWidget,
+        reason: 'an unreachable host shows the check-address snackbar',
+      );
+      expect(app.servers.getServersList, isEmpty);
+      expect(find.byType(AddServerFullscreen), findsOneWidget);
+    });
+
+    testWidgets('(C10) duplicate URL is rejected (no second server)', (
+      tester,
+    ) async {
+      final app = AppHarness(tester);
+      await app.boot();
+      final uri = Uri.parse(RealPiholeEnv.v6Base);
+      final port = uri.hasPort ? '${uri.port}' : '';
+
+      await app.openAddServer();
+      await app.addV6ServerViaUi(
+        host: uri.host,
+        port: port,
+        password: RealPiholeEnv.v6Password,
+        alias: 'first',
+      );
+      expect(
+        find.text(app.l10n.connectedSuccessfully),
+        findsOneWidget,
+        reason: 'the first add succeeds',
+      );
+      expect(app.servers.getServersList, hasLength(1));
+
+      await app.openAddServer();
+      await app.addV6ServerViaUi(
+        host: uri.host,
+        port: port,
+        password: RealPiholeEnv.v6Password,
+        alias: 'dup',
+      );
+      expect(
+        find.text(app.l10n.connectionAlreadyExists),
+        findsOneWidget,
+        reason: 'a duplicate address shows the already-exists snackbar',
+      );
+      expect(
+        app.servers.getServersList,
+        hasLength(1),
+        reason: 'a duplicate address must not create a second server',
+      );
+    });
+
+    testWidgets(
+      '(C13) a failed connection check after successful auth does not leave a sid behind (TODO FIX)',
+      (tester) async {
+        final app = AppHarness(tester);
+        await app.boot();
+
+        // /api/auth passes through to the real Pi-hole (login succeeds), but
+        // the blocking-status probe that follows is faulted with 503.
+        final uri = Uri.parse(RealPiholeEnv.faultBase);
+
+        await app.openAddServer();
+        await app.addV6ServerViaUi(
+          host: uri.host,
+          port: uri.hasPort ? '${uri.port}' : '',
+          password: RealPiholeEnv.v6Password,
+          alias: 'fault-add',
+        );
+
+        expect(
+          app.servers.getServersList,
+          isEmpty,
+          reason: 'the connection check failed, so the server must not be saved',
+        );
+        expect(find.byType(AddServerFullscreen), findsOneWidget);
+
+        final secretKeys = await app.serverSecretKeys();
+        expect(
+          secretKeys.where((k) => k.endsWith('_sid')),
+          isEmpty,
+          reason: 'a failed add must clean up the sid saved during login',
+        );
+      },
+    );
+  });
+
+  group('add (v6, HTTPS strict)', () {
+    testWidgets(
+      '(C19) an untrusted certificate is blocked with no dialog when '
+      '"allow untrusted certificate" is off',
+      (tester) async {
+        final app = AppHarness(tester);
+        await app.boot();
+        final uri = Uri.parse(RealPiholeEnv.v6HttpsBase);
+
+        await app.openAddServer();
+        await app.addV6ServerHttpsViaUi(
+          host: uri.host,
+          port: uri.hasPort ? '${uri.port}' : '',
+          password: RealPiholeEnv.v6Password,
+          alias: 'https-strict-blocked',
+          allowUntrustedCert: false,
+        );
+
+        expect(
+          find.text(app.l10n.sslErrorLong),
+          findsOneWidget,
+          reason:
+              'strict mode must block an untrusted/self-signed certificate '
+              'with an SSL error, not a certificate dialog',
+        );
+        expect(app.servers.getServersList, isEmpty);
+        expect(find.byType(AddServerFullscreen), findsOneWidget);
+      },
+    );
+  });
+
+  group('add (v5, HTTP)', () {
+    testWidgets('(C3) add + connect a real v5 server saves it to the list', (
+      tester,
+    ) async {
+      final app = AppHarness(tester);
+      await app.boot();
+
+      final uri = Uri.parse(RealPiholeEnv.v5Base);
+
+      await app.openAddServer();
+      expect(find.byType(AddServerFullscreen), findsOneWidget);
+
+      await app.addV5ServerViaUi(
+        host: uri.host,
+        port: uri.hasPort ? '${uri.port}' : '',
+        token: RealPiholeEnv.v5Token,
+        alias: 'e2e-v5',
+      );
+
+      expect(
+        find.text(app.l10n.connectedSuccessfully),
+        findsOneWidget,
+        reason: 'a successful login shows the success snackbar',
+      );
+      expect(
+        app.servers.getServersList,
+        isNotEmpty,
+        reason: 'a successful real login should save the server',
+      );
+      expect(
+        app.servers.getServersList.any((s) => s.address.contains(uri.host)),
+        isTrue,
+      );
+
+      final saved = app.servers.getServersList.first;
+      expect(await app.tokenOf(saved.address), RealPiholeEnv.v5Token);
+    });
+  });
+
+  group('add (v6, no password)', () {
+    testWidgets('(C2) password-less v6 connects and stores no sid', (
+      tester,
+    ) async {
+      final app = AppHarness(tester);
+      await app.boot();
+      final uri = Uri.parse(RealPiholeEnv.v6BaseWP);
+
+      await app.openAddServer();
+      await app.addV6ServerViaUi(
+        host: uri.host,
+        port: uri.hasPort ? '${uri.port}' : '',
+        password: '',
+        alias: 'noauth-v6',
+      );
+
+      expect(
+        find.text(app.l10n.connectedSuccessfully),
+        findsOneWidget,
+        reason: 'a password-less v6 login still shows the success snackbar',
+      );
+      expect(app.servers.getServersList, isNotEmpty);
+      final saved = app.servers.getServersList.first;
+      expect(await app.passwordOf(saved.address), '');
+      final sid = await app.sidOf(saved.address);
+      expect(
+        sid == null || sid.isEmpty,
+        isTrue,
+        reason: 'a password-less v6 server should not persist a sid',
+      );
+    });
+  });
+
+  group('add (v5, no token)', () {
+    testWidgets('(C4) password-less v5 connects and stores no token', (
+      tester,
+    ) async {
+      final app = AppHarness(tester);
+      await app.boot();
+      final uri = Uri.parse(RealPiholeEnv.v5BaseWP);
+
+      await app.openAddServer();
+      await app.addV5ServerViaUi(
+        host: uri.host,
+        port: uri.hasPort ? '${uri.port}' : '',
+        token: '',
+        alias: 'noauth-v5',
+      );
+
+      expect(
+        find.text(app.l10n.connectedSuccessfully),
+        findsOneWidget,
+        reason: 'a token-less v5 login still shows the success snackbar',
+      );
+      expect(app.servers.getServersList, isNotEmpty);
+      final saved = app.servers.getServersList.first;
+      expect(await app.tokenOf(saved.address), '');
+    });
+  });
+}

--- a/integration_test/real/edit_real_test.dart
+++ b/integration_test/real/edit_real_test.dart
@@ -1,0 +1,328 @@
+import 'package:flutter_dotenv/flutter_dotenv.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+import 'package:pi_hole_client/data/services/api/pihole_v6_api_client.dart';
+
+import '../support/app_harness.dart';
+import '../support/real_pihole_env.dart';
+
+/// Real-Pi-hole tests for editing a server: alias-only edits, version
+/// switches, address replacement, duplicate-address rejection, default
+/// promotion, and session cleanup on a failed delete.
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  setUpAll(() async {
+    if (!dotenv.isInitialized) {
+      try {
+        await dotenv.load();
+      } catch (_) {
+        // .env is optional (Sentry/biometrics disabled in tests).
+      }
+    }
+  });
+
+  group('edit alias', () {
+    testWidgets('(E1) an alias-only edit does not touch the session', (
+      tester,
+    ) async {
+      final app = AppHarness(tester);
+      await app.boot();
+      final uri = Uri.parse(RealPiholeEnv.v6Base);
+
+      await app.openAddServer();
+      await app.addV6ServerViaUi(
+        host: uri.host,
+        port: uri.hasPort ? '${uri.port}' : '',
+        password: RealPiholeEnv.v6Password,
+        alias: 'em1-original',
+      );
+      expect(find.text(app.l10n.connectedSuccessfully), findsOneWidget);
+      final address = app.servers.getServersList.single.address;
+      final sidBefore = await app.sidOf(address);
+
+      await app.editServer(alias: 'em1-renamed');
+      expect(find.text(app.l10n.editServerSuccessfully), findsOneWidget);
+
+      expect(app.servers.getServersList.single.alias, 'em1-renamed');
+      expect(
+        await app.sidOf(address),
+        equals(sidBefore),
+        reason: 'an alias-only edit must not force a re-login',
+      );
+    });
+  });
+
+  group('v6 to v5 version change', () {
+    testWidgets('(X3) switching version replaces the server with a v5 one', (
+      tester,
+    ) async {
+      final app = AppHarness(tester);
+      await app.boot();
+      final oldUri = Uri.parse(RealPiholeEnv.v6Base);
+
+      await app.openAddServer();
+      await app.addV6ServerViaUi(
+        host: oldUri.host,
+        port: oldUri.hasPort ? '${oldUri.port}' : '',
+        password: RealPiholeEnv.v6Password,
+        alias: 'em2-v6',
+      );
+      expect(find.text(app.l10n.connectedSuccessfully), findsOneWidget);
+      final oldAddress = app.servers.getServersList.single.address;
+
+      final newUri = Uri.parse(RealPiholeEnv.v5Base);
+      await app.editServer(
+        version: 'v5',
+        host: newUri.host,
+        port: newUri.hasPort ? '${newUri.port}' : '',
+        token: RealPiholeEnv.v5Token,
+      );
+      expect(find.text(app.l10n.editServerSuccessfully), findsOneWidget);
+
+      expect(app.servers.getServersList, hasLength(1));
+      final saved = app.servers.getServersList.single;
+      expect(await app.tokenOf(saved.address), RealPiholeEnv.v5Token);
+
+      final oldSecrets = await app.serverSecretKeys();
+      expect(
+        oldSecrets.where((k) => k.startsWith(oldAddress)),
+        isEmpty,
+        reason: 'a version-change replace must not leave old-address secrets',
+      );
+    });
+  });
+
+  group('address change (replace)', () {
+    testWidgets('(X1) changing the address replaces the old v6 entry', (
+      tester,
+    ) async {
+      final app = AppHarness(tester);
+      await app.boot();
+      final oldUri = Uri.parse(RealPiholeEnv.v6Base);
+
+      await app.openAddServer();
+      await app.addV6ServerViaUi(
+        host: oldUri.host,
+        port: oldUri.hasPort ? '${oldUri.port}' : '',
+        password: RealPiholeEnv.v6Password,
+        alias: 'em4-original',
+      );
+      expect(find.text(app.l10n.connectedSuccessfully), findsOneWidget);
+      final oldAddress = app.servers.getServersList.single.address;
+
+      final newUri = Uri.parse(RealPiholeEnv.v6BaseWP);
+      await app.editServer(
+        host: newUri.host,
+        port: newUri.hasPort ? '${newUri.port}' : '',
+        password: '',
+      );
+      expect(find.text(app.l10n.editServerSuccessfully), findsOneWidget);
+
+      expect(app.servers.getServersList, hasLength(1));
+      expect(
+        app.servers.getServersList.single.address.contains(newUri.host),
+        isTrue,
+      );
+
+      final secrets = await app.serverSecretKeys();
+      expect(
+        secrets.where((k) => k.startsWith(oldAddress)),
+        isEmpty,
+        reason: 'an address-change replace must not leave old-address secrets',
+      );
+    });
+  });
+
+  group('duplicate URL on edit', () {
+    testWidgets(
+      "(X5) editing one server's address to match another's is rejected",
+      (tester) async {
+        final app = AppHarness(tester);
+        await app.boot();
+        final uriA = Uri.parse(RealPiholeEnv.v6Base);
+        final uriB = Uri.parse(RealPiholeEnv.v6BaseWP);
+
+        await app.openAddServer();
+        await app.addV6ServerViaUi(
+          host: uriA.host,
+          port: uriA.hasPort ? '${uriA.port}' : '',
+          password: RealPiholeEnv.v6Password,
+          alias: 'em7-dup-a',
+        );
+        expect(find.text(app.l10n.connectedSuccessfully), findsOneWidget);
+
+        await app.openAddServer();
+        await app.addV6ServerViaUi(
+          host: uriB.host,
+          port: uriB.hasPort ? '${uriB.port}' : '',
+          password: '',
+          alias: 'em7-dup-b',
+        );
+        expect(find.text(app.l10n.connectedSuccessfully), findsOneWidget);
+        expect(app.servers.getServersList, hasLength(2));
+
+        await app.editServer(
+          at: 'em7-dup-b',
+          host: uriA.host,
+          port: uriA.hasPort ? '${uriA.port}' : '',
+        );
+        expect(find.text(app.l10n.connectionAlreadyExists), findsOneWidget);
+
+        expect(
+          app.servers.getServersList,
+          hasLength(2),
+          reason: 'a rejected duplicate-address edit must not merge servers',
+        );
+        final dupB = app.servers.getServersList.firstWhere(
+          (s) => s.alias == 'em7-dup-b',
+        );
+        expect(
+          dupB.address.contains(uriB.host),
+          isTrue,
+          reason: "the rejected edit must leave em7-dup-b's address unchanged",
+        );
+      },
+    );
+  });
+
+  group('default promotion', () {
+    testWidgets('(E10) setting a new default clears the old one', (
+      tester,
+    ) async {
+      final app = AppHarness(tester);
+      await app.boot();
+      final uriA = Uri.parse(RealPiholeEnv.v6Base);
+      final uriB = Uri.parse(RealPiholeEnv.v6BaseWP);
+
+      await app.openAddServer();
+      await app.addV6ServerViaUi(
+        host: uriA.host,
+        port: uriA.hasPort ? '${uriA.port}' : '',
+        password: RealPiholeEnv.v6Password,
+        alias: 'em8-a',
+      );
+      expect(find.text(app.l10n.connectedSuccessfully), findsOneWidget);
+
+      await app.openAddServer();
+      await app.addV6ServerViaUi(
+        host: uriB.host,
+        port: uriB.hasPort ? '${uriB.port}' : '',
+        password: '',
+        alias: 'em8-b',
+      );
+      expect(find.text(app.l10n.connectedSuccessfully), findsOneWidget);
+
+      await app.setDefaultServerFor('em8-a');
+      await app.settle(frames: 5);
+      expect(
+        app.servers.getServersList
+            .firstWhere((s) => s.alias == 'em8-a')
+            .defaultServer,
+        isTrue,
+      );
+
+      await app.setDefaultServerFor('em8-b');
+      await app.settle(frames: 5);
+      expect(
+        app.servers.getServersList
+            .firstWhere((s) => s.alias == 'em8-b')
+            .defaultServer,
+        isTrue,
+      );
+      expect(
+        app.servers.getServersList
+            .firstWhere((s) => s.alias == 'em8-a')
+            .defaultServer,
+        isFalse,
+        reason: 'promoting a new default must clear the previous one',
+      );
+    });
+  });
+
+  group('v5 replace', () {
+    testWidgets('(X4) changing a v5 address replaces the old entry', (
+      tester,
+    ) async {
+      final app = AppHarness(tester);
+      await app.boot();
+      final oldUri = Uri.parse(RealPiholeEnv.v5Base);
+
+      await app.openAddServer();
+      await app.addV5ServerViaUi(
+        host: oldUri.host,
+        port: oldUri.hasPort ? '${oldUri.port}' : '',
+        token: RealPiholeEnv.v5Token,
+        alias: 'em17-original',
+      );
+      expect(find.text(app.l10n.connectedSuccessfully), findsOneWidget);
+      final oldAddress = app.servers.getServersList.single.address;
+
+      final newUri = Uri.parse(RealPiholeEnv.v5BaseWP);
+      await app.editServer(
+        host: newUri.host,
+        port: newUri.hasPort ? '${newUri.port}' : '',
+        token: '',
+      );
+      expect(find.text(app.l10n.editServerSuccessfully), findsOneWidget);
+
+      expect(app.servers.getServersList, hasLength(1));
+      final secrets = await app.serverSecretKeys();
+      expect(
+        secrets.where((k) => k.startsWith(oldAddress)),
+        isEmpty,
+        reason: 'a v5 address-change replace must not leave old-address secrets',
+      );
+    });
+  });
+
+  group('edit v6 to v5 through fault-delete proxy', () {
+    testWidgets(
+      '(X3) the old v6 session is logged out even when the first delete attempt fails (TODO FIX)',
+      (tester) async {
+        final app = AppHarness(tester);
+        await app.boot();
+
+        // Add/connect (auth + blocking status) succeed here; only a later
+        // DELETE /api/auth is faulted with 401.
+        final oldUri = Uri.parse(RealPiholeEnv.faultDeleteBase);
+        await app.openAddServer();
+        await app.addV6ServerViaUi(
+          host: oldUri.host,
+          port: oldUri.hasPort ? '${oldUri.port}' : '',
+          password: RealPiholeEnv.v6Password,
+          alias: 'edit-old-v6',
+        );
+        expect(find.text(app.l10n.connectedSuccessfully), findsOneWidget);
+        await app.connectServer();
+
+        final oldAddress = app.servers.getServersList.single.address;
+        final oldSid = await app.sidOf(oldAddress);
+        expect(oldSid, isNotNull);
+
+        final newUri = Uri.parse(RealPiholeEnv.v5Base);
+        await app.editServer(
+          version: 'v5',
+          host: newUri.host,
+          port: newUri.hasPort ? '${newUri.port}' : '',
+          token: RealPiholeEnv.v5Token,
+        );
+        expect(find.text(app.l10n.editServerSuccessfully), findsOneWidget);
+
+        // Check directly against the real Pi-hole (no proxy) whether the old
+        // session is still valid.
+        final directClient = PiholeV6ApiClient(url: RealPiholeEnv.v6Base);
+        try {
+          final result = await directClient.getAuth(oldSid);
+          expect(
+            result.getOrThrow().session.valid,
+            isFalse,
+            reason: 'the old v6 session must be logged out on version switch',
+          );
+        } finally {
+          directClient.close();
+        }
+      },
+    );
+  });
+}

--- a/integration_test/real/edit_real_test.dart
+++ b/integration_test/real/edit_real_test.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/material.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
@@ -271,7 +272,8 @@ void main() {
       expect(
         secrets.where((k) => k.startsWith(oldAddress)),
         isEmpty,
-        reason: 'a v5 address-change replace must not leave old-address secrets',
+        reason:
+            'a v5 address-change replace must not leave old-address secrets',
       );
     });
   });
@@ -299,6 +301,14 @@ void main() {
         final oldAddress = app.servers.getServersList.single.address;
         final oldSid = await app.sidOf(oldAddress);
         expect(oldSid, isNotNull);
+
+        // Settings > Servers (the bottom nav has no direct "connect" tab).
+        await tester.tap(
+          find.widgetWithText(NavigationDestination, app.l10n.settings),
+        );
+        await app.settle(frames: 10);
+        await tester.tap(find.widgetWithText(ListTile, app.l10n.servers));
+        await app.settle(frames: 10);
 
         final newUri = Uri.parse(RealPiholeEnv.v5Base);
         await app.editServer(

--- a/integration_test/real/general_ops_real_test.dart
+++ b/integration_test/real/general_ops_real_test.dart
@@ -1,0 +1,338 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_dotenv/flutter_dotenv.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+import 'package:pi_hole_client/ui/domains/widgets/domain_details_screen.dart';
+import 'package:pi_hole_client/ui/domains/widgets/domains_screen.dart';
+import 'package:pi_hole_client/ui/home/widgets/disable_modal.dart';
+import 'package:pi_hole_client/ui/home/widgets/home_screen.dart';
+import 'package:pi_hole_client/ui/logs/widgets/logs_screen.dart';
+import 'package:pi_hole_client/ui/settings/server_settings/adlists/widgets/adlist_details_screen.dart';
+import 'package:pi_hole_client/ui/settings/server_settings/adlists/widgets/adlist_screen.dart';
+import 'package:pi_hole_client/ui/settings/server_settings/group_client/widgets/group_client_screen.dart';
+import 'package:pi_hole_client/ui/settings/server_settings/group_client/widgets/group_details_screen.dart';
+import 'package:pi_hole_client/ui/settings/server_settings/server_info/widgets/server_info_screen.dart';
+import 'package:pi_hole_client/ui/settings/widgets/settings_screen.dart';
+import 'package:pi_hole_client/ui/statistics/widgets/statistics_screen.dart';
+
+import '../support/app_harness.dart';
+import '../support/real_pihole_env.dart';
+
+/// Real-Pi-hole tests for post-login UI operations: tab navigation, settings
+/// sub-screens, blocking toggle, and domain/adlist/group CRUD.
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  setUpAll(() async {
+    if (!dotenv.isInitialized) {
+      try {
+        await dotenv.load();
+      } catch (_) {
+        // .env is optional (Sentry/biometrics disabled in tests).
+      }
+    }
+  });
+
+  group('post-login UI (v6, HTTP)', () {
+    testWidgets('walks every tab and opens settings sub-screens', (
+      tester,
+    ) async {
+      final app = AppHarness(tester);
+      await app.boot();
+      final uri = Uri.parse(RealPiholeEnv.v6Base);
+
+      await app.openAddServer();
+      await app.addV6ServerViaUi(
+        host: uri.host,
+        port: uri.hasPort ? '${uri.port}' : '',
+        password: RealPiholeEnv.v6Password,
+        alias: 'ui-nav',
+      );
+      expect(find.text(app.l10n.connectedSuccessfully), findsOneWidget);
+      await app.connectServer();
+      expect(find.byType(HomeScreen), findsOneWidget);
+
+      Future<void> gotoTab(String label) async {
+        await tester.tap(find.widgetWithText(NavigationDestination, label));
+        await app.settle(frames: 10);
+      }
+
+      await gotoTab(app.l10n.statistics);
+      expect(find.byType(StatisticsScreen), findsOneWidget);
+
+      await gotoTab(app.l10n.logs);
+      expect(find.byType(LogsScreen), findsOneWidget);
+
+      await gotoTab(app.l10n.domains);
+      expect(find.byType(DomainsScreen), findsOneWidget);
+      expect(find.text('Whitelist'), findsOneWidget);
+      expect(find.text('Blacklist'), findsOneWidget);
+
+      await gotoTab(app.l10n.settings);
+      expect(find.byType(SettingsScreen), findsOneWidget);
+
+      Future<void> openAndBackSetting<T extends Widget>(String label) async {
+        final tile = find.widgetWithText(ListTile, label);
+        await tester.ensureVisible(tile);
+        await app.settle(frames: 5);
+        await tester.tap(tile);
+        await app.settle(); // sub-screen fetches real data over HTTP
+        expect(
+          find.byType(T),
+          findsOneWidget,
+          reason: 'opening $label navigates to it',
+        );
+        await tester.tap(find.byType(BackButton));
+        await app.settle(frames: 10);
+        expect(
+          find.byType(SettingsScreen),
+          findsOneWidget,
+          reason: 'back from $label must return to the settings list',
+        );
+      }
+
+      await openAndBackSetting<ServerInfoScreen>(app.l10n.serverInfo);
+      await openAndBackSetting<AdlistScreen>(app.l10n.adlists);
+      await openAndBackSetting<GroupClientScreen>(app.l10n.groupsAndClients);
+
+      await gotoTab(app.l10n.home);
+      expect(find.byType(HomeScreen), findsOneWidget);
+    });
+
+    testWidgets('blocking toggle is state-aware and self-healing', (
+      tester,
+    ) async {
+      final app = AppHarness(tester);
+      await app.boot();
+      final uri = Uri.parse(RealPiholeEnv.v6Base);
+
+      await app.openAddServer();
+      await app.addV6ServerViaUi(
+        host: uri.host,
+        port: uri.hasPort ? '${uri.port}' : '',
+        password: RealPiholeEnv.v6Password,
+        alias: 'ui-blocking',
+      );
+      expect(find.text(app.l10n.connectedSuccessfully), findsOneWidget);
+      await app.connectServer();
+
+      final fab = find.widgetWithIcon(
+        FloatingActionButton,
+        Icons.shield_rounded,
+      );
+      if (app.servers.selectedServerEnabled != true) {
+        await tester.tap(fab);
+        await app.waitFor(find.byType(SnackBar));
+        await app.settle(frames: 4);
+        expect(find.text(app.l10n.serverEnabled), findsOneWidget);
+      }
+      expect(app.servers.selectedServerEnabled, isTrue);
+      await app.settle(frames: 15);
+
+      // Enabled -> tap opens DisableModal. Pick "Indefinitely"
+      await tester.tap(fab);
+      await app.settle(frames: 5);
+      expect(find.byType(DisableModal), findsOneWidget);
+      expect(find.text(app.l10n.indefinitely), findsWidgets);
+      await tester.tap(find.text(app.l10n.indefinitely).first);
+      await app.settle(frames: 3);
+      await tester.tap(find.text(app.l10n.accept));
+      await app.waitFor(find.byType(SnackBar));
+      await app.settle(frames: 4);
+      expect(find.text(app.l10n.serverDisabled), findsOneWidget);
+      expect(app.servers.selectedServerEnabled, isFalse);
+
+      // Disabled -> tap re-enables directly
+      await tester.tap(fab);
+      await app.waitFor(find.byType(SnackBar));
+      await app.settle(frames: 4);
+      expect(find.text(app.l10n.serverEnabled), findsOneWidget);
+      expect(app.servers.selectedServerEnabled, isTrue);
+    });
+
+    testWidgets('domain: add, edit, then delete', (tester) async {
+      final app = AppHarness(tester);
+      await app.boot();
+      final uri = Uri.parse(RealPiholeEnv.v6Base);
+
+      await app.openAddServer();
+      await app.addV6ServerViaUi(
+        host: uri.host,
+        port: uri.hasPort ? '${uri.port}' : '',
+        password: RealPiholeEnv.v6Password,
+        alias: 'ui-domain',
+      );
+      expect(find.text(app.l10n.connectedSuccessfully), findsOneWidget);
+      await app.connectServer();
+
+      final testDomain =
+          'e2e-${DateTime.now().millisecondsSinceEpoch}.example.com';
+
+      await tester.tap(
+        find.widgetWithText(NavigationDestination, app.l10n.domains),
+      );
+      await app.settle(frames: 10);
+      expect(find.byType(DomainsScreen), findsOneWidget);
+
+      // Add (Whitelist is the default selected tab).
+      await tester.tap(find.byIcon(Icons.add));
+      await app.settle(frames: 5);
+      await tester.enterText(find.byType(TextField), testDomain);
+      // (no-op) button
+      await app.settle(frames: 3);
+      await tester.tap(find.text(app.l10n.add));
+      await app.waitFor(find.text(app.l10n.domainAdded));
+      expect(find.text(app.l10n.domainAdded), findsOneWidget);
+      await app.settle();
+      expect(find.text(testDomain), findsOneWidget);
+
+      // Edit: toggle the Status switch off.
+      await tester.tap(find.text(testDomain));
+      await app.settle();
+      expect(find.byType(DomainDetailsScreen), findsOneWidget);
+      final domainSwitch = find.byType(Switch);
+      await tester.tap(domainSwitch);
+      await app.waitFor(find.text(app.l10n.domainUpdated));
+      await app.settle(frames: 4);
+      expect(find.text(app.l10n.domainUpdated), findsOneWidget);
+      expect(tester.widget<Switch>(domainSwitch).value, isFalse);
+
+      // Delete.
+      await tester.tap(find.byIcon(Icons.delete_rounded));
+      await app.settle(frames: 3);
+      expect(find.text(app.l10n.domainDelete), findsOneWidget);
+      await tester.tap(find.text(app.l10n.delete));
+      await app.waitFor(find.text(app.l10n.domainRemoved));
+      expect(find.text(app.l10n.domainRemoved), findsOneWidget);
+      await app.settle();
+      expect(find.byType(DomainsScreen), findsOneWidget);
+      expect(find.text(testDomain), findsNothing);
+    });
+
+    testWidgets('adlist: add, edit, then delete', (tester) async {
+      final app = AppHarness(tester);
+      await app.boot();
+      final uri = Uri.parse(RealPiholeEnv.v6Base);
+
+      await app.openAddServer();
+      await app.addV6ServerViaUi(
+        host: uri.host,
+        port: uri.hasPort ? '${uri.port}' : '',
+        password: RealPiholeEnv.v6Password,
+        alias: 'ui-adlist',
+      );
+      expect(find.text(app.l10n.connectedSuccessfully), findsOneWidget);
+      await app.connectServer();
+
+      final testAddress =
+          'http://example.com/e2e-${DateTime.now().millisecondsSinceEpoch}.txt';
+
+      await tester.tap(
+        find.widgetWithText(NavigationDestination, app.l10n.settings),
+      );
+      await app.settle(frames: 10);
+      final adlistsTile = find.widgetWithText(ListTile, app.l10n.adlists);
+      await tester.ensureVisible(adlistsTile);
+      await app.settle(frames: 5);
+      await tester.tap(adlistsTile);
+      await app.settle();
+      expect(find.byType(AdlistScreen), findsOneWidget);
+
+      // Add (Allow/whitelist is the default selected tab).
+      await tester.tap(find.byIcon(Icons.add));
+      await app.settle(frames: 5);
+      await tester.enterText(find.byType(TextField).at(0), testAddress);
+      await app.settle(frames: 3);
+      await tester.tap(find.text(app.l10n.add));
+      await app.waitFor(find.text(app.l10n.adlistAdded));
+      expect(find.text(app.l10n.adlistAdded), findsOneWidget);
+      await app.settle();
+      expect(find.text(testAddress), findsOneWidget);
+
+      // Edit: toggle the Status switch off.
+      await tester.tap(find.text(testAddress));
+      await app.settle();
+      expect(find.byType(AdlistDetailsScreen), findsOneWidget);
+      final adlistSwitch = find.byType(Switch);
+      await tester.tap(adlistSwitch);
+      await app.waitFor(find.text(app.l10n.adlistUpdated));
+      await app.settle(frames: 4);
+      expect(find.text(app.l10n.adlistUpdated), findsOneWidget);
+      expect(tester.widget<Switch>(adlistSwitch).value, isFalse);
+
+      // Delete.
+      await tester.tap(find.byIcon(Icons.delete_rounded));
+      await app.settle(frames: 3);
+      expect(find.text(app.l10n.adlistDelete), findsOneWidget);
+      await tester.tap(find.text(app.l10n.delete));
+      await app.waitFor(find.text(app.l10n.adlistRemoved));
+      expect(find.text(app.l10n.adlistRemoved), findsOneWidget);
+      await app.settle();
+      expect(find.text(testAddress), findsNothing);
+    });
+
+    testWidgets('group: add, edit, then delete', (tester) async {
+      final app = AppHarness(tester);
+      await app.boot();
+      final uri = Uri.parse(RealPiholeEnv.v6Base);
+
+      await app.openAddServer();
+      await app.addV6ServerViaUi(
+        host: uri.host,
+        port: uri.hasPort ? '${uri.port}' : '',
+        password: RealPiholeEnv.v6Password,
+        alias: 'ui-group',
+      );
+      expect(find.text(app.l10n.connectedSuccessfully), findsOneWidget);
+      await app.connectServer();
+
+      final testGroup = 'e2e-group-${DateTime.now().millisecondsSinceEpoch}';
+
+      await tester.tap(
+        find.widgetWithText(NavigationDestination, app.l10n.settings),
+      );
+      await app.settle(frames: 10);
+      final groupsTile = find.widgetWithText(
+        ListTile,
+        app.l10n.groupsAndClients,
+      );
+      await tester.ensureVisible(groupsTile);
+      await app.settle(frames: 5);
+      await tester.tap(groupsTile);
+      await app.settle();
+      expect(find.byType(GroupClientScreen), findsOneWidget);
+
+      // Add (Groups is the default selected tab).
+      await tester.tap(find.byIcon(Icons.add));
+      await app.settle(frames: 5);
+      await tester.enterText(find.byType(TextField).at(0), testGroup);
+      await app.settle(frames: 3);
+      await tester.tap(find.text(app.l10n.add));
+      await app.waitFor(find.text(app.l10n.groupAdded));
+      expect(find.text(app.l10n.groupAdded), findsOneWidget);
+      await app.settle();
+      expect(find.text(testGroup), findsOneWidget);
+
+      // Edit: toggle the Status switch off.
+      await tester.tap(find.text(testGroup));
+      await app.settle();
+      expect(find.byType(GroupDetailsScreen), findsOneWidget);
+      final groupSwitch = find.byType(Switch);
+      await tester.tap(groupSwitch);
+      await app.waitFor(find.text(app.l10n.groupUpdated));
+      await app.settle(frames: 4);
+      expect(find.text(app.l10n.groupUpdated), findsOneWidget);
+      expect(tester.widget<Switch>(groupSwitch).value, isFalse);
+
+      // Delete.
+      await tester.tap(find.byIcon(Icons.delete_rounded));
+      await app.settle(frames: 3);
+      expect(find.text(app.l10n.groupDelete), findsOneWidget);
+      await tester.tap(find.text(app.l10n.delete));
+      await app.waitFor(find.text(app.l10n.groupRemoved));
+      expect(find.text(app.l10n.groupRemoved), findsOneWidget);
+      await app.settle();
+      expect(find.text(testGroup), findsNothing);
+    });
+  });
+}

--- a/integration_test/support/app_harness.dart
+++ b/integration_test/support/app_harness.dart
@@ -1,0 +1,402 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pi_hole_client/data/repositories/api/repository_factory.dart';
+import 'package:pi_hole_client/data/repositories/local/server_repository.dart';
+import 'package:pi_hole_client/data/services/local/database_service.dart';
+import 'package:pi_hole_client/data/services/local/secure_storage_service.dart';
+import 'package:pi_hole_client/domain/model/server/api_versions.dart';
+import 'package:pi_hole_client/main.dart' as app;
+import 'package:pi_hole_client/pi_hole_client.dart';
+import 'package:pi_hole_client/ui/core/l10n/generated/app_localizations.dart';
+import 'package:pi_hole_client/ui/core/view_models/servers_viewmodel.dart';
+import 'package:pi_hole_client/ui/core/view_models/status_viewmodel.dart';
+import 'package:pi_hole_client/ui/domains/widgets/domain_details_screen.dart';
+import 'package:pi_hole_client/ui/domains/widgets/domains_screen.dart';
+import 'package:pi_hole_client/ui/home/widgets/home_screen.dart';
+import 'package:pi_hole_client/ui/logs/widgets/logs_screen.dart';
+import 'package:pi_hole_client/ui/servers/widgets/add_server_fullscreen.dart';
+import 'package:pi_hole_client/ui/servers/widgets/servers_screen.dart';
+import 'package:pi_hole_client/ui/servers/widgets/servers_tile_item.dart';
+import 'package:pi_hole_client/ui/settings/server_settings/adlists/widgets/adlist_details_screen.dart';
+import 'package:pi_hole_client/ui/settings/server_settings/adlists/widgets/adlist_screen.dart';
+import 'package:pi_hole_client/ui/settings/server_settings/group_client/widgets/group_client_screen.dart';
+import 'package:pi_hole_client/ui/settings/server_settings/group_client/widgets/group_details_screen.dart';
+import 'package:pi_hole_client/ui/settings/widgets/settings_screen.dart';
+import 'package:pi_hole_client/ui/statistics/widgets/statistics_screen.dart';
+import 'package:provider/provider.dart';
+
+/// Drives the **real** app (real DI, real DB, real secure storage) in an
+/// integration test, pointed at a real Pi-hole (or Caddy proxy) via the server
+/// URL entered in the UI.
+class AppHarness {
+  AppHarness(this.tester);
+
+  final WidgetTester tester;
+
+  late final DatabaseService db;
+  late final SecureStorageService storage;
+
+  BuildContext get _ctx => tester.element(find.byType(PiHoleClient));
+
+  BuildContext get _localizedCtx {
+    final candidates = [
+      find.byType(ServersScreen),
+      find.byType(AddServerFullscreen),
+      find.byType(HomeScreen),
+      find.byType(StatisticsScreen),
+      find.byType(LogsScreen),
+      find.byType(DomainsScreen),
+      find.byType(DomainDetailsScreen),
+      find.byType(SettingsScreen),
+      find.byType(AdlistScreen),
+      find.byType(AdlistDetailsScreen),
+      find.byType(GroupClientScreen),
+      find.byType(GroupDetailsScreen),
+      find.byType(PiHoleClient),
+    ];
+
+    for (final finder in candidates) {
+      final elements = finder.evaluate();
+      if (elements.isNotEmpty) {
+        return elements.first;
+      }
+    }
+
+    throw TestFailure('No localized screen is currently visible.');
+  }
+
+  /// Live view models from the running provider tree.
+  ServersViewModel get servers =>
+      Provider.of<ServersViewModel>(_ctx, listen: false);
+  StatusViewModel get status =>
+      Provider.of<StatusViewModel>(_ctx, listen: false);
+
+  AppLocalizations get l10n {
+    final l10n = AppLocalizations.of(_localizedCtx);
+    if (l10n == null) {
+      throw TestFailure(
+        'AppLocalizations was not found in the current widget tree.',
+      );
+    }
+    return l10n;
+  }
+
+  /// Boots the real app with an isolated, empty DB + secure storage.
+  ///
+  /// [autoRefreshTimeSeconds], when given, seeds a short auto-refresh
+  /// interval (instead of the persisted default of 5s) so a test can wait
+  /// for a real background `Timer.periodic` tick in a few seconds rather
+  /// than waiting on the default interval.
+  Future<void> boot({
+    String dbPath = 'integration_test.db',
+    int? autoRefreshTimeSeconds,
+  }) async {
+    db = DatabaseService(path: dbPath);
+    storage = SecureStorageService();
+
+    await db.open();
+    // skip the welcome screen
+    await db.update('appConfig', {'importantInfoReaden': 1});
+    if (autoRefreshTimeSeconds != null) {
+      await db.update('appConfig', {'autoRefreshTime': autoRefreshTimeSeconds});
+    }
+
+    // Clean slate: clears servers + secure storage.
+    final repo = LocalServerRepository(db, storage);
+    await repo.deleteAllServers();
+    await storage.clearAll();
+
+    final root = await app.bootstrapApp(
+      enableSentry: false,
+      enableBiometrics: false,
+      databaseService: db,
+      secureStorageService: storage,
+    );
+    await tester.pumpWidget(root);
+    await settle();
+
+    addTearDown(logoutRealSessions);
+  }
+
+  /// Deletes every v6 session created during this test from the real Pi-hole
+  Future<void> logoutRealSessions() async {
+    // Stop the app's auto-refresh first so it can't re-create a session
+    try {
+      status.stopAutoRefresh();
+    } catch (_) {}
+
+    final servers = (await LocalServerRepository(
+      db,
+      storage,
+    ).fetchServers()).getOrNull();
+    if (servers == null) return;
+
+    for (final server in servers) {
+      if (server.apiVersion != SupportedApiVersions.v6) continue;
+      final sid = await sidOf(server.address);
+      if (sid == null || sid.isEmpty) continue;
+      try {
+        final bundle = RepositoryBundleFactory.create(
+          server: server,
+          storage: storage,
+        );
+        await bundle.auth.deleteCurrentSession();
+      } catch (_) {}
+    }
+  }
+
+  /// Bounded replacement for `pumpAndSettle`, which would hang on the
+  /// periodic auto-refresh timers.
+  Future<void> settle({
+    int frames = 40,
+    Duration step = const Duration(milliseconds: 150),
+  }) async {
+    for (var i = 0; i < frames; i++) {
+      await tester.pump(step);
+    }
+  }
+
+  /// Pumps up to [maxFrames], returning true as soon as [finder] matches, or
+  /// false if it never appears -- catches a transient snackbar before it
+  /// auto-dismisses.
+  Future<bool> waitFor(
+    Finder finder, {
+    int maxFrames = 60,
+    Duration step = const Duration(milliseconds: 150),
+  }) async {
+    for (var i = 0; i < maxFrames; i++) {
+      await tester.pump(step);
+      if (finder.evaluate().isNotEmpty) return true;
+    }
+    return false;
+  }
+
+  Future<bool> waitForText(String text, {int maxFrames = 60}) =>
+      waitFor(find.text(text), maxFrames: maxFrames);
+
+  Future<String?> secret(String key) async =>
+      (await storage.getValue(key)).getOrNull();
+
+  Future<String?> sidOf(String address) => secret('${address}_sid');
+  Future<String?> passwordOf(String address) => secret('${address}_password');
+  Future<String?> tokenOf(String address) => secret('${address}_token');
+
+  Future<List<String>> serverSecretKeys() async {
+    final all = (await storage.readAll()).getOrNull() ?? const {};
+    return all.keys
+        .where(
+          (k) =>
+              k.endsWith('_sid') ||
+              k.endsWith('_password') ||
+              k.endsWith('_token'),
+        )
+        .toList();
+  }
+
+  /// Opens the add-server screen from the servers list FAB.
+  Future<void> openAddServer() async {
+    await tester.tap(find.byIcon(Icons.add));
+    await settle();
+  }
+
+  bool hasServer(String address) =>
+      servers.getServersList.any((s) => s.address == address);
+
+  /// Taps Connect on the unselected server tile and waits for it to finish.
+  Future<void> connectServer() async {
+    await tester.tap(find.widgetWithText(FilledButton, l10n.connect));
+    await waitFor(find.byType(HomeScreen));
+    await settle(frames: 4);
+  }
+
+  // ==========================================================================
+  // UI helpers for the add-server form
+  // ==========================================================================
+
+  /// Fills and submits the add-server form for a v6 server over HTTP.
+  /// Assumes the default form state (HTTP + v6).
+  Future<void> addV6ServerViaUi({
+    required String host,
+    required String password,
+    String alias = 'it-v6',
+    String port = '',
+  }) async {
+    final fields = find.byType(EditableText);
+    await tester.enterText(fields.at(0), alias);
+    await tester.enterText(fields.at(1), host);
+    if (port.isNotEmpty) await tester.enterText(fields.at(2), port);
+    await tester.enterText(fields.at(3), password);
+    await settle(frames: 3);
+
+    await tester.tap(find.byIcon(Icons.login_rounded));
+    // catch the outcome snackbar before it auto-dismisses
+    await waitFor(find.byType(SnackBar));
+    await settle(frames: 4);
+  }
+
+  /// Fills and submits the add-server form for a v5 server over HTTP.
+  /// Assumes the default form state (HTTP + v5).
+  Future<void> addV5ServerViaUi({
+    required String host,
+    required String token,
+    String alias = 'it-v5',
+    String port = '',
+  }) async {
+    final fields = find.byType(EditableText);
+    await tester.enterText(fields.at(0), alias);
+    await tester.enterText(fields.at(1), host);
+    if (port.isNotEmpty) await tester.enterText(fields.at(2), port);
+    await tester.tap(find.text('v5').last); // switch to v5
+    await tester.enterText(fields.at(3), token);
+    await settle(frames: 3);
+
+    await tester.tap(find.byIcon(Icons.login_rounded));
+    // catch the outcome snackbar before it auto-dismisses
+    await waitFor(find.byType(SnackBar));
+    await settle(frames: 4);
+  }
+
+  /// Fills and submits the add-server form for a v6 server over HTTPS.
+  Future<void> addV6ServerHttpsViaUi({
+    required String host,
+    required String password,
+    String alias = 'it-v6-https',
+    String port = '',
+    bool allowUntrustedCert = true,
+  }) async {
+    await tester.tap(find.text('HTTPS'));
+    await settle(frames: 3);
+
+    final fields = find.byType(EditableText);
+    await tester.enterText(fields.at(0), alias);
+    await tester.enterText(fields.at(1), host);
+    if (port.isNotEmpty) await tester.enterText(fields.at(2), port);
+    if (!allowUntrustedCert) {
+      // The "allow untrusted certificate" checkbox is checked by default.
+      await tester.tap(find.byType(CheckboxListTile).first);
+      await settle(frames: 2);
+    }
+    await tester.enterText(fields.at(4), password);
+    await settle(frames: 3);
+
+    await tester.tap(find.byIcon(Icons.login_rounded));
+    // catch the outcome snackbar before it auto-dismisses
+    await waitFor(find.byType(SnackBar));
+    await settle(frames: 4);
+  }
+
+  /// Opens the edit screen via the tile's `more_vert` > Edit, and waits for
+  /// stored secrets to load (Save is disabled until then).
+  Future<void> openEditServer() async {
+    await tester.tap(find.byIcon(Icons.more_vert));
+    await settle(frames: 5);
+    await tester.tap(find.text(l10n.edit));
+    await settle();
+  }
+
+  /// Scopes to the tile showing [alias] -- needed once more than one server
+  /// is in the list (tiles are otherwise structurally identical).
+  Finder _tileFor(String alias) => find.ancestor(
+    of: find.text(alias),
+    matching: find.byType(ServersTileItem),
+  );
+
+  /// Opens [alias]'s `more_vert` menu and taps [menuText] (only one popup
+  /// menu is ever open, so the item itself doesn't need tile-scoping).
+  Future<void> _tapTileMenu(String alias, String menuText) async {
+    final tile = _tileFor(alias);
+    await tester.ensureVisible(tile);
+    await settle(frames: 3);
+    await tester.tap(
+      find.descendant(of: tile, matching: find.byIcon(Icons.more_vert)),
+    );
+    await settle(frames: 5);
+    await tester.tap(find.text(menuText));
+  }
+
+  /// Like [openEditServer], but for a specific tile when more than one server
+  /// is in the list.
+  Future<void> openEditServerFor(String alias) async {
+    await _tapTileMenu(alias, l10n.edit);
+    await settle();
+  }
+
+  /// Deletes the (only) server via its tile's `more_vert` > Delete, confirming
+  /// the modal.
+  Future<void> deleteServer() async {
+    await tester.tap(find.byIcon(Icons.more_vert));
+    await settle(frames: 5);
+    await tester.tap(find.text(l10n.delete));
+    await settle(frames: 5);
+    await tester.tap(find.text(l10n.delete).last);
+    await waitFor(find.byType(SnackBar));
+    await settle(frames: 4);
+  }
+
+  /// Sets [alias]'s server as the default via its tile's `more_vert` menu.
+  Future<void> setDefaultServerFor(String alias) async {
+    await _tapTileMenu(alias, l10n.setDefault);
+    await settle(frames: 5);
+  }
+
+  /// Edits a server tile
+  Future<void> editServer({
+    String? at,
+    String? version,
+    String? alias,
+    String? host,
+    String? port,
+    String? password,
+    String? token,
+  }) async {
+    if (at != null) {
+      await openEditServerFor(at);
+    } else {
+      await openEditServer();
+    }
+
+    if (version != null) {
+      await tester.tap(find.text(version).last);
+      await settle(frames: 3);
+    }
+
+    final fields = find.byType(EditableText);
+    if (alias != null) await tester.enterText(fields.at(0), alias);
+    if (host != null) await tester.enterText(fields.at(1), host);
+    if (port != null) await tester.enterText(fields.at(2), port);
+    final authValue = token ?? password;
+    if (authValue != null) await tester.enterText(fields.at(3), authValue);
+    await settle(frames: 3);
+
+    await tester.tap(find.byIcon(Icons.save_rounded));
+    await waitFor(find.byType(SnackBar));
+    await settle(frames: 4);
+  }
+
+  /// Waits for the TOTP prompt to appear.
+  Future<bool> waitForTotpPrompt() => waitFor(find.text(l10n.confirm));
+
+  /// Fills the TOTP prompt's 6 single-digit boxes. No Confirm tap needed --
+  /// the modal auto-submits once all 6 are filled.
+  Future<void> submitTotpCode(String code) async {
+    final allFields = find.byType(EditableText);
+    final firstDigitIndex = allFields.evaluate().length - code.length;
+    for (var i = 0; i < code.length; i++) {
+      await tester.enterText(allFields.at(firstDigitIndex + i), code[i]);
+    }
+    await settle(frames: 3);
+  }
+
+  /// Submits the correct [code] and waits for the connect/edit to finish.
+  Future<void> completeTotpPrompt(String code) async {
+    await submitTotpCode(code);
+    await waitFor(find.byType(SnackBar));
+    await settle(frames: 4);
+  }
+
+  /// Cancels the TOTP prompt (modal bottom sheet).
+  Future<void> cancelTotpPrompt() async {
+    await tester.tap(find.text(l10n.cancel));
+    await settle(frames: 5);
+  }
+}

--- a/integration_test/support/fake_pihole_server.dart
+++ b/integration_test/support/fake_pihole_server.dart
@@ -1,0 +1,252 @@
+import 'dart:convert';
+import 'dart:io';
+
+/// Minimal in-process Pi-hole **v6** API stand-in, for state-transition tests
+/// (TOTP flows, session lifecycle) that are impractical to drive
+/// deterministically against a real Pi-hole.
+///
+/// This is **not** a faithful API reimplementation — see
+/// `integration_test/COVERAGE.md`'s "Fake server" notes. It only implements
+/// what `postAuth`/`getAuth`/`deleteAuth` and the blocking-status probe used
+/// during connect need: `POST/GET/DELETE /api/auth` and `GET/POST
+/// /api/dns/blocking`. Everything else responds `200 {}` so unimplemented
+/// polling (stats, over-time data, metrics) doesn't hang or crash the app.
+///
+/// One instance == one fake Pi-hole == one session at a time. Configure the
+/// scenario via the public fields *before* driving the app, then call
+/// [start] and point `RepositoryBundleFactory`/the UI at the returned URL.
+class FakePiholeServer {
+  FakePiholeServer({this.password = 'fake-pw'});
+
+  /// The password `POST /api/auth` must match to succeed.
+  String password;
+
+  /// When true, a correct password alone isn't enough — the request must
+  /// also include a `totp` matching [totpCode].
+  bool totpRequired = false;
+
+  /// The accepted TOTP code while [totpRequired] is true.
+  int totpCode = 123456;
+
+  /// When true, the *next* `POST /api/auth` that would otherwise succeed (or
+  /// fail on an invalid code) instead returns 429 rate-limiting once, then
+  /// this resets itself to false.
+  bool rateLimitNextAuth = false;
+
+  bool blockingEnabled = true;
+
+  /// When true, the *next* `GET /api/dns/blocking` returns 503 once (even
+  /// with a valid sid), then this resets itself to false. Used to force a
+  /// post-login connection check to fail.
+  bool failNextBlockingCheck = false;
+
+  String? _sid;
+  int _sidCounter = 0;
+  final Set<int> _usedTotpCodes = {};
+
+  HttpServer? _server;
+
+  /// Starts listening on an OS-assigned loopback port and returns the base
+  /// URL (e.g. `http://127.0.0.1:54321`) to register as a server's address.
+  Future<String> start() async {
+    final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+    _server = server;
+    server.listen(_handle);
+    return 'http://127.0.0.1:${server.port}';
+  }
+
+  Future<void> close() async {
+    await _server?.close(force: true);
+  }
+
+  /// The current live session id, if any (null after a delete or before the
+  /// first successful auth). Tests can read this to assert against
+  /// `AppHarness.sidOf(address)` (the app's locally *stored* copy) staying in
+  /// sync with what this fake server considers valid.
+  String? get currentSid => _sid;
+
+  /// Simulates the current session expiring server-side (e.g. a Pi-hole
+  /// restart) — the next request presenting the old sid is rejected as
+  /// invalid, forcing the app to re-authenticate.
+  void invalidateSession() => _sid = null;
+
+  /// Marks [code] as already consumed, so a subsequent `POST /api/auth` with
+  /// this code is rejected as "Reused 2FA token" even if it matches
+  /// [totpCode] — simulates the code having been used elsewhere already.
+  void markTotpCodeUsed(int code) => _usedTotpCodes.add(code);
+
+  Future<void> _handle(HttpRequest request) async {
+    try {
+      final path = request.uri.path;
+      final sid = request.headers.value('X-FTL-SID');
+      final body = await utf8.decoder.bind(request).join();
+
+      switch ((request.method, path)) {
+        case ('POST', '/api/auth'):
+          await _postAuth(request, body);
+        case ('GET', '/api/auth'):
+          await _getAuth(request, sid);
+        case ('DELETE', '/api/auth'):
+          await _deleteAuth(request, sid);
+        case ('GET', '/api/dns/blocking'):
+          await _getBlocking(request, sid);
+        case ('POST', '/api/dns/blocking'):
+          await _postBlocking(request, body, sid);
+        default:
+          // Not a faithful re-implementation of every v6 endpoint
+          if (sid == null || sid != _sid) {
+            await _respond(request, 401, {
+              'error': {'key': 'unauthorized', 'message': 'Invalid session'},
+            });
+          } else {
+            await _respond(request, 200, {});
+          }
+      }
+    } catch (e) {
+      await _respond(request, 500, {
+        'error': {'key': 'internal', 'message': '$e'},
+      });
+    }
+  }
+
+  Future<void> _postAuth(HttpRequest request, String body) async {
+    final json = body.isEmpty
+        ? <String, dynamic>{}
+        : jsonDecode(body) as Map<String, dynamic>;
+    final suppliedPassword = json['password'] as String?;
+    final suppliedTotp = json['totp'] as int?;
+
+    if (suppliedPassword != password) {
+      await _respond(request, 401, {
+        'error': {'key': 'unauthorized', 'message': 'Invalid password'},
+      });
+      return;
+    }
+
+    if (totpRequired) {
+      if (suppliedTotp == null) {
+        await _respond(request, 400, {
+          'error': {
+            'key': 'bad_request',
+            'message': 'No 2FA token found in JSON payload (2FA token)',
+          },
+        });
+        return;
+      }
+      if (rateLimitNextAuth) {
+        rateLimitNextAuth = false;
+        await _respond(request, 429, {
+          'error': {
+            'key': 'rate_limiting',
+            'message':
+                'Rate limiting 2FA token requests, try again later (2FA token)',
+          },
+        });
+        return;
+      }
+      if (_usedTotpCodes.contains(suppliedTotp)) {
+        await _respond(request, 401, {
+          'error': {'key': 'unauthorized', 'message': 'Reused 2FA token'},
+        });
+        return;
+      }
+      if (suppliedTotp != totpCode) {
+        await _respond(request, 401, {
+          'error': {'key': 'unauthorized', 'message': 'Invalid 2FA token'},
+        });
+        return;
+      }
+      _usedTotpCodes.add(suppliedTotp);
+    }
+
+    _sidCounter++;
+    _sid = 'fake-sid-$_sidCounter';
+    await _respond(request, 200, _sessionJson(valid: true, sid: _sid));
+  }
+
+  Future<void> _getAuth(HttpRequest request, String? sid) async {
+    final valid = sid != null && sid == _sid;
+    await _respond(
+      request,
+      200,
+      _sessionJson(valid: valid, sid: valid ? sid : ''),
+    );
+  }
+
+  Future<void> _deleteAuth(HttpRequest request, String? sid) async {
+    if (sid != null && sid == _sid) {
+      _sid = null;
+      request.response.statusCode = 204;
+      await request.response.close();
+      return;
+    }
+    await _respond(request, 401, {
+      'error': {'key': 'unauthorized', 'message': 'Invalid session'},
+    });
+  }
+
+  Future<void> _getBlocking(HttpRequest request, String? sid) async {
+    if (sid == null || sid != _sid) {
+      await _respond(request, 401, {
+        'error': {'key': 'unauthorized', 'message': 'Invalid session'},
+      });
+      return;
+    }
+    if (failNextBlockingCheck) {
+      failNextBlockingCheck = false;
+      await _respond(request, 503, {
+        'error': {'key': 'unavailable', 'message': 'Service unavailable'},
+      });
+      return;
+    }
+    await _respond(request, 200, _blockingJson());
+  }
+
+  Future<void> _postBlocking(
+    HttpRequest request,
+    String body,
+    String? sid,
+  ) async {
+    if (sid == null || sid != _sid) {
+      await _respond(request, 401, {
+        'error': {'key': 'unauthorized', 'message': 'Invalid session'},
+      });
+      return;
+    }
+    final json = body.isEmpty
+        ? <String, dynamic>{}
+        : jsonDecode(body) as Map<String, dynamic>;
+    final enabled = json['blocking'] as bool?;
+    if (enabled != null) blockingEnabled = enabled;
+    await _respond(request, 200, _blockingJson());
+  }
+
+  Map<String, dynamic> _sessionJson({required bool valid, String? sid}) => {
+    'session': {
+      'valid': valid,
+      'totp': totpRequired,
+      'sid': sid ?? '',
+      'csrf': 'fake-csrf',
+      'validity': 1800,
+      'message': valid ? 'session valid' : 'session invalid',
+    },
+    'took': 0.001,
+  };
+
+  Map<String, dynamic> _blockingJson() => {
+    'blocking': blockingEnabled ? 'enabled' : 'disabled',
+    'timer': null,
+    'took': 0.001,
+  };
+
+  Future<void> _respond(
+    HttpRequest request,
+    int statusCode,
+    Map<String, dynamic> json,
+  ) async {
+    request.response.statusCode = statusCode;
+    request.response.headers.contentType = ContentType.json;
+    request.response.write(jsonEncode(json));
+    await request.response.close();
+  }
+}

--- a/integration_test/support/real_pihole_env.dart
+++ b/integration_test/support/real_pihole_env.dart
@@ -1,0 +1,70 @@
+/// Connection settings for the real Pi-hole integration/e2e layer.
+///
+/// | service        | host port | url (from emulator)     | secret         |
+/// |----------------|-----------|-------------------------|----------------|
+/// | pihole-v6-test | 19080     | http://10.0.2.2:19080   | pass `test001` |
+/// | pihole-v5-test | 19085     | http://10.0.2.2:19085   | WEBPASSWORD `test123` → API token |
+/// | caddy fault    | 19082     | http://10.0.2.2:19082   | pass `test001` (blocking → 503) |
+/// | caddy fault-delete | 19086 | http://10.0.2.2:19086  | pass `test001` (DELETE /api/auth* → 401) |
+/// | caddy TLS      | 19443     | https://10.0.2.2:19443  | pass `test001` (self-signed) |
+///
+/// Run example:
+/// ```sh
+/// docker compose -f e2e/docker-compose.yml up -d
+/// flutter test integration_test/real -d EMULATOR
+/// # override any target with e.g. --dart-define=PIHOLE_V6_BASE=http://10.0.2.2:19080
+/// ```
+class RealPiholeEnv {
+  RealPiholeEnv._();
+
+  //  v6 (HTTP, direct)
+  static const String v6Base = String.fromEnvironment(
+    'PIHOLE_V6_BASE',
+    defaultValue: 'http://10.0.2.2:19080',
+  );
+  static const String v6Password = String.fromEnvironment(
+    'PIHOLE_V6_PASSWORD',
+    defaultValue: 'test001',
+  );
+
+  //  v5 (HTTP, direct)  token has no safe default → v5 tests skip if empty
+  static const String v5Base = String.fromEnvironment(
+    'PIHOLE_V5_BASE',
+    defaultValue: 'http://10.0.2.2:19083',
+  );
+  static const String v5Token = String.fromEnvironment(
+    'PIHOLE_V5_TOKEN',
+    defaultValue:
+        'bdaa62c79c1f74a96290af23ac66a3bd21cf61f841c0df7d1477b9f4df37e6ae',
+  );
+
+  // without password
+  static const String v6BaseWP = String.fromEnvironment(
+    'PIHOLE_V6_BASE_WP',
+    defaultValue: 'http://10.0.2.2:19084',
+  );
+
+  // without password
+  static const String v5BaseWP = String.fromEnvironment(
+    'PIHOLE_V5_BASE_WP',
+    defaultValue: 'http://10.0.2.2:19085',
+  );
+
+  //  v6 (HTTPS, self-signed via Caddy)
+  static const String v6HttpsBase = String.fromEnvironment(
+    'PIHOLE_V6_HTTPS_BASE',
+    defaultValue: 'https://10.0.2.2:19443',
+  );
+
+  //  fault proxy (auth ok, /api/dns/blocking -> 503)
+  static const String faultBase = String.fromEnvironment(
+    'CADDY_FAULT_BASE',
+    defaultValue: 'http://10.0.2.2:19082',
+  );
+
+  //  fault-delete proxy (normal add/connect; DELETE /api/auth* -> 401)
+  static const String faultDeleteBase = String.fromEnvironment(
+    'CADDY_FAULT_DELETE_BASE',
+    defaultValue: 'http://10.0.2.2:19086',
+  );
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -172,26 +172,31 @@ Future<void> initializeSentry(AppConfigViewModel configProvider) async {
   }
 }
 
-void main() async {
-  // 1. System init
-  await initializeFlutter();
-  await initializeDesktop();
-  await dotenv.load();
-
-  // 2. Services & Repositories
-  final dbService = DatabaseService();
+/// Builds the full application widget tree: services, repositories, view models
+/// and the provider tree, then returns the root widget ready for [runApp] or
+/// `tester.pumpWidget`.
+///
+/// Extracted from [main] so integration tests can pump the real app with real
+/// DI while disabling side effects and isolating storage:
+/// - [enableSentry] / [enableBiometrics]: skipped in tests.
+/// - [databaseService] / [secureStorageService]: inject test-owned instances so
+///   the test can reset and assert on the same storage the app uses.
+///
+/// Production behaviour is unchanged — [main] calls this with all defaults.
+Future<Widget> bootstrapApp({
+  bool enableSentry = true,
+  bool enableBiometrics = true,
+  DatabaseService? databaseService,
+  SecureStorageService? secureStorageService,
+}) async {
+  // Services & Repositories
+  final dbService = databaseService ?? DatabaseService();
   await dbService.open();
-  final secureStorageService = SecureStorageService();
-  final appConfigRepository = LocalAppConfigRepository(
-    dbService,
-    secureStorageService,
-  );
-  final serverRepository = LocalServerRepository(
-    dbService,
-    secureStorageService,
-  );
+  final storage = secureStorageService ?? SecureStorageService();
+  final appConfigRepository = LocalAppConfigRepository(dbService, storage);
+  final serverRepository = LocalServerRepository(dbService, storage);
 
-  // 3. ViewModels
+  // ViewModels
   final gravityRepository = LocalGravityRepository(dbService);
   final sessionCacheStore = V6SessionCacheStore();
   final serversViewModel = ServersViewModel(
@@ -206,7 +211,7 @@ void main() async {
     repository: gravityRepository,
   );
 
-  // 4. Load persisted data
+  // Load persisted data
   final appdata = await appConfigRepository.fetchAppConfig();
   final servers = await serverRepository.fetchServers();
   switch (appdata) {
@@ -235,36 +240,47 @@ void main() async {
     );
   }
 
-  // 5. Platform-specific setup
-  await initializeBiometrics(configProvider, appConfigRepository);
+  // Platform-specific setup
+  if (enableBiometrics) {
+    await initializeBiometrics(configProvider, appConfigRepository);
+  }
   await initializeVibration(configProvider);
   await initializeDeviceInfo(configProvider);
   configProvider.setAppInfo(await loadAppInfo());
 
-  // 6. Error handling & Sentry
+  // Error handling & Sentry
   Command.globalExceptionHandler = (error, stackTrace) {
     Sentry.captureException(error.error, stackTrace: stackTrace);
     logger.e('Command error: ${error.error}', stackTrace: stackTrace);
   };
-  await initializeSentry(configProvider);
+  if (enableSentry) {
+    await initializeSentry(configProvider);
+  }
 
-  // 7. Launch
-  runApp(
-    MultiProvider(
-      providers: createProviders(
-        dbService: dbService,
-        secureStorageService: secureStorageService,
-        appConfigRepository: appConfigRepository,
-        serverRepository: serverRepository,
-        configProvider: configProvider,
-        serversViewModel: serversViewModel,
-        statusViewModel: statusViewModel,
-        logsViewModel: logsViewModel,
-        domainsViewModel: domainsViewModel,
-        gravityUpdateViewModel: gravityUpdateViewModel,
-        sessionCacheStore: sessionCacheStore,
-      ),
-      child: SentryWidget(child: Phoenix(child: const PiHoleClient())),
+  return MultiProvider(
+    providers: createProviders(
+      dbService: dbService,
+      secureStorageService: storage,
+      appConfigRepository: appConfigRepository,
+      serverRepository: serverRepository,
+      configProvider: configProvider,
+      serversViewModel: serversViewModel,
+      statusViewModel: statusViewModel,
+      logsViewModel: logsViewModel,
+      domainsViewModel: domainsViewModel,
+      gravityUpdateViewModel: gravityUpdateViewModel,
+      sessionCacheStore: sessionCacheStore,
     ),
+    child: SentryWidget(child: Phoenix(child: const PiHoleClient())),
   );
+}
+
+void main() async {
+  // 1. System init
+  await initializeFlutter();
+  await initializeDesktop();
+  await dotenv.load();
+
+  // 2. Build + launch (all side effects enabled, real storage)
+  runApp(await bootstrapApp());
 }

--- a/test/ui/core/view_models/status_viewmodel_test.dart
+++ b/test/ui/core/view_models/status_viewmodel_test.dart
@@ -383,6 +383,21 @@ void main() {
       expect(vm.getRealtimeStatus, isNotNull);
       expect(vm.getStatusLoading, LoadStatus.loaded);
     });
+
+    test('(AP6) an auto-refresh tick that hits TotpRequiredException on a v6 '
+        'server sets fatalConnectionError', () async {
+      final failingDns = FakeDnsRepository()
+        ..shouldFail = true
+        ..failureException = TotpRequiredException();
+      _setup(vm, apiVersion: 'v6', dnsRepository: failingDns);
+
+      vm.startAutoRefresh();
+      // Pump the event queue to let the immediate timerFn() complete.
+      await Future<void>.delayed(Duration.zero);
+      await pumpEventQueue();
+
+      expect(vm.fatalConnectionError, isA<TotpRequiredException>());
+    });
   });
 
   // ---------------------------------------------------------------------------

--- a/test/ui/servers/view_models/add_server_viewmodel_test.dart
+++ b/test/ui/servers/view_models/add_server_viewmodel_test.dart
@@ -42,6 +42,15 @@ const _oldServer = Server(
   ignoreCertificateErrors: false,
 );
 
+const _oldServerV5 = Server(
+  address: 'http://localhost:8081',
+  alias: 'old-v5',
+  apiVersion: SupportedApiVersions.v5,
+  defaultServer: false,
+  allowUntrustedCert: true,
+  ignoreCertificateErrors: false,
+);
+
 void main() {
   group('AddServerViewModel', () {
     late FakeServersViewModel serversViewModel;
@@ -481,6 +490,56 @@ void main() {
 
           expect(outcome, isA<UpdateDbError>());
           expect(statusViewModel.startAutoRefreshCallCount, 1);
+        },
+      );
+
+      test(
+        '(E15) same-address v6->v5 version switch deletes the old SID, '
+        'no login',
+        () async {
+          final vm = buildViewModel();
+
+          final outcome = await vm.updateServer.runAsync(
+            updateReq(apiVersion: SupportedApiVersions.v5),
+          );
+
+          expect(outcome, isA<UpdateSuccess>());
+          expect(serversViewModel.editServerCallCount, 1);
+          expect(serversViewModel.replaceServerCallCount, 0);
+          // v5 has no session concept -- no login attempt at all.
+          expect(authRepository.createSessionCallCount, 0);
+          // The now-unused v6 session is logged out and its SID dropped.
+          expect(authRepository.deleteCurrentSessionCallCount, 1);
+          expect(serversViewModel.deleteSidCallCount, 1);
+        },
+      );
+
+      test(
+        '(E16) same-address v5->v6 version switch logs in with the new '
+        'password (2FA required)',
+        () async {
+          authRepository
+            ..shouldRequireTotp = true
+            ..validTotp = '123456'
+            ..serverUsesTotp = true;
+          final vm = buildViewModel();
+
+          final outcome = await vm.updateServer.runAsync(
+            updateReq(
+              oldServer: _oldServerV5,
+              apiVersion: SupportedApiVersions.v6,
+              password: 'new-v6-pass',
+              initPassword: '',
+              resolveTotp: ({error}) async => '123456',
+            ),
+          );
+
+          expect(outcome, isA<UpdateSuccess>());
+          expect(serversViewModel.editServerCallCount, 1);
+          expect(serversViewModel.replaceServerCallCount, 0);
+          // First password-only attempt + the password+totp retry.
+          expect(authRepository.createSessionCallCount, 2);
+          expect(authRepository.lastTotp, '123456');
         },
       );
     });

--- a/test/ui/shell/base_test.dart
+++ b/test/ui/shell/base_test.dart
@@ -1,11 +1,17 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:pi_hole_client/domain/model/dns/dns.dart';
 import 'package:pi_hole_client/domain/model/server/server.dart';
 import 'package:pi_hole_client/ui/core/ui/modals/start_warning_modal.dart';
 import 'package:pi_hole_client/ui/core/view_models/app_config_viewmodel.dart';
 import 'package:pi_hole_client/ui/shell/base.dart';
 import 'package:pi_hole_client/utils/exceptions.dart';
+import 'package:result_dart/result_dart.dart';
+import 'package:window_manager/window_manager.dart';
 
+import '../../../testing/fakes/repositories/api/fake_dns_repository.dart';
 import '../../../testing/fakes/repositories/local/fake_app_config_repository.dart';
 import '../../../testing/fakes/viewmodels/fake_servers_viewmodel.dart';
 import '../../../testing/fakes/viewmodels/fake_status_viewmodel.dart';
@@ -19,6 +25,32 @@ const _serverV6 = Server(
   allowUntrustedCert: true,
   ignoreCertificateErrors: false,
 );
+
+const _serverV6Other = Server(
+  address: 'http://localhost:8082',
+  alias: 'test v6 other',
+  defaultServer: false,
+  apiVersion: 'v6',
+  allowUntrustedCert: true,
+  ignoreCertificateErrors: false,
+);
+
+/// A [FakeDnsRepository] whose [fetchBlockingStatus] hangs until the test
+/// calls [allowCompletion] -- lets a test interleave a state change (e.g.
+/// changing the selected server) while a fetch is still in flight.
+class _DelayedDns extends FakeDnsRepository {
+  final _completer = Completer<void>();
+
+  void allowCompletion() => _completer.complete();
+
+  @override
+  Future<Result<Blocking>> fetchBlockingStatus({
+    bool skipRenewal = false,
+  }) async {
+    await _completer.future;
+    return super.fetchBlockingStatus(skipRenewal: skipRenewal);
+  }
+}
 
 void main() async {
   await initTestApp();
@@ -300,5 +332,104 @@ void main() async {
 
       expect(statusViewModel.stopAutoRefreshCallCount, greaterThan(before));
     });
+
+    testWidgets('(AP3) resuming from background re-fetches status and restarts '
+        'auto-refresh', (WidgetTester tester) async {
+      tester.view.physicalSize = const Size(1080, 2400);
+      tester.view.devicePixelRatio = 2.0;
+      addTearDown(() {
+        tester.view.resetPhysicalSize();
+        tester.view.resetDevicePixelRatio();
+      });
+
+      final repo = FakeAppConfigRepository()..importantInfoReadenValue = true;
+      final appConfigViewModel = AppConfigViewModel(repo);
+      appConfigViewModel.saveFromDb(repo.appConfig.getOrThrow());
+      serversViewModel.selectedServer = _serverV6;
+
+      await tester.pumpWidget(
+        buildTestApp(
+          const Base(child: SizedBox()),
+          appConfigViewModel: appConfigViewModel,
+          serversViewModel: serversViewModel,
+          statusViewModel: statusViewModel,
+          repositoryBundle: createFakeRepositoryBundle(),
+          createRepositoryBundle: ({required server}) =>
+              createFakeRepositoryBundle(),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      tester.binding.handleAppLifecycleStateChanged(AppLifecycleState.paused);
+      await tester.pump();
+
+      final fetchBefore = serversViewModel.updateselectedServerStatusCallCount;
+      final refreshBefore = statusViewModel.startAutoRefreshCallCount;
+      // `didChangeAppLifecycleState(resumed)` is a no-op on desktop
+      (tester.state(find.byType(Base)) as WindowListener).onWindowRestore();
+      await tester.pumpAndSettle();
+
+      expect(
+        serversViewModel.updateselectedServerStatusCallCount,
+        greaterThan(fetchBefore),
+        reason:
+            "resuming must re-fetch the selected server's status, "
+            'exactly like a cold start does',
+      );
+      expect(
+        statusViewModel.startAutoRefreshCallCount,
+        greaterThan(refreshBefore),
+        reason: 'resuming must restart auto-refresh after pause stopped it',
+      );
+    });
+
+    testWidgets(
+      '(AP5) discards a stale resume fetch when the selected server changes '
+      'mid-flight (TODO FIX)',
+      (WidgetTester tester) async {
+        tester.view.physicalSize = const Size(1080, 2400);
+        tester.view.devicePixelRatio = 2.0;
+        addTearDown(() {
+          tester.view.resetPhysicalSize();
+          tester.view.resetDevicePixelRatio();
+        });
+
+        final repo = FakeAppConfigRepository()..importantInfoReadenValue = true;
+        final appConfigViewModel = AppConfigViewModel(repo);
+        appConfigViewModel.saveFromDb(repo.appConfig.getOrThrow());
+        serversViewModel.selectedServer = _serverV6;
+
+        final delayedDns = _DelayedDns();
+
+        await tester.pumpWidget(
+          buildTestApp(
+            const Base(child: SizedBox()),
+            appConfigViewModel: appConfigViewModel,
+            serversViewModel: serversViewModel,
+            statusViewModel: statusViewModel,
+            repositoryBundle: createFakeRepositoryBundle(dns: delayedDns),
+            createRepositoryBundle: ({required server}) =>
+                createFakeRepositoryBundle(dns: delayedDns),
+          ),
+        );
+        await tester.pump();
+
+        // The cold-start fetch for _serverV6 is now in flight (blocked on
+        // _DelayedDns). Before it completes, the selected server changes --
+        // e.g. the user deleted it, or switched to another one.
+        serversViewModel.selectedServer = _serverV6Other;
+        delayedDns.allowCompletion();
+        await tester.pumpAndSettle();
+
+        expect(
+          serversViewModel.updateselectedServerStatusCallCount,
+          0,
+          reason:
+              'a fetch that started for a server which is no longer '
+              'selected by the time it completes must be discarded, not '
+              'applied to whatever is selected now',
+        );
+      },
+    );
   });
 }


### PR DESCRIPTION
## Overview
Adds an end-to-end testing harness (a scripted fake Pi-hole server and a real Pi-hole/Caddy docker stack) plus a broad set of integration and unit tests covering the v6 2FA/TOTP session lifecycle across add, edit, replace, delete, app resume, and auto-refresh reauthentication. 

main.dart is refactored to expose a testable bootstrapApp() so integration tests can drive the real app with injected storage.

## Summary by Sourcery

Introduce an end-to-end testing harness and refactor app bootstrap for testability, adding extensive integration and unit coverage around v6 server sessions, TOTP/2FA flows, and app lifecycle behavior.

Enhancements:
- Refactor main.dart to extract a reusable bootstrapApp() that builds the full provider tree and supports injecting services and disabling Sentry/biometrics for tests.

Build:
- Add e2e docker-compose stack and Caddy configuration to spin up dedicated Pi-hole and proxy instances for integration testing.

Documentation:
- Document known failing integration tests and their expected assertions in KNOWN_FAILURES.md.
- Add documentation and Docker/Caddy configuration for a dedicated Pi-hole+Caddy stack used by integration tests.

Tests:
- Add integration test harness that boots the real app with injectable DB and secure storage and drives it against real and fake Pi-hole instances.
- Add fake in-process Pi-hole v6 server to deterministically exercise TOTP and session lifecycle scenarios.
- Add extensive real Pi-hole integration tests covering add/connect, edit/replace, delete, navigation, and CRUD flows for domains, adlists, and groups.
- Add fake-server integration tests covering password changes, TOTP prompts, replace flows, delete semantics, and known failure scenarios.
- Extend widget tests to cover app resume auto-refresh behavior and session error handling (e.g., TOTP-required on auto-refresh).