### PR TITLE
fix(servers): mark/clear TOTP reauth-declined flag in the edit flow

### DIFF
--- a/docs/server-connection-flow.md
+++ b/docs/server-connection-flow.md
@@ -90,6 +90,48 @@ flowchart TD
 
 On `UpdateSuccess` the widget pops and shows the success snackbar.
 
+### `restartAutoRefresh` can trigger a second, independent TOTP prompt
+
+`restartAutoRefresh` (called on every `updateServer` exit path, including
+`UpdateCancelled`) just calls `StatusViewModel.startAutoRefresh()` — but that
+runs its first tick **immediately** (`runImmediately: true`), not after the
+configured interval. If the edit's own `_authenticate`/`_loginWithTotp` TOTP
+prompt is dismissed because the session is genuinely invalid server-side, that
+immediate tick re-fetches status for the same server, hits the same
+`TotpRequiredException`, and — via a completely separate subsystem outside
+this file — surfaces a **second** TOTP prompt. Cancelling the edit's own
+prompt does not (currently — see `(E8)`/`(E9)`/`(X6)` in the MFA decision
+table) mark the address as reauth-declined, so this second prompt is not
+suppressed.
+
+The second prompt does not come back through `AddServerViewModel`; it is
+raised by the shell-level auto-refresh error handler and goes through the
+connect/switch flow instead:
+
+```mermaid
+sequenceDiagram
+  participant VM as AddServerViewModel
+  participant ST as StatusViewModel
+  participant Base as _BaseState (base.dart)
+  participant H as handleTotpReauth
+  participant SCS as ServerConnectionService
+
+  VM->>ST: restartAutoRefresh -> startAutoRefresh(runImmediately: true)
+  ST->>ST: immediate tick: fetchRealtimeStatus() -> TotpRequiredException
+  ST->>ST: _handleFatalConnectionError: stop, set fatalConnectionError, notify
+  ST-->>Base: listener callback (_onFatalConnectionError)
+  Base->>H: handleTotpReauth(context)
+  H->>SCS: ServerConnectionService(...).connect()
+  Note over SCS: shows the TOTP modal (2nd prompt)
+  SCS->>SCS: on cancel: _onTotpCancelled -> markTotpReauthDeclined(address)
+```
+
+Confirmed on a real device (not just the fake-server test): the two prompts
+appear back-to-back, deterministically, every time — not a timing
+coincidence. See `lib/ui/shell/base.dart` (`_onFatalConnectionError`,
+`StatusViewModel` listener registered in `initState`) and
+`lib/ui/core/actions/handle_totp_reauth.dart`.
+
 ### Session handling inside `updateServer` - `_authenticate`
 
 Only re-authenticates when needed, to avoid duplicate sessions on transient

--- a/integration_test/fake/edit_fake_test.dart
+++ b/integration_test/fake/edit_fake_test.dart
@@ -96,7 +96,7 @@ void main() {
 
   group('edit success clears a declined TOTP reauth', () {
     testWidgets(
-      '(E9) a successful edit clears a previously-declined TOTP reauth (TODO FIX)',
+      '(E9) a successful edit clears a previously-declined TOTP reauth',
       (tester) async {
         final app = AppHarness(tester);
         await app.boot();
@@ -133,7 +133,7 @@ void main() {
 
   group('edit-time TOTP cancel', () {
     testWidgets(
-      '(E8) cancelling the TOTP prompt during an edit marks reauth declined (TODO FIX)',
+      '(E8) cancelling the TOTP prompt during an edit marks reauth declined',
       (tester) async {
         final app = AppHarness(tester);
         await app.boot();
@@ -456,7 +456,7 @@ void main() {
 
   group('address replace and declined TOTP reauth', () {
     testWidgets(
-      "(X6) replacing a server clears the old address's declined TOTP reauth (TODO FIX)",
+      "(X6) replacing a server clears the old address's declined TOTP reauth",
       (tester) async {
         final app = AppHarness(tester);
         await app.boot();

--- a/lib/ui/servers/view_models/add_server_viewmodel.dart
+++ b/lib/ui/servers/view_models/add_server_viewmodel.dart
@@ -422,6 +422,7 @@ class AddServerViewModel extends ChangeNotifier {
     if (auth.cancelled) {
       // User dismissed the TOTP prompt: undo this attempt's writes and keep the
       // old server (row, credentials, session) intact, same as a failed save.
+      _serversViewModel.markTotpReauthDeclined(targetAddress);
       if (auth.needsRollback) {
         await rollbackFailedSave(bundle: bundle, sessionCreated: false);
       }
@@ -477,6 +478,7 @@ class AddServerViewModel extends ChangeNotifier {
       oldAddress: oldAddress,
       targetAddress: targetAddress,
     );
+    _serversViewModel.clearTotpReauthDeclined(targetAddress);
     restartAutoRefresh();
     return const UpdateSuccess();
   }
@@ -643,10 +645,11 @@ class AddServerViewModel extends ChangeNotifier {
     // 2. Now safe to drop the old server's credentials.
     if (isAddressChanged) {
       // New credentials already live under the new address; remove the stale
-      // ones left behind under the old address.
+      // ones left behind under the old address, including its 2FA-declined mark.
       await _serversViewModel.deleteToken(oldAddress);
       await _serversViewModel.deletePassword(oldAddress);
       await _serversViewModel.deleteSid(oldAddress);
+      _serversViewModel.clearTotpReauthDeclined(oldAddress);
     } else if (oldWasV6 && !newIsV6) {
       // Same address, v6 -> v5: the SID is now unused.
       await _serversViewModel.deleteSid(targetAddress);


### PR DESCRIPTION
## Overview

Cancelling the 2FA prompt during a server edit didn't register as "declined", so the app immediately popped a second 2FA prompt for the same server. 

The edit flow was missing the declined-flag handling that the connect flow already had. This adds it (mark on cancel, clear on a successful edit / address change), so one cancel is enough.

## Summary by Sourcery

Handle TOTP reauth-declined flags consistently in the server edit flow to prevent redundant 2FA prompts after cancelling or successfully editing a server.

Bug Fixes:
- Ensure cancelling the TOTP prompt during a server edit marks the server address as TOTP reauth-declined so subsequent auto-refreshes do not trigger a second prompt.
- Ensure a successful server edit clears any previously-declined TOTP reauth flag for that server address.
- Ensure replacing a server address clears the old address’s declined TOTP reauth flag to avoid incorrect suppression or prompts.

Documentation:
- Document how auto-refresh can trigger a second independent TOTP prompt and how the declined-flag handling interacts with the connection and edit flows.

Tests:
- Finalize and enable integration tests for edit-time TOTP cancel, successful edits, and address replacement scenarios around declined TOTP reauth handling.