### PR TITLE
fix(server): cleanup on failure paths

### DIFF
--- a/docs/server-connection-flow.md
+++ b/docs/server-connection-flow.md
@@ -49,12 +49,16 @@ flowchart TD
   F -- error --> G[deletePassword + deleteToken] --> H([CreateApiError])
   F -- ok --> I[dns.fetchBlockingStatus<br/>skipRenewal: true]
   E -- no --> I
-  I -- success --> J([CreateSuccess server])
-  I -- error --> K[deletePassword + deleteToken] --> L([CreateApiError])
+  I -- success --> M[addServer.runAsync<br/>persist row]
+  I -- error --> K[cleanup session + creds] --> L([CreateApiError])
+  M -- ok --> J([CreateSuccess server])
+  M -- error --> N[cleanup session + creds] --> DB([CreateDbError])
 ```
 
-On `CreateSuccess` the widget pops, shows the success snackbar, then persists
-the server (`serversViewModel.addServer.runAsync`, fire-and-forget).
+`createServer` persists the server row (`addServer.runAsync`) before returning
+`CreateSuccess`, so the widget only pops and shows the success snackbar. A failed
+DB write returns `CreateDbError` after tearing down the session/credentials, so
+the user sees an error instead of a false "connected" message.
 
 ## Edit an existing server - `updateServer`
 
@@ -211,10 +215,10 @@ sequenceDiagram
     end
   end
   VM->>B: dns.fetchBlockingStatus(skipRenewal: true)
-  VM-->>W: CreateSuccess(server) | CreateCancelled | CreateApiError | CreateDuplicateUrl | CreateUrlCheckFailed
+  VM->>SV: addServer.runAsync(server)
+  VM-->>W: CreateSuccess(server) | CreateDbError | CreateCancelled | CreateApiError | CreateDuplicateUrl | CreateUrlCheckFailed
   alt success
     W->>W: Navigator.maybePop + success snackbar
-    W->>SV: addServer.runAsync(server)
   else failure
     W->>W: error snackbar
   else cancelled

--- a/lib/data/repositories/local/server_repository.dart
+++ b/lib/data/repositories/local/server_repository.dart
@@ -260,17 +260,17 @@ class LocalServerRepository implements ServerRepository {
     try {
       await openDbIfNeeded(_database);
 
-      await _secureStorage.deleteValue('${address}_token');
-      await _secureStorage.deleteValue('${address}_password');
-      await _secureStorage.deleteValue('${address}_sid');
-
-      logger.d((await _secureStorage.readAll()).toString());
-
-      return await _database.delete(
+      final deleted = await _database.delete(
         'servers',
         where: 'address = ?',
         whereArgs: [address],
       );
+      if (deleted.isSuccess()) {
+        await _secureStorage.deleteValue('${address}_token');
+        await _secureStorage.deleteValue('${address}_password');
+        await _secureStorage.deleteValue('${address}_sid');
+      }
+      return deleted;
     } catch (e, st) {
       logger.e('Failed to remove server: $e\n$st');
       return Failure(Exception('Failed to remove server: $e\n$st'));
@@ -288,9 +288,14 @@ class LocalServerRepository implements ServerRepository {
     try {
       await openDbIfNeeded(_database);
 
-      await _secureStorage.clearAll();
-
-      return await _database.delete('servers');
+      // Delete the rows first; only clear secrets if that succeeded. A failed
+      // clearAll then leaves orphan secrets (harmless, reclaimed by
+      // deleteUnusedServerSecrets) rather than credential-less server rows.
+      final deleted = await _database.delete('servers');
+      if (deleted.isSuccess()) {
+        await _secureStorage.clearAll();
+      }
+      return deleted;
     } catch (e, st) {
       logger.e('Failed to delete all servers data: $e\n$st');
       return Failure(Exception('Failed to delete all servers data: $e\n$st'));

--- a/lib/ui/core/services/server_connection_service.dart
+++ b/lib/ui/core/services/server_connection_service.dart
@@ -148,7 +148,8 @@ class ServerConnectionService {
       await _onSuccess(result.getOrNull()!, serverForLogin);
     } catch (e, st) {
       logger.e(
-        'Unexpected error during server connection',
+        'Unexpected error during server connection: '
+        '${server.address}(${server.alias})',
         error: e,
         stackTrace: st,
       );

--- a/lib/ui/core/services/server_connection_service.dart
+++ b/lib/ui/core/services/server_connection_service.dart
@@ -98,53 +98,64 @@ class ServerConnectionService {
 
     _startConnection();
 
-    final serverForLogin = await _ensurePinnedFingerprintIfNeeded(server);
-    if (serverForLogin == null) {
-      _abortConnection(previouslySelectedServer);
-      return;
-    }
-
-    if (serversViewModel.connectingServer != server) {
-      return;
-    }
-
-    final result = await _runLoginQuery(serverForLogin);
-
-    // If another server (other than B) is selected while switching from server A to B, abort the process.
-    // Without this check, it may appear as if the app is connected to B, even though a different server was actually selected.
-    if (serversViewModel.connectingServer != server) {
-      logger.w(
-        'Server switch interrupted: '
-        '${previouslySelectedServer?.address}(${previouslySelectedServer?.alias}) '
-        '-> ${server.address}(${server.alias}) '
-        '-> ${serversViewModel.selectedServer?.address}(${serversViewModel.selectedServer?.alias})',
-      );
-      return;
-    }
-
-    serversViewModel.clearConnectingServer();
-
-    if (result == null || result.isError()) {
-      final error = result?.exceptionOrNull();
-      if (error is TotpCancelledException) {
-        _onTotpCancelled(previouslySelectedServer);
+    try {
+      final serverForLogin = await _ensurePinnedFingerprintIfNeeded(server);
+      if (serverForLogin == null) {
+        _abortConnection(previouslySelectedServer);
         return;
       }
-      logger.d(
-        'Fallback to previously selected server: '
-        '${previouslySelectedServer?.address}(${previouslySelectedServer?.alias}) '
-        '<- ${server.address}(${server.alias})',
-      );
-      await _onFailure(previouslySelectedServer, error, previousStatus);
-      return;
-    }
 
-    logger.d(
-      '<*> Server connection successful: '
-      '${previouslySelectedServer?.address}(${previouslySelectedServer?.alias}) '
-      '-> ${server.address}(${server.alias})',
-    );
-    await _onSuccess(result.getOrNull()!, serverForLogin);
+      if (serversViewModel.connectingServer != server) {
+        return;
+      }
+
+      final result = await _runLoginQuery(serverForLogin);
+
+      // If another server (other than B) is selected while switching from server A to B, abort the process.
+      // Without this check, it may appear as if the app is connected to B, even though a different server was actually selected.
+      if (serversViewModel.connectingServer != server) {
+        logger.w(
+          'Server switch interrupted: '
+          '${previouslySelectedServer?.address}(${previouslySelectedServer?.alias}) '
+          '-> ${server.address}(${server.alias}) '
+          '-> ${serversViewModel.selectedServer?.address}(${serversViewModel.selectedServer?.alias})',
+        );
+        return;
+      }
+
+      serversViewModel.clearConnectingServer();
+
+      if (result == null || result.isError()) {
+        final error = result?.exceptionOrNull();
+        if (error is TotpCancelledException) {
+          _onTotpCancelled(previouslySelectedServer);
+          return;
+        }
+        logger.d(
+          'Fallback to previously selected server: '
+          '${previouslySelectedServer?.address}(${previouslySelectedServer?.alias}) '
+          '<- ${server.address}(${server.alias})',
+        );
+        await _onFailure(previouslySelectedServer, error, previousStatus);
+        return;
+      }
+
+      logger.d(
+        '<*> Server connection successful: '
+        '${previouslySelectedServer?.address}(${previouslySelectedServer?.alias}) '
+        '-> ${server.address}(${server.alias})',
+      );
+      await _onSuccess(result.getOrNull()!, serverForLogin);
+    } catch (e, st) {
+      logger.e(
+        'Unexpected error during server connection',
+        error: e,
+        stackTrace: st,
+      );
+      if (serversViewModel.connectingServer == server) {
+        _abortConnection(previouslySelectedServer);
+      }
+    }
   }
 
   void _startConnection() {

--- a/lib/ui/core/view_models/servers_viewmodel.dart
+++ b/lib/ui/core/view_models/servers_viewmodel.dart
@@ -378,6 +378,8 @@ class ServersViewModel with ChangeNotifier {
         _serversList = [];
         _selectedServer = null;
         _selectedServerEnabled = null;
+        _sessionCacheStore?.clear();
+        _totpReauthDeclined.clear();
         notifyListeners();
         return true;
       } else {

--- a/lib/ui/servers/view_models/add_server_viewmodel.dart
+++ b/lib/ui/servers/view_models/add_server_viewmodel.dart
@@ -299,7 +299,8 @@ class AddServerViewModel extends ChangeNotifier {
     return CreateSuccess(server);
   }
 
-  /// Best-effort teardown of everything a failed
+  /// Best-effort teardown of everything saved during a failed add-server
+  /// attempt: the remote v6 session plus the stored password/token/sid.
   Future<void> _cleanupCreateAttempt(
     RepositoryBundle bundle,
     CreateServerRequest req,

--- a/lib/ui/servers/view_models/add_server_viewmodel.dart
+++ b/lib/ui/servers/view_models/add_server_viewmodel.dart
@@ -131,6 +131,10 @@ final class CreateApiError extends CreateOutcome {
   final String version;
 }
 
+final class CreateDbError extends CreateOutcome {
+  const CreateDbError();
+}
+
 // ==================================================================
 // Outcome of [AddServerViewModel.updateServer], mapped to UI by the widget.
 // ==================================================================
@@ -277,21 +281,36 @@ class AddServerViewModel extends ChangeNotifier {
     // Retrying with clearAndRenewSid would create a duplicate session.
     // Transient errors (e.g. network timeout) are still retried.
     final result = await bundle.dns.fetchBlockingStatus(skipRenewal: true);
-    if (result.isSuccess()) {
-      return CreateSuccess(
-        serverObj.copyWith(defaultServer: req.defaultServer),
-      );
+    if (result.isError()) {
+      // Connection test failed: clean up everything saved for this attempt.
+      await _cleanupCreateAttempt(bundle, req);
+      return CreateApiError(result.exceptionOrNull()!, req.apiVersion);
     }
 
-    // Clean up everything saved for this attempt; the server was not added.
-    if (serverObj.apiVersion == SupportedApiVersions.v6) {
+    // Persist the server row BEFORE reporting success.
+    final server = serverObj.copyWith(defaultServer: req.defaultServer);
+    try {
+      await _serversViewModel.addServer.runAsync(server);
+    } catch (e, s) {
+      logger.e('Failed to save new server', error: e, stackTrace: s);
+      await _cleanupCreateAttempt(bundle, req);
+      return const CreateDbError();
+    }
+    return CreateSuccess(server);
+  }
+
+  /// Best-effort teardown of everything a failed
+  Future<void> _cleanupCreateAttempt(
+    RepositoryBundle bundle,
+    CreateServerRequest req,
+  ) async {
+    if (req.apiVersion == SupportedApiVersions.v6) {
       // Best-effort logout of the session created during login above.
       await bundle.auth.deleteCurrentSession();
     }
     await _serversViewModel.deletePassword(req.url);
     await _serversViewModel.deleteToken(req.url);
     await _serversViewModel.deleteSid(req.url);
-    return CreateApiError(result.exceptionOrNull()!, req.apiVersion);
   }
 
   /// Edits an existing server, keeping the old server's row, credentials and

--- a/lib/ui/servers/widgets/add_server_fullscreen.dart
+++ b/lib/ui/servers/widgets/add_server_fullscreen.dart
@@ -18,7 +18,6 @@ import 'package:pi_hole_client/ui/core/view_models/status_viewmodel.dart';
 import 'package:pi_hole_client/ui/servers/view_models/add_server_viewmodel.dart';
 import 'package:pi_hole_client/ui/servers/widgets/certificate_details_dialog.dart';
 import 'package:pi_hole_client/utils/exceptions.dart';
-import 'package:pi_hole_client/utils/logger.dart';
 import 'package:pi_hole_client/utils/open_url.dart';
 import 'package:pi_hole_client/utils/tls_certificate.dart';
 import 'package:pi_hole_client/utils/url.dart';
@@ -528,7 +527,6 @@ class _AddServerFullscreenState extends State<AddServerFullscreen> {
   }
 
   Future<void> createServer() async {
-    final serversViewModel = context.read<ServersViewModel>();
     final appConfigViewModel = context.read<AppConfigViewModel>();
     final viewModel = _ensureViewModel();
     FocusManager.instance.primaryFocus?.unfocus();
@@ -585,7 +583,13 @@ class _AddServerFullscreenState extends State<AddServerFullscreen> {
           error: error,
           version: version,
         );
-      case CreateSuccess(:final server):
+      case CreateDbError():
+        showErrorSnackBar(
+          context: context,
+          appConfigViewModel: appConfigViewModel,
+          label: AppLocalizations.of(context)!.cantSaveConnectionData,
+        );
+      case CreateSuccess():
         await Navigator.maybePop(context);
         if (!mounted) return;
         showSuccessSnackBar(
@@ -593,11 +597,6 @@ class _AddServerFullscreenState extends State<AddServerFullscreen> {
           appConfigViewModel: appConfigViewModel,
           label: AppLocalizations.of(context)!.connectedSuccessfully,
         );
-        try {
-          await serversViewModel.addServer.runAsync(server);
-        } catch (e, s) {
-          logger.e('Failed to save server', error: e, stackTrace: s);
-        }
     }
   }
 

--- a/test/data/repositories/local/server_repository_test.dart
+++ b/test/data/repositories/local/server_repository_test.dart
@@ -97,7 +97,6 @@ void main() {
         contains('Failed to load servers'),
       );
     });
-
   });
 
   group('ServerRepository.insertServer', () {
@@ -411,6 +410,19 @@ void main() {
         contains('Exception: Failed to remove server'),
       );
     });
+
+    test('keeps secrets when the DB row delete fails', () async {
+      await repository.insertServer(serverV6);
+      await repository.savePassword(serverV6.address, 'secret-pass');
+      dbService.shouldThrowOnDelete = true;
+
+      final result = await repository.deleteServer(serverV6.address);
+      expect(result.isError(), true);
+
+      final password = await secureDataRepository.password;
+      expect(password.isSuccess(), true);
+      expect(password.getOrNull(), 'secret-pass');
+    });
   });
 
   group('ServerRepository.replaceServer', () {
@@ -642,6 +654,19 @@ void main() {
         result.exceptionOrNull()?.toString(),
         contains('Exception: Failed to delete all servers data'),
       );
+    });
+
+    test('keeps secrets when the DB rows delete fails', () async {
+      await repository.insertServer(serverV6);
+      await repository.savePassword(serverV6.address, 'secret-pass');
+      dbService.shouldThrowOnDelete = true;
+
+      final result = await repository.deleteAllServers();
+      expect(result.isError(), true);
+
+      final password = await secureDataRepository.password;
+      expect(password.isSuccess(), true);
+      expect(password.getOrNull(), 'secret-pass');
     });
   });
 

--- a/test/ui/core/services/server_connection_service_test.dart
+++ b/test/ui/core/services/server_connection_service_test.dart
@@ -169,6 +169,27 @@ void main() async {
       expect(serversViewModel.connectingServer, isNull);
     });
 
+    testWidgets('an unexpected error still releases the connecting guard', (
+      tester,
+    ) async {
+      serversViewModel.selectedServer = _serverV6;
+      authRepository.shouldRequireTotp = true;
+      final ctx = await pumpContext(tester);
+
+      await buildService(
+        ctx,
+        server: _serverV6,
+        // preCheck 401 -> re-auth -> the TOTP prompt throws unexpectedly.
+        dns: _SeqDns([HttpStatusCodeException(401, 'unauthorized')]),
+        resolveTotp: ({error}) async => throw Exception('boom'),
+      ).connect();
+      await tester.pump();
+
+      // Without the catch, connectingServer would stay set to this server and
+      // silently no-op every future reconnect attempt until an app restart.
+      expect(serversViewModel.connectingServer, isNull);
+    });
+
     testWidgets('invalid TOTP re-prompts then connects', (tester) async {
       serversViewModel.selectedServer = _serverV6;
       authRepository

--- a/test/ui/core/view_models/servers_viewmodel_test.dart
+++ b/test/ui/core/view_models/servers_viewmodel_test.dart
@@ -567,5 +567,16 @@ void main() async {
 
       expect(identical(seeded, getOrCreateAgain()), isFalse);
     });
+
+    test('deleteDbData clears session caches and declined marks', () async {
+      final seeded = await seedCache();
+      vm.markTotpReauthDeclined(address);
+
+      final ok = await vm.deleteDbData();
+
+      expect(ok, isTrue);
+      expect(identical(seeded, getOrCreateAgain()), isFalse);
+      expect(vm.isTotpReauthDeclined(address), isFalse);
+    });
   });
 }

--- a/test/ui/servers/view_models/add_server_viewmodel_test.dart
+++ b/test/ui/servers/view_models/add_server_viewmodel_test.dart
@@ -214,6 +214,19 @@ void main() {
         },
       );
 
+      test('returns CreateDbError and cleans up creds/session when the DB '
+          'write fails', () async {
+        serversViewModel.shouldFailAddServer = true;
+        final vm = buildViewModel();
+
+        final outcome = await vm.createServer.runAsync(createReq());
+
+        expect(outcome, isA<CreateDbError>());
+        expect(serversViewModel.addServerCallCount, 1);
+        expect(authRepository.deleteCurrentSessionCallCount, 1);
+        expect(serversViewModel.deleteSidCallCount, 1);
+      });
+
       test('a cancelled certificate aborts with CreateCancelled', () async {
         final vm = buildViewModel();
 
@@ -493,55 +506,49 @@ void main() {
         },
       );
 
-      test(
-        '(E15) same-address v6->v5 version switch deletes the old SID, '
-        'no login',
-        () async {
-          final vm = buildViewModel();
+      test('(E15) same-address v6->v5 version switch deletes the old SID, '
+          'no login', () async {
+        final vm = buildViewModel();
 
-          final outcome = await vm.updateServer.runAsync(
-            updateReq(apiVersion: SupportedApiVersions.v5),
-          );
+        final outcome = await vm.updateServer.runAsync(
+          updateReq(apiVersion: SupportedApiVersions.v5),
+        );
 
-          expect(outcome, isA<UpdateSuccess>());
-          expect(serversViewModel.editServerCallCount, 1);
-          expect(serversViewModel.replaceServerCallCount, 0);
-          // v5 has no session concept -- no login attempt at all.
-          expect(authRepository.createSessionCallCount, 0);
-          // The now-unused v6 session is logged out and its SID dropped.
-          expect(authRepository.deleteCurrentSessionCallCount, 1);
-          expect(serversViewModel.deleteSidCallCount, 1);
-        },
-      );
+        expect(outcome, isA<UpdateSuccess>());
+        expect(serversViewModel.editServerCallCount, 1);
+        expect(serversViewModel.replaceServerCallCount, 0);
+        // v5 has no session concept -- no login attempt at all.
+        expect(authRepository.createSessionCallCount, 0);
+        // The now-unused v6 session is logged out and its SID dropped.
+        expect(authRepository.deleteCurrentSessionCallCount, 1);
+        expect(serversViewModel.deleteSidCallCount, 1);
+      });
 
-      test(
-        '(E16) same-address v5->v6 version switch logs in with the new '
-        'password (2FA required)',
-        () async {
-          authRepository
-            ..shouldRequireTotp = true
-            ..validTotp = '123456'
-            ..serverUsesTotp = true;
-          final vm = buildViewModel();
+      test('(E16) same-address v5->v6 version switch logs in with the new '
+          'password (2FA required)', () async {
+        authRepository
+          ..shouldRequireTotp = true
+          ..validTotp = '123456'
+          ..serverUsesTotp = true;
+        final vm = buildViewModel();
 
-          final outcome = await vm.updateServer.runAsync(
-            updateReq(
-              oldServer: _oldServerV5,
-              apiVersion: SupportedApiVersions.v6,
-              password: 'new-v6-pass',
-              initPassword: '',
-              resolveTotp: ({error}) async => '123456',
-            ),
-          );
+        final outcome = await vm.updateServer.runAsync(
+          updateReq(
+            oldServer: _oldServerV5,
+            apiVersion: SupportedApiVersions.v6,
+            password: 'new-v6-pass',
+            initPassword: '',
+            resolveTotp: ({error}) async => '123456',
+          ),
+        );
 
-          expect(outcome, isA<UpdateSuccess>());
-          expect(serversViewModel.editServerCallCount, 1);
-          expect(serversViewModel.replaceServerCallCount, 0);
-          // First password-only attempt + the password+totp retry.
-          expect(authRepository.createSessionCallCount, 2);
-          expect(authRepository.lastTotp, '123456');
-        },
-      );
+        expect(outcome, isA<UpdateSuccess>());
+        expect(serversViewModel.editServerCallCount, 1);
+        expect(serversViewModel.replaceServerCallCount, 0);
+        // First password-only attempt + the password+totp retry.
+        expect(authRepository.createSessionCallCount, 2);
+        expect(authRepository.lastTotp, '123456');
+      });
     });
   });
 }

--- a/testing/fakes/viewmodels/fake_servers_viewmodel.dart
+++ b/testing/fakes/viewmodels/fake_servers_viewmodel.dart
@@ -33,6 +33,8 @@ class FakeServersViewModel extends ServersViewModel {
 
   // --- Failure controls (delegate to repo) ---
 
+  set shouldFailAddServer(bool value) => _fakeRepo.shouldFailInsert = value;
+
   set shouldFailRemoveServer(bool value) => _fakeRepo.shouldFailDelete = value;
 
   set shouldFailReplaceServer(bool value) =>


### PR DESCRIPTION
## Summary by Sourcery

Improve server connection and creation failure handling to avoid stale sessions/credentials and false success states.

Bug Fixes:
- Ensure server connection cleanup runs even when unexpected exceptions occur so the connecting guard is released.
- Prevent deletion of stored credentials when database row deletion fails for single-server and bulk deletion operations.
- Ensure add-server flow cleans up sessions and secrets when DNS or database persistence fails, returning explicit error outcomes instead of reporting success.

Enhancements:
- Move server row persistence into the add-server view model and introduce a CreateDbError outcome so the UI can show a dedicated error when saving fails.
- Refine server connection logging and flow control around successful connections and interrupted server switches.
- Ensure ServersViewModel.deleteDbData also clears session caches and TOTP reauth-declined markers for a fully reset state.

Documentation:
- Update server connection flow documentation to reflect in-view-model persistence, cleanup on failure, and the new CreateDbError outcome.

Tests:
- Add tests covering cleanup of sessions/credentials on add-server DB failures, retention of secrets when DB deletion fails, releasing the connecting guard after unexpected errors, and clearing caches on deleteDbData.