### PR TITLE
fix(fetch): skip stale status updates when the selected server changes

### DIFF
--- a/lib/ui/shell/base.dart
+++ b/lib/ui/shell/base.dart
@@ -216,6 +216,15 @@ class _BaseState extends State<Base>
 
     final result = await bundle.dns.fetchBlockingStatus();
 
+    if (serversViewModel.selectedServer?.address != server.address) {
+      logger.d(
+        'Skipping stale status update: selected server changed during fetch '
+        '(fetched for ${server.address}, '
+        'now selected ${serversViewModel.selectedServer?.address})',
+      );
+      return;
+    }
+
     serversViewModel.updateselectedServerStatus(
       result.getOrNull()?.status == DnsBlockingStatus.enabled,
     );

--- a/test/ui/shell/base_test.dart
+++ b/test/ui/shell/base_test.dart
@@ -385,7 +385,7 @@ void main() async {
 
     testWidgets(
       '(AP5) discards a stale resume fetch when the selected server changes '
-      'mid-flight (TODO FIX)',
+      'mid-flight',
       (WidgetTester tester) async {
         tester.view.physicalSize = const Size(1080, 2400);
         tester.view.devicePixelRatio = 2.0;


### PR DESCRIPTION
## Overview
A status fetch triggered by cold start, resume, or a widget tap could apply its result to the wrong server if the selection changed before it completed. Rare, self-healing race - low severity.

## Summary by Sourcery

Skip applying fetched DNS blocking status when the selected server has changed during the fetch to avoid stale updates.

Bug Fixes:
- Prevent stale DNS status updates from being applied when the user switches selected servers while a status fetch is in progress.

Tests:
- Enable and rely on the widget test that verifies stale resume fetches are discarded when the selected server changes mid-flight.