### PR TITLE
fix(status): drop stale fetch results after switching servers

### DIFF
--- a/lib/config/dependencies.dart
+++ b/lib/config/dependencies.dart
@@ -114,7 +114,7 @@ List<SingleChildWidget> createProviders({
           dnsRepository: bundle?.dns,
           ftlRepository: bundle?.ftl,
           apiVersion: bundle?.apiVersion,
-          selectedServerAddress: servers.selectedServer?.address,
+          selectedServerAddress: bundle?.serverAddress,
           selectedServerAlias: servers.selectedServer?.alias,
           isConnecting: servers.connectingServer != null,
           onUpdateServerStatus: servers.updateselectedServerStatus,

--- a/lib/ui/core/view_models/status_viewmodel.dart
+++ b/lib/ui/core/view_models/status_viewmodel.dart
@@ -354,6 +354,7 @@ class StatusViewModel with ChangeNotifier {
   // ---------------------------------------------------------------------------
 
   Future<bool> _refreshOnce() async {
+    final selectedUrlBefore = _selectedServerAddress;
     // _fetchStatusData issues multiple HTTP requests, so we start it
     // immediately to give it a head start. The others are slightly delayed
     // to avoid overwhelming the connection pool.
@@ -369,6 +370,14 @@ class StatusViewModel with ChangeNotifier {
         const Duration(milliseconds: 100),
       ).then((_) => _fetchSlowSystemData()),
     ).wait;
+
+    if (_selectedServerAddress != selectedUrlBefore) {
+      logger.d(
+        'Skipping stale refreshOnce result: server was changed during fetch. '
+        'Previous: $selectedUrlBefore, Selected: $_selectedServerAddress',
+      );
+      return false;
+    }
 
     if (statusOk && overtimeOk && metricsOk) {
       _serverStatus = LoadStatus.loaded;
@@ -412,6 +421,14 @@ class StatusViewModel with ChangeNotifier {
 
     final result = await useCase.fetchRealtimeStatus();
 
+    if (_selectedServerAddress != selectedUrlBefore) {
+      logger.d(
+        'Skipping stale status update: server was changed during fetch. '
+        'Previous: $selectedUrlBefore, Selected: $_selectedServerAddress',
+      );
+      return false;
+    }
+
     return result.fold(
       (status) {
         _realtimeStatus = status;
@@ -431,11 +448,20 @@ class StatusViewModel with ChangeNotifier {
 
   Future<bool> _fetchOverTimeData() async {
     if (_selectedServerAddress == null) return false;
+    final selectedUrlBefore = _selectedServerAddress;
 
     final metricsRepo = _metricsRepository;
     if (metricsRepo == null) return false;
 
     final result = await metricsRepo.fetchOverTime();
+
+    if (_selectedServerAddress != selectedUrlBefore) {
+      logger.d(
+        'Skipping stale overtime data update: server was changed during '
+        'fetch. Previous: $selectedUrlBefore, Selected: $_selectedServerAddress',
+      );
+      return false;
+    }
 
     return result.fold(
       (overTime) {
@@ -455,11 +481,20 @@ class StatusViewModel with ChangeNotifier {
 
   Future<bool> _fetchMetricsData() async {
     if (_selectedServerAddress == null) return false;
+    final selectedUrlBefore = _selectedServerAddress;
 
     final ftlRepo = _ftlRepository;
     if (ftlRepo == null) return false;
 
     final result = await ftlRepo.fetchInfoMetrics();
+
+    if (_selectedServerAddress != selectedUrlBefore) {
+      logger.d(
+        'Skipping stale metrics update: server was changed during fetch. '
+        'Previous: $selectedUrlBefore, Selected: $_selectedServerAddress',
+      );
+      return false;
+    }
 
     return result.fold(
       (metrics) {
@@ -479,6 +514,7 @@ class StatusViewModel with ChangeNotifier {
   // Fetched at overtime-timer frequency (slow): system stats + temperature
   Future<bool> _fetchSlowSystemData() async {
     if (_selectedServerAddress == null) return false;
+    final selectedUrlBefore = _selectedServerAddress;
     final ftlRepo = _ftlRepository;
     if (ftlRepo == null) return false;
 
@@ -486,6 +522,15 @@ class StatusViewModel with ChangeNotifier {
       ftlRepo.fetchInfoSystem(),
       ftlRepo.fetchInfoSensors(),
     ).wait;
+
+    // Drop the result when the selected server changed during the fetch.
+    if (_selectedServerAddress != selectedUrlBefore) {
+      logger.d(
+        'Skipping stale system data update: server was changed during fetch. '
+        'Previous: $selectedUrlBefore, Selected: $_selectedServerAddress',
+      );
+      return false;
+    }
 
     systemResult.fold((system) => _ftlSystem = system, (_) {});
     sensorResult.fold((sensor) => _ftlSensor = sensor, (_) {});

--- a/testing/fakes/repositories/api/fake_realtime_status_repository.dart
+++ b/testing/fakes/repositories/api/fake_realtime_status_repository.dart
@@ -11,6 +11,9 @@ class FakeRealTimeStatusRepository implements RealtimeStatusRepository {
   /// failure (e.g. a 495 TLS error) instead of the generic one.
   Exception? failureError;
 
+  /// Optional override for the returned status.
+  RealtimeStatus? response;
+
   @override
   Future<Result<RealtimeStatus>> fetchRealtimeStatus() async {
     if (shouldFail) {
@@ -18,6 +21,6 @@ class FakeRealTimeStatusRepository implements RealtimeStatusRepository {
         failureError ?? Exception('Failed to fetch real-time status'),
       );
     }
-    return Success(kRepoFetchRealTimeStatus);
+    return Success(response ?? kRepoFetchRealTimeStatus);
   }
 }


### PR DESCRIPTION
## Overview
After switching from one server to another on the Home and Statistics screens, the status chips, 24-hour graph, and query stats could briefly revert to the previous server's data before self-correcting on the next refresh tick. The shared `StatusViewModel` took its selected-server address from `ServersViewModel` but its repositories from `RepositoryBundle` (two separate providers), and several in-flight fetches wrote their results back without checking whether the selected server had changed. This regressed after the real-time system-metrics chips were introduced.

## Changes
- Derive the selected server address in `StatusViewModel` from the `RepositoryBundle` (`bundle?.serverAddress`) so the address and the repositories always come from a single source and can never disagree — making the "server changed during fetch" guards reliable.
- Add that guard to the one-shot refresh path (`refreshOnce` and its status/overtime/metrics fetchers) so a refresh started for the previous server no longer writes its data or flips the connection state after a switch.
- Add the same guard to the slow system/sensor fetch, which ran inside the overtime timer before its guard and could leave the CPU/RAM/temperature/uptime chips showing the previous server until the next minute-interval tick.

## Summary by Sourcery

Guard status refreshes against server changes to prevent stale data from overwriting the current server's status.

Bug Fixes:
- Prevent status, overtime metrics, and slow system data refreshes from applying results if the selected server changes mid-fetch, avoiding brief reversion to the previous server's data.

Enhancements:
- Derive the selected server address for StatusViewModel from the repository bundle to keep the selected server and repositories in sync.

Tests:
- Allow fake real-time status repository to return a configurable response for more precise testing of status flows.