### PR TITLE
fix(totp): re-prompt for a 2FA code on a user-requested refresh

### DIFF
--- a/integration_test/fake/totp_fake_test.dart
+++ b/integration_test/fake/totp_fake_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
+import 'package:pi_hole_client/ui/home/widgets/home_screen.dart';
 
 import '../support/app_harness.dart';
 import '../support/fake_pihole_server.dart';
@@ -176,6 +177,51 @@ void main() {
 
       expect(app.servers.getServersList, isEmpty);
     });
+  });
+
+  group('totp fake - manual refresh after a cancelled prompt', () {
+    testWidgets(
+      'a refresh the user asks for prompts again, unlike an auto-refresh tick',
+      (tester) async {
+        final app = AppHarness(tester);
+        await app.boot();
+
+        final fakeServer = FakePiholeServer(password: 'pw')
+          ..totpRequired = true
+          ..totpCode = 246813;
+        addTearDown(fakeServer.close);
+        final uri = Uri.parse(await fakeServer.start());
+
+        await fillAddV6Form(
+          tester,
+          app,
+          host: uri.host,
+          port: '${uri.port}',
+          password: 'pw',
+          alias: 'refresh-after-cancel',
+        );
+        await app.completeTotpPrompt('246813');
+        expect(find.text(app.l10n.connectedSuccessfully), findsOneWidget);
+        final address = app.servers.getServersList.single.address;
+
+        await app.connectServer();
+        expect(find.byType(HomeScreen), findsOneWidget);
+
+        // Session gone server-side and a prompt already declined.
+        fakeServer
+          ..invalidateSession()
+          ..totpCode = 314157;
+        app.servers.markTotpReauthDeclined(address);
+
+        // Tap the refresh button in the home menu, which is a user-initiated refresh.
+        await app.refreshFromHomeMenu();
+
+        expect(await app.waitForTotpPrompt(), isTrue);
+        await app.completeTotpPrompt('314157');
+
+        expect(app.servers.isTotpReauthDeclined(address), isFalse);
+      },
+    );
   });
 
   group('totp fake - edit', () {

--- a/integration_test/support/app_harness.dart
+++ b/integration_test/support/app_harness.dart
@@ -373,6 +373,19 @@ class AppHarness {
     await settle(frames: 4);
   }
 
+  /// Taps the refresh entry in the home app bar's action menu, which reads
+  /// "Refresh" while connected and "Try reconnect" once the server is in an
+  /// error state.
+  Future<void> refreshFromHomeMenu() async {
+    await tester.tap(find.byIcon(Icons.more_vert));
+    await settle(frames: 5);
+    final refresh = find.text(l10n.refresh);
+    await tester.tap(
+      refresh.evaluate().isNotEmpty ? refresh : find.text(l10n.tryReconnect),
+    );
+    await settle(frames: 5);
+  }
+
   /// Waits for the TOTP prompt to appear.
   Future<bool> waitForTotpPrompt() => waitFor(find.text(l10n.confirm));
 

--- a/lib/ui/core/actions/refresh_server_status.dart
+++ b/lib/ui/core/actions/refresh_server_status.dart
@@ -8,7 +8,7 @@ import 'package:provider/provider.dart';
 
 /// Refreshes the selected server, in response to a user gesture (pull to
 /// refresh, the app bar's refresh / try-reconnect action).
-Future<dynamic> refreshServerStatus(BuildContext context) async {
+Future<void> refreshServerStatus(BuildContext context) async {
   final statusViewModel = Provider.of<StatusViewModel>(context, listen: false);
   final appConfigViewModel = Provider.of<AppConfigViewModel>(
     context,

--- a/lib/ui/core/actions/refresh_server_status.dart
+++ b/lib/ui/core/actions/refresh_server_status.dart
@@ -2,15 +2,27 @@ import 'package:flutter/material.dart';
 import 'package:pi_hole_client/ui/core/l10n/generated/app_localizations.dart';
 import 'package:pi_hole_client/ui/core/ui/helpers/snackbar.dart';
 import 'package:pi_hole_client/ui/core/view_models/app_config_viewmodel.dart';
+import 'package:pi_hole_client/ui/core/view_models/servers_viewmodel.dart';
 import 'package:pi_hole_client/ui/core/view_models/status_viewmodel.dart';
 import 'package:provider/provider.dart';
 
+/// Refreshes the selected server, in response to a user gesture (pull to
+/// refresh, the app bar's refresh / try-reconnect action).
 Future<dynamic> refreshServerStatus(BuildContext context) async {
   final statusViewModel = Provider.of<StatusViewModel>(context, listen: false);
   final appConfigViewModel = Provider.of<AppConfigViewModel>(
     context,
     listen: false,
   );
+  final serversViewModel = Provider.of<ServersViewModel>(
+    context,
+    listen: false,
+  );
+
+  final address = serversViewModel.selectedServer?.address;
+  if (address != null) {
+    serversViewModel.clearTotpReauthDeclined(address);
+  }
 
   final success = await statusViewModel.refreshOnce();
   if (!context.mounted) return;

--- a/lib/ui/core/view_models/servers_viewmodel.dart
+++ b/lib/ui/core/view_models/servers_viewmodel.dart
@@ -133,8 +133,9 @@ class ServersViewModel with ChangeNotifier {
     _connectingServer = null;
   }
 
-  /// Marks [address] as having a user-cancelled 2FA prompt, so background
-  /// paths (auto-refresh fallback, app resume, refresh) won't auto-prompt again.
+  /// Marks [address] as having a user-cancelled 2FA prompt, so automatic paths
+  /// (auto-refresh ticks, app resume) won't prompt again. A refresh the user
+  /// asks for clears the mark instead — see `refreshServerStatus`.
   void markTotpReauthDeclined(String address) {
     _totpReauthDeclined.add(address);
   }

--- a/lib/ui/home/widgets/home_appbar/server_actions_menu.dart
+++ b/lib/ui/home/widgets/home_appbar/server_actions_menu.dart
@@ -1,9 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import 'package:pi_hole_client/routing/routes.dart';
+import 'package:pi_hole_client/ui/core/actions/refresh_server_status.dart';
 import 'package:pi_hole_client/ui/core/l10n/generated/app_localizations.dart';
-import 'package:pi_hole_client/ui/core/ui/helpers/snackbar.dart';
-import 'package:pi_hole_client/ui/core/view_models/app_config_viewmodel.dart';
 import 'package:pi_hole_client/ui/core/view_models/servers_viewmodel.dart';
 import 'package:pi_hole_client/ui/core/view_models/status_viewmodel.dart';
 import 'package:pi_hole_client/utils/open_url.dart';
@@ -29,15 +28,12 @@ import 'package:provider/provider.dart';
 /// See also:
 /// - [ServersViewModel] for managing server selection.
 /// - [StatusViewModel] for server connection status.
-/// - [AppConfigViewModel] for app configuration and error handling.
 class ServerActionsMenu extends StatelessWidget {
   const ServerActionsMenu({super.key});
 
   @override
   Widget build(BuildContext context) {
     final serversViewModel = context.watch<ServersViewModel>();
-    final statusViewModel = context.read<StatusViewModel>();
-    final appConfigViewModel = context.read<AppConfigViewModel>();
 
     final isConnected = context.select<StatusViewModel, bool>(
       (p) => !p.isServerLoading,
@@ -50,8 +46,6 @@ class ServerActionsMenu extends StatelessWidget {
       splashRadius: 20,
       itemBuilder: (context) => _buildPopupMenuItems(
         context,
-        appConfigViewModel,
-        statusViewModel,
         serversViewModel,
         isConnected,
         isServerSelected,
@@ -73,16 +67,12 @@ class ServerActionsMenu extends StatelessWidget {
   ///
   /// Parameters:
   /// - [context]: The build context used for localization and navigation.
-  /// - [appConfigViewModel]: The app configuration provider used for error handling.
-  /// - [statusViewModel]: The status provider to read the current server connection status.
   /// - [serversViewModel]: The servers provider to access the selected server.
   ///
   /// Returns:
   /// A list of [PopupMenuEntry] widgets to be shown in the popup menu.
   List<PopupMenuEntry<void>> _buildPopupMenuItems(
     BuildContext context,
-    AppConfigViewModel appConfigViewModel,
-    StatusViewModel statusViewModel,
     ServersViewModel serversViewModel,
     bool isConnected,
     bool isServerSelected,
@@ -102,7 +92,7 @@ class ServerActionsMenu extends StatelessWidget {
     if (isConnected) {
       return [
         PopupMenuItem(
-          onTap: () => _refresh(context, appConfigViewModel, statusViewModel),
+          onTap: () => refreshServerStatus(context),
           child: _menuItem(
             Icons.refresh,
             AppLocalizations.of(context)!.refresh,
@@ -128,7 +118,7 @@ class ServerActionsMenu extends StatelessWidget {
 
     return [
       PopupMenuItem(
-        onTap: () => _refresh(context, appConfigViewModel, statusViewModel),
+        onTap: () => refreshServerStatus(context),
         child: _menuItem(
           Icons.refresh_rounded,
           AppLocalizations.of(context)!.tryReconnect,
@@ -147,24 +137,6 @@ class ServerActionsMenu extends StatelessWidget {
   /// Returns a standard icon + label row used in popup menu items.
   Widget _menuItem(IconData icon, String label) {
     return Row(children: [Icon(icon), const SizedBox(width: 15), Text(label)]);
-  }
-
-  /// Refreshes the server status by delegating to [StatusViewModel].
-  Future<void> _refresh(
-    BuildContext context,
-    AppConfigViewModel appConfigViewModel,
-    StatusViewModel statusViewModel,
-  ) async {
-    final success = await statusViewModel.refreshOnce();
-    if (!context.mounted) return;
-
-    if (!success) {
-      showErrorSnackBar(
-        context: context,
-        appConfigViewModel: appConfigViewModel,
-        label: AppLocalizations.of(context)!.couldNotConnectServer,
-      );
-    }
   }
 
   /// Navigates to the [Routes.settingsAppServers] screen, allowing the user to change the current server.

--- a/test/ui/core/actions/refresh_server_status_test.dart
+++ b/test/ui/core/actions/refresh_server_status_test.dart
@@ -1,0 +1,92 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pi_hole_client/domain/model/server/api_versions.dart';
+import 'package:pi_hole_client/domain/model/server/server.dart';
+import 'package:pi_hole_client/ui/core/actions/refresh_server_status.dart';
+import 'package:pi_hole_client/ui/core/view_models/app_config_viewmodel.dart';
+
+import '../../../../testing/fakes/repositories/local/fake_app_config_repository.dart';
+import '../../../../testing/fakes/viewmodels/fake_servers_viewmodel.dart';
+import '../../../../testing/fakes/viewmodels/fake_status_viewmodel.dart';
+import '../../../../testing/test_app.dart';
+
+const _serverV6 = Server(
+  address: 'http://localhost:8081',
+  alias: 'v6',
+  apiVersion: SupportedApiVersions.v6,
+  defaultServer: false,
+  allowUntrustedCert: true,
+  ignoreCertificateErrors: false,
+);
+
+void main() async {
+  await initTestApp();
+
+  group('refreshServerStatus', () {
+    late FakeServersViewModel serversViewModel;
+    late FakeStatusViewModel statusViewModel;
+    late AppConfigViewModel appConfigViewModel;
+
+    setUp(() {
+      serversViewModel = FakeServersViewModel();
+      statusViewModel = FakeStatusViewModel();
+      appConfigViewModel = AppConfigViewModel(FakeAppConfigRepository());
+    });
+
+    Future<BuildContext> pumpContext(WidgetTester tester) async {
+      late BuildContext ctx;
+      await tester.pumpWidget(
+        buildTestApp(
+          Builder(
+            builder: (context) {
+              ctx = context;
+              return const SizedBox();
+            },
+          ),
+          appConfigViewModel: appConfigViewModel,
+          serversViewModel: serversViewModel,
+          statusViewModel: statusViewModel,
+        ),
+      );
+      await tester.pump();
+      return ctx;
+    }
+
+    testWidgets('clears an earlier 2FA cancellation before refreshing', (
+      tester,
+    ) async {
+      serversViewModel.selectedServer = _serverV6;
+      serversViewModel.markTotpReauthDeclined(_serverV6.address);
+      final ctx = await pumpContext(tester);
+
+      await refreshServerStatus(ctx);
+      await tester.pumpAndSettle();
+
+      expect(serversViewModel.isTotpReauthDeclined(_serverV6.address), isFalse);
+      expect(statusViewModel.refreshOnceCallCount, 1);
+    });
+
+    testWidgets('refreshes when no server is selected', (tester) async {
+      final ctx = await pumpContext(tester);
+
+      await refreshServerStatus(ctx);
+      await tester.pumpAndSettle();
+
+      expect(statusViewModel.refreshOnceCallCount, 1);
+      expect(serversViewModel.clearTotpReauthDeclinedCallCount, 0);
+    });
+
+    testWidgets('shows an error snackbar when the refresh fails', (
+      tester,
+    ) async {
+      serversViewModel.selectedServer = _serverV6;
+      statusViewModel.refreshOnceResult = false;
+      final ctx = await pumpContext(tester);
+
+      await refreshServerStatus(ctx);
+      await tester.pumpAndSettle();
+
+      expect(find.text('Could not connect to the server'), findsOneWidget);
+    });
+  });
+}

--- a/test/ui/home/home_test.dart
+++ b/test/ui/home/home_test.dart
@@ -471,6 +471,53 @@ void main() async {
       await tester.pump(const Duration(seconds: 1));
     });
 
+    testWidgets('"Try reconnect" clears an earlier 2FA cancellation', (
+      WidgetTester tester,
+    ) async {
+      tester.view.physicalSize = const Size(1080, 2400);
+      tester.view.devicePixelRatio = 2.0;
+
+      addTearDown(() {
+        tester.view.resetPhysicalSize();
+        tester.view.resetDevicePixelRatio();
+      });
+
+      // cancelled 2FA prompt
+      statusViewModel.serverStatus = LoadStatus.loading;
+      serversViewModel.markTotpReauthDeclined(_serverV6.address);
+
+      await tester.pumpWidget(
+        buildTestApp(
+          HomeScreen(
+            serversViewModel: serversViewModel,
+            appConfigViewModel: appConfigViewModel,
+            statusViewModel: statusViewModel,
+          ),
+          appConfigViewModel: appConfigViewModel,
+          serversViewModel: serversViewModel,
+          statusViewModel: statusViewModel,
+          logsViewModel: logsViewModel,
+          repositoryBundle: createFakeRepositoryBundle(),
+        ),
+      );
+
+      // The disconnected screen shimmers forever, so settle by pumping fixed
+      // frames rather than pumpAndSettle.
+      Future<void> pumpFrames() async {
+        for (var i = 0; i < 6; i++) {
+          await tester.pump(const Duration(milliseconds: 100));
+        }
+      }
+
+      await tester.tap(find.byIcon(Icons.more_vert));
+      await pumpFrames();
+      await tester.tap(find.text('Try reconnect'));
+      await pumpFrames();
+
+      expect(statusViewModel.refreshOnceCallCount, 1);
+      expect(serversViewModel.isTotpReauthDeclined(_serverV6.address), isFalse);
+    });
+
     testWidgets('should show servers page', (WidgetTester tester) async {
       tester.view.physicalSize = const Size(1080, 2400);
       tester.view.devicePixelRatio = 2.0;

--- a/testing/fakes/viewmodels/fake_status_viewmodel.dart
+++ b/testing/fakes/viewmodels/fake_status_viewmodel.dart
@@ -134,6 +134,16 @@ class FakeStatusViewModel extends StatusViewModel {
   int startAutoRefreshCallCount = 0;
   int stopAutoRefreshCallCount = 0;
 
+  // Call tracking for one-shot refreshes, plus the result they report back.
+  int refreshOnceCallCount = 0;
+  bool refreshOnceResult = true;
+
+  @override
+  Future<bool> refreshOnce() async {
+    refreshOnceCallCount++;
+    return refreshOnceResult;
+  }
+
   @override
   void startAutoRefresh({
     bool runImmediately = true,


### PR DESCRIPTION
## Overview
Cancelling the TOTP prompt suppresses re-prompts during auto-refresh, as intended. However, manual refreshes were suppressed too, leaving a server switch as the only way to re-authenticate after a 2FA session expired.

User-requested refreshes now re-prompt for TOTP, while automatic refreshes remain suppressed.

## Changes
- Clear the declined-2FA mark in `refreshServerStatus` before refreshing, so a user-initiated refresh reaches the TOTP prompt again. Auto-refresh ticks and app resume do not go through this action, so their suppression is unchanged.
- Fold the app bar menu's duplicate refresh handler into `refreshServerStatus`; keeping its own copy is why both the swipe gesture and the menu entry were affected.
- Add `refreshOnce` call tracking to `FakeStatusViewModel` and a `refreshFromHomeMenu` helper to `AppHarness`.

## Summary by Sourcery

Ensure manually triggered server refreshes re-prompt for TOTP after a cancelled 2FA prompt while keeping automatic refresh suppression unchanged.

Bug Fixes:
- Allow user-initiated refresh actions to clear previously declined TOTP reauthentication so a new 2FA prompt is shown.
- Ensure the home app bar refresh/try-reconnect menu delegates to the shared refreshServerStatus action instead of duplicating refresh logic.

Enhancements:
- Track one-shot refresh calls in the fake status view model to support behaviour verification in tests.
- Add an AppHarness helper for triggering a refresh from the home menu in integration tests.

Tests:
- Add unit tests for refreshServerStatus to verify TOTP-decline clearing, behaviour without a selected server, and error snackbar display.
- Extend UI and integration tests to cover manual refresh behaviour after cancelling a TOTP prompt.