### PR TITLE
fix(auth): connect to a password-less Pi-hole with a password entered

### DIFF
--- a/integration_test/fake/add_fake_test.dart
+++ b/integration_test/fake/add_fake_test.dart
@@ -1,0 +1,36 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+
+import '../support/app_harness.dart';
+import '../support/fake_pihole_server.dart';
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  group('add a password-less server with a password typed', () {
+    testWidgets(
+      'a password-less v6 server connects even when a password is typed',
+      (tester) async {
+        final app = AppHarness(tester);
+        await app.boot();
+
+        final fakeServer = FakePiholeServer()..noPassword = true;
+        addTearDown(fakeServer.close);
+        final uri = Uri.parse(await fakeServer.start());
+
+        await app.openAddServer();
+        await app.addV6ServerViaUi(
+          host: uri.host,
+          port: '${uri.port}',
+          password: 'left-over-password',
+          alias: 'no-pw-with-pw',
+        );
+
+        expect(find.text(app.l10n.connectedSuccessfully), findsOneWidget);
+        final address = app.servers.getServersList.single.address;
+        expect(await app.passwordOf(address), 'left-over-password');
+        expect(await app.sidOf(address) ?? '', isEmpty);
+      },
+    );
+  });
+}

--- a/integration_test/fake/edit_fake_test.dart
+++ b/integration_test/fake/edit_fake_test.dart
@@ -55,7 +55,7 @@ void main() {
 
   group('same-address password removal', () {
     testWidgets(
-      'clearing the password logs in password-less and keeps the old sid',
+      'clearing the password logs in password-less and stores an empty sid',
       (tester) async {
         final app = AppHarness(tester);
         await app.boot();
@@ -86,9 +86,36 @@ void main() {
 
         expect(find.text(app.l10n.editServerSuccessfully), findsOneWidget);
         expect(await app.passwordOf(address) ?? '', isEmpty);
-        expect(await app.sidOf(address), sidBefore);
+        expect(await app.sidOf(address) ?? '', isEmpty);
       },
     );
+
+    testWidgets('adding a password to a password-less server still connects', (
+      tester,
+    ) async {
+      final app = AppHarness(tester);
+      await app.boot();
+
+      final fakeServer = FakePiholeServer()..noPassword = true;
+      addTearDown(fakeServer.close);
+      final uri = Uri.parse(await fakeServer.start());
+
+      await app.openAddServer();
+      await app.addV6ServerViaUi(
+        host: uri.host,
+        port: '${uri.port}',
+        password: '',
+        alias: 'no-pw-then-pw',
+      );
+      expect(find.text(app.l10n.connectedSuccessfully), findsOneWidget);
+      final address = app.servers.getServersList.single.address;
+
+      await app.editServer(password: 'typed-by-mistake');
+
+      expect(find.text(app.l10n.editServerSuccessfully), findsOneWidget);
+      expect(await app.passwordOf(address), 'typed-by-mistake');
+      expect(await app.sidOf(address) ?? '', isEmpty);
+    });
   });
 
   group('same-address password change rollback', () {

--- a/integration_test/real/add_real_test.dart
+++ b/integration_test/real/add_real_test.dart
@@ -269,7 +269,7 @@ void main() {
   });
 
   group('add (v6, no password)', () {
-    testWidgets('(C2) password-less v6 connects and stores no sid', (
+    testWidgets('password-less v6 connects and stores an empty sid', (
       tester,
     ) async {
       final app = AppHarness(tester);
@@ -293,11 +293,7 @@ void main() {
       final saved = app.servers.getServersList.first;
       expect(await app.passwordOf(saved.address), '');
       final sid = await app.sidOf(saved.address);
-      expect(
-        sid == null || sid.isEmpty,
-        isTrue,
-        reason: 'a password-less v6 server should not persist a sid',
-      );
+      expect(sid == null || sid.isEmpty, isTrue);
     });
   });
 

--- a/lib/data/repositories/api/v6/auth_repository.dart
+++ b/lib/data/repositories/api/v6/auth_repository.dart
@@ -27,15 +27,16 @@ class AuthRepositoryV6 extends BaseV6SidRepository implements AuthRepository {
         );
         final auth = result.map((e) => e.toDomain());
         final value = auth.getOrNull();
-        // Persist only a real sid. An empty sid (no app password) is
-        // intentionally not saved; any leftover sid is harmless since a
-        // password-less v6 server ignores the sid header.
-        if (value != null && value.valid && value.sid.isNotEmpty) {
+        // Save on every valid session, even when the sid is empty. A
+        // password-less v6 server answers 200 with `sid: null`.
+        if (value != null && value.valid) {
           await saveSid(value.sid);
-          await WidgetChannel.sendSidUpdated(
-            serverAddress: serverAddress,
-            sid: value.sid,
-          );
+          if (value.sid.isNotEmpty) {
+            await WidgetChannel.sendSidUpdated(
+              serverAddress: serverAddress,
+              sid: value.sid,
+            );
+          }
         }
         return auth;
       },

--- a/lib/data/services/utils/safe_api_call.dart
+++ b/lib/data/services/utils/safe_api_call.dart
@@ -47,8 +47,8 @@ Future<Result<T>> safeApiCall<T extends Object>(
   } on TotpRateLimitException catch (e) {
     logger.e('TOTP rate limited: ${e.message}');
     return Failure(e);
-  } on HttpStatusCodeException catch (e) {
-    logger.e('HTTP error occurred: ${e.message}');
+  } on HttpStatusCodeException catch (e, st) {
+    logger.e('HTTP error occurred: [${e.statusCode}] ${e.message}\n$st');
     return Failure(e);
   } on SocketException catch (e) {
     final msg = 'Network connection failed. ${e.message}';
@@ -105,8 +105,8 @@ Stream<Result<T>> safeApiCallStream<T extends Object>(
     await for (final result in apiCall()) {
       yield Success(result);
     }
-  } on HttpStatusCodeException catch (e) {
-    logger.e('HTTP error occurred: ${e.message}');
+  } on HttpStatusCodeException catch (e, st) {
+    logger.e('HTTP error occurred: [${e.statusCode}] ${e.message}\n$st');
     yield Failure(e);
   } on SocketException catch (e) {
     final msg = 'Network connection failed. ${e.message}';

--- a/test/data/repositories/api/v6/auth_repository_test.dart
+++ b/test/data/repositories/api/v6/auth_repository_test.dart
@@ -35,17 +35,31 @@ void main() {
       expectError(result, messageContains: 'Forced postAuth failure');
     });
 
+    test('persists an empty sid when no app password is set', () async {
+      client.shouldReturnNoPasswordSession = true;
+
+      final result = await repository.createSession('');
+
+      expect(result.isSuccess(), isTrue);
+      expect(result.getOrNull()!.valid, isTrue);
+      expect(result.getOrNull()!.sid, '');
+      expect(creds.saveSidCallCount, 1);
+      expect(creds.lastSavedSid, '');
+    });
+
     test(
-      'succeeds without persisting a sid when no app password is set',
+      'a password-less login leaves a usable session even when a password is stored',
       () async {
         client.shouldReturnNoPasswordSession = true;
+        creds
+          ..shouldFailSidRead = true
+          ..addressPassword = 'typed-by-mistake';
 
-        final result = await repository.createSession('');
+        final result = await repository.createSession('typed-by-mistake');
 
         expect(result.isSuccess(), isTrue);
-        expect(result.getOrNull()!.valid, isTrue);
-        expect(result.getOrNull()!.sid, '');
-        expect(creds.saveSidCallCount, 0);
+        expect(creds.lastSavedSid, '');
+        expect(await repository.getSid(), '');
       },
     );
 

--- a/test/data/repositories/api/v6/v6_session_cache_test.dart
+++ b/test/data/repositories/api/v6/v6_session_cache_test.dart
@@ -82,6 +82,16 @@ void main() {
         ..addressPassword = 'secret';
       await expectLater(cache.getSid(), throwsA(isA<SidNotFoundException>()));
     });
+
+    test('returns the stored empty SID even when a password is set', () async {
+      // A password-less login stores an empty SID. Reading it back must not be
+      // confused with "no SID stored", whatever password the user typed.
+      creds
+        ..addressSid = ''
+        ..addressPassword = 'typed-by-mistake';
+      final sid = await cache.getSid();
+      expect(sid, '');
+    });
   });
 
   // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Overview

Connecting to a Pi-hole v6 with no web password failed with an "Unknown Error" snackbar if anything was left in the password field, when adding a server, changing its address, or editing one in place. 
The app now connects to a password-less server regardless of what is in the password field.


## Changes

- Persist the sid on every valid session, the empty one included.
- Keep widget sid notifications gated to a real, non-empty sid.
- Add unit and fake-server integration tests.
- Include the status code and stack trace in HTTP error logs.

## Summary by Sourcery

Fix password-less Pi-hole v6 authentication when a password is entered or retained.

Bug Fixes:
- Allow authentication with password-less Pi-hole v6 servers even when a password remains in the password field.
- Persist empty session IDs for valid password-less sessions so they remain usable across authentication and credential lookups.

Enhancements:
- Keep widget session-ID notifications limited to non-empty session IDs.
- Include HTTP status codes and stack traces in HTTP error logs.

Tests:
- Add unit and fake-server integration coverage for password-less authentication with entered passwords and empty session-ID persistence.