### PR TITLE
fix(widget): show widget data for a passwordless Pi-hole v6 server

### DIFF
--- a/android/app/src/main/kotlin/io/github/tsutsu3/pi_hole_client/MainActivity.kt
+++ b/android/app/src/main/kotlin/io/github/tsutsu3/pi_hole_client/MainActivity.kt
@@ -25,7 +25,11 @@ class MainActivity : FlutterFragmentActivity() {
             when (call.method) {
                 "sidUpdated" -> {
                     val serverId = requireServerId(call, result) ?: return@setMethodCallHandler
-                    val sid = call.argument<String>("sid").orEmpty()
+                    val sid = call.argument<String>("sid")
+                    if (sid == null) {
+                        result.error("invalid_args", "sid is required", null)
+                        return@setMethodCallHandler
+                    }
                     prefs.saveSid(serverId, sid)
                     prefs.setSidValid(serverId, true)
                     WidgetUpdateHelper.refreshWidgetsForServer(

--- a/android/app/src/main/kotlin/io/github/tsutsu3/pi_hole_client/widget/data/WidgetPrefs.kt
+++ b/android/app/src/main/kotlin/io/github/tsutsu3/pi_hole_client/widget/data/WidgetPrefs.kt
@@ -5,6 +5,7 @@ import android.content.ComponentName
 import android.content.Context
 import android.content.SharedPreferences
 import android.util.Log
+import androidx.annotation.VisibleForTesting
 import androidx.security.crypto.EncryptedSharedPreferences
 import androidx.security.crypto.MasterKey
 import io.github.tsutsu3.pi_hole_client.widget.WidgetConstants
@@ -76,6 +77,12 @@ class WidgetPrefs private constructor(context: Context) {
             return instance ?: synchronized(this) {
                 instance ?: WidgetPrefs(context.applicationContext).also { instance = it }
             }
+        }
+
+        /** Drops the cached singleton so each test starts from a clean store. */
+        @VisibleForTesting
+        internal fun clearInstanceForTest() {
+            synchronized(this) { instance = null }
         }
     }
 
@@ -188,6 +195,16 @@ class WidgetPrefs private constructor(context: Context) {
      */
     fun isSidValid(serverId: String): Boolean {
         return prefs.getBoolean(keyForSidValid(serverId), false)
+    }
+
+    /**
+     * Returns true when Flutter has pushed a session and it is still valid.
+     *
+     * An empty SID is a real value: a password-less v6 server has no session
+     * token, so Flutter pushes "". Only a missing key means "never pushed".
+     */
+    fun hasUsableSession(serverId: String): Boolean {
+        return getSid(serverId) != null && isSidValid(serverId)
     }
 
     /**

--- a/android/app/src/main/kotlin/io/github/tsutsu3/pi_hole_client/widget/worker/ServerBlockingStatusWorker.kt
+++ b/android/app/src/main/kotlin/io/github/tsutsu3/pi_hole_client/widget/worker/ServerBlockingStatusWorker.kt
@@ -54,11 +54,12 @@ class ServerBlockingStatusWorker(
             return Result.success()
         }
 
-        val sid = prefs.getSid(serverId)
-        if (!prefs.isSidValid(serverId) || sid.isNullOrEmpty()) {
+        if (!prefs.hasUsableSession(serverId)) {
             broadcast(serverId, prefs, ToggleWidgetState(serverId, server.alias, WidgetStatus.AUTH_REQUIRED, false))
             return Result.success()
         }
+
+        val sid = prefs.getSid(serverId)
 
         val client = PiHoleApiClient(
             allowUntrustedCert = server.allowUntrustedCert,

--- a/android/app/src/main/kotlin/io/github/tsutsu3/pi_hole_client/widget/worker/ServerPaddWorker.kt
+++ b/android/app/src/main/kotlin/io/github/tsutsu3/pi_hole_client/widget/worker/ServerPaddWorker.kt
@@ -55,11 +55,12 @@ class ServerPaddWorker(
             return Result.success()
         }
 
-        val sid = prefs.getSid(serverId)
-        if (!prefs.isSidValid(serverId) || sid.isNullOrEmpty()) {
+        if (!prefs.hasUsableSession(serverId)) {
             broadcast(serverId, prefs, PaddResponseParser.placeholderState(serverId, server.alias, WidgetStatus.AUTH_REQUIRED, false))
             return Result.success()
         }
+
+        val sid = prefs.getSid(serverId)
 
         val client = PiHoleApiClient(
             allowUntrustedCert = server.allowUntrustedCert,

--- a/android/app/src/main/kotlin/io/github/tsutsu3/pi_hole_client/widget/worker/ServerToggleWorker.kt
+++ b/android/app/src/main/kotlin/io/github/tsutsu3/pi_hole_client/widget/worker/ServerToggleWorker.kt
@@ -63,11 +63,12 @@ class ServerToggleWorker(
             return Result.success()
         }
 
-        val sid = prefs.getSid(serverId)
-        if (!prefs.isSidValid(serverId) || sid.isNullOrEmpty()) {
+        if (!prefs.hasUsableSession(serverId)) {
             broadcast(serverId, prefs, ToggleWidgetState(serverId, server.alias, WidgetStatus.AUTH_REQUIRED, false))
             return Result.success()
         }
+
+        val sid = prefs.getSid(serverId)
 
         val client = PiHoleApiClient(
             allowUntrustedCert = server.allowUntrustedCert,

--- a/android/app/src/test/kotlin/io/github/tsutsu3/pi_hole_client/widget/data/WidgetPrefsTest.kt
+++ b/android/app/src/test/kotlin/io/github/tsutsu3/pi_hole_client/widget/data/WidgetPrefsTest.kt
@@ -1,0 +1,78 @@
+package io.github.tsutsu3.pi_hole_client.widget.data
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class WidgetPrefsTest {
+
+    private lateinit var prefs: WidgetPrefs
+
+    @Before
+    fun setUp() {
+        WidgetPrefs.clearInstanceForTest()
+        prefs = WidgetPrefs.getInstance(ApplicationProvider.getApplicationContext<Context>())
+    }
+
+    @Test
+    fun getSid_returnsNullWhenNeverSaved() {
+        assertNull(prefs.getSid("http://never-saved"))
+    }
+
+    @Test
+    fun getSid_returnsEmptyStringAfterSavingEmpty() {
+        prefs.saveSid("http://no-auth", "")
+
+        assertEquals("", prefs.getSid("http://no-auth"))
+    }
+
+    @Test
+    fun hasUsableSession_trueForEmptySidPushedByFlutter() {
+        prefs.saveSid("http://no-auth", "")
+        prefs.setSidValid("http://no-auth", true)
+
+        assertTrue(prefs.hasUsableSession("http://no-auth"))
+    }
+
+    @Test
+    fun hasUsableSession_falseWhenSidNeverPushed() {
+        prefs.setSidValid("http://never-pushed", true)
+
+        assertFalse(prefs.hasUsableSession("http://never-pushed"))
+    }
+
+    @Test
+    fun hasUsableSession_falseWhenEmptySidMarkedInvalid() {
+        prefs.saveSid("http://revoked", "")
+        prefs.setSidValid("http://revoked", false)
+
+        assertFalse(prefs.hasUsableSession("http://revoked"))
+    }
+
+    @Test
+    fun hasUsableSession_trueForNormalSid() {
+        prefs.saveSid("http://normal", "abc123")
+        prefs.setSidValid("http://normal", true)
+
+        assertTrue(prefs.hasUsableSession("http://normal"))
+    }
+
+    @Test
+    fun hasUsableSession_falseAfterRemoveServer() {
+        prefs.saveSid("http://removed", "")
+        prefs.setSidValid("http://removed", true)
+
+        prefs.removeServer("http://removed")
+
+        assertNull(prefs.getSid("http://removed"))
+        assertFalse(prefs.hasUsableSession("http://removed"))
+    }
+}

--- a/android/app/src/test/kotlin/io/github/tsutsu3/pi_hole_client/widget/worker/ServerBlockingStatusWorkerTest.kt
+++ b/android/app/src/test/kotlin/io/github/tsutsu3/pi_hole_client/widget/worker/ServerBlockingStatusWorkerTest.kt
@@ -1,0 +1,113 @@
+package io.github.tsutsu3.pi_hole_client.widget.worker
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import androidx.work.testing.TestListenableWorkerBuilder
+import androidx.work.workDataOf
+import io.github.tsutsu3.pi_hole_client.widget.WidgetConstants
+import io.github.tsutsu3.pi_hole_client.widget.data.WidgetPrefs
+import io.github.tsutsu3.pi_hole_client.widget.data.WidgetServer
+import io.mockk.every
+import io.mockk.mockkObject
+import io.mockk.unmockkAll
+import io.mockk.verify
+import kotlinx.coroutines.runBlocking
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class ServerBlockingStatusWorkerTest {
+
+    private lateinit var server: MockWebServer
+    private lateinit var prefs: WidgetPrefs
+    private lateinit var serverId: String
+
+    @Before
+    fun setUp() {
+        server = MockWebServer()
+        server.start()
+        serverId = server.url("/").toString().trimEnd('/')
+        prefs = mockWidgetPrefs(serverId)
+    }
+
+    @After
+    fun tearDown() {
+        server.shutdown()
+        unmockkAll()
+    }
+
+    private fun mockWidgetPrefs(id: String): WidgetPrefs {
+        val mock = io.mockk.mockk<WidgetPrefs>(relaxed = true)
+        every { mock.getServerInfo(id) } returns WidgetServer(
+            serverId = id,
+            alias = "test",
+            address = id,
+            apiVersion = "v6",
+            allowUntrustedCert = false,
+            ignoreCertificateErrors = false,
+            pinnedCertificateSha256 = null,
+        )
+        every { mock.getWidgetIdsForServer(any(), any()) } returns IntArray(0)
+        mockkObject(WidgetPrefs.Companion)
+        every { WidgetPrefs.getInstance(any()) } returns mock
+        return mock
+    }
+
+    private fun runWorker() = runBlocking {
+        TestListenableWorkerBuilder<ServerBlockingStatusWorker>(
+            ApplicationProvider.getApplicationContext<Context>(),
+        )
+            .setInputData(workDataOf(WidgetConstants.EXTRA_SERVER_ID to serverId))
+            .build()
+            .doWork()
+    }
+
+    @Test
+    fun noRequestWhenSidWasNeverPushed() {
+        every { prefs.hasUsableSession(serverId) } returns false
+
+        runWorker()
+
+        assertEquals(0, server.requestCount)
+    }
+
+    @Test
+    fun emptySidSendsRequestWithoutSidHeader() {
+        every { prefs.hasUsableSession(serverId) } returns true
+        every { prefs.getSid(serverId) } returns ""
+        server.enqueue(MockResponse().setResponseCode(200).setBody("""{"blocking":"enabled"}"""))
+
+        runWorker()
+
+        assertEquals(1, server.requestCount)
+        assertNull(server.takeRequest().getHeader("X-FTL-SID"))
+    }
+
+    @Test
+    fun realSidIsSentAsHeader() {
+        every { prefs.hasUsableSession(serverId) } returns true
+        every { prefs.getSid(serverId) } returns "abc123"
+        server.enqueue(MockResponse().setResponseCode(200).setBody("""{"blocking":"enabled"}"""))
+
+        runWorker()
+
+        assertEquals("abc123", server.takeRequest().getHeader("X-FTL-SID"))
+    }
+
+    @Test
+    fun noRequestWhenEmptySidIsMarkedInvalid() {
+        every { prefs.hasUsableSession(serverId) } returns false
+        every { prefs.getSid(serverId) } returns ""
+
+        runWorker()
+
+        assertEquals(0, server.requestCount)
+    }
+}

--- a/android/app/src/test/kotlin/io/github/tsutsu3/pi_hole_client/widget/worker/ServerPaddWorkerTest.kt
+++ b/android/app/src/test/kotlin/io/github/tsutsu3/pi_hole_client/widget/worker/ServerPaddWorkerTest.kt
@@ -1,0 +1,113 @@
+package io.github.tsutsu3.pi_hole_client.widget.worker
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import androidx.work.testing.TestListenableWorkerBuilder
+import androidx.work.workDataOf
+import io.github.tsutsu3.pi_hole_client.widget.WidgetConstants
+import io.github.tsutsu3.pi_hole_client.widget.data.WidgetPrefs
+import io.github.tsutsu3.pi_hole_client.widget.data.WidgetServer
+import io.mockk.every
+import io.mockk.mockkObject
+import io.mockk.unmockkAll
+import io.mockk.verify
+import kotlinx.coroutines.runBlocking
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class ServerPaddWorkerTest {
+
+    private lateinit var server: MockWebServer
+    private lateinit var prefs: WidgetPrefs
+    private lateinit var serverId: String
+
+    @Before
+    fun setUp() {
+        server = MockWebServer()
+        server.start()
+        serverId = server.url("/").toString().trimEnd('/')
+        prefs = mockWidgetPrefs(serverId)
+    }
+
+    @After
+    fun tearDown() {
+        server.shutdown()
+        unmockkAll()
+    }
+
+    private fun mockWidgetPrefs(id: String): WidgetPrefs {
+        val mock = io.mockk.mockk<WidgetPrefs>(relaxed = true)
+        every { mock.getServerInfo(id) } returns WidgetServer(
+            serverId = id,
+            alias = "test",
+            address = id,
+            apiVersion = "v6",
+            allowUntrustedCert = false,
+            ignoreCertificateErrors = false,
+            pinnedCertificateSha256 = null,
+        )
+        every { mock.getWidgetIdsForServer(any(), any()) } returns IntArray(0)
+        mockkObject(WidgetPrefs.Companion)
+        every { WidgetPrefs.getInstance(any()) } returns mock
+        return mock
+    }
+
+    private fun runWorker() = runBlocking {
+        TestListenableWorkerBuilder<ServerPaddWorker>(
+            ApplicationProvider.getApplicationContext<Context>(),
+        )
+            .setInputData(workDataOf(WidgetConstants.EXTRA_SERVER_ID to serverId))
+            .build()
+            .doWork()
+    }
+
+    @Test
+    fun noRequestWhenSidWasNeverPushed() {
+        every { prefs.hasUsableSession(serverId) } returns false
+
+        runWorker()
+
+        assertEquals(0, server.requestCount)
+    }
+
+    @Test
+    fun emptySidSendsRequestWithoutSidHeader() {
+        every { prefs.hasUsableSession(serverId) } returns true
+        every { prefs.getSid(serverId) } returns ""
+        server.enqueue(MockResponse().setResponseCode(200).setBody("{}"))
+
+        runWorker()
+
+        assertEquals(1, server.requestCount)
+        assertNull(server.takeRequest().getHeader("X-FTL-SID"))
+    }
+
+    @Test
+    fun realSidIsSentAsHeader() {
+        every { prefs.hasUsableSession(serverId) } returns true
+        every { prefs.getSid(serverId) } returns "abc123"
+        server.enqueue(MockResponse().setResponseCode(200).setBody("{}"))
+
+        runWorker()
+
+        assertEquals("abc123", server.takeRequest().getHeader("X-FTL-SID"))
+    }
+
+    @Test
+    fun noRequestWhenEmptySidIsMarkedInvalid() {
+        every { prefs.hasUsableSession(serverId) } returns false
+        every { prefs.getSid(serverId) } returns ""
+
+        runWorker()
+
+        assertEquals(0, server.requestCount)
+    }
+}

--- a/android/app/src/test/kotlin/io/github/tsutsu3/pi_hole_client/widget/worker/ServerToggleWorkerTest.kt
+++ b/android/app/src/test/kotlin/io/github/tsutsu3/pi_hole_client/widget/worker/ServerToggleWorkerTest.kt
@@ -1,0 +1,123 @@
+package io.github.tsutsu3.pi_hole_client.widget.worker
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import androidx.work.testing.TestListenableWorkerBuilder
+import androidx.work.workDataOf
+import io.github.tsutsu3.pi_hole_client.widget.WidgetConstants
+import io.github.tsutsu3.pi_hole_client.widget.WidgetUpdateHelper
+import io.github.tsutsu3.pi_hole_client.widget.data.WidgetPrefs
+import io.github.tsutsu3.pi_hole_client.widget.data.WidgetServer
+import io.mockk.every
+import io.mockk.mockkObject
+import io.mockk.unmockkAll
+import io.mockk.verify
+import kotlinx.coroutines.runBlocking
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class ServerToggleWorkerTest {
+
+    private lateinit var server: MockWebServer
+    private lateinit var prefs: WidgetPrefs
+    private lateinit var serverId: String
+
+    @Before
+    fun setUp() {
+        server = MockWebServer()
+        server.start()
+        serverId = server.url("/").toString().trimEnd('/')
+
+        val mock = io.mockk.mockk<WidgetPrefs>(relaxed = true)
+        every { mock.getServerInfo(serverId) } returns WidgetServer(
+            serverId = serverId,
+            alias = "test",
+            address = serverId,
+            apiVersion = "v6",
+            allowUntrustedCert = false,
+            ignoreCertificateErrors = false,
+            pinnedCertificateSha256 = null,
+        )
+        every { mock.getWidgetIdsForServer(any(), any()) } returns IntArray(0)
+        mockkObject(WidgetPrefs.Companion)
+        every { WidgetPrefs.getInstance(any()) } returns mock
+        prefs = mock
+
+        // The follow-up PADD refresh needs a real WorkManager; not under test.
+        mockkObject(WidgetUpdateHelper)
+        every { WidgetUpdateHelper.enqueueServerPadd(any(), any(), any()) } returns Unit
+    }
+
+    @After
+    fun tearDown() {
+        server.shutdown()
+        unmockkAll()
+    }
+
+    private fun runWorker() = runBlocking {
+        TestListenableWorkerBuilder<ServerToggleWorker>(
+            ApplicationProvider.getApplicationContext<Context>(),
+        )
+            .setInputData(workDataOf(WidgetConstants.EXTRA_SERVER_ID to serverId))
+            .build()
+            .doWork()
+    }
+
+    @Test
+    fun noRequestWhenSidWasNeverPushed() {
+        every { prefs.hasUsableSession(serverId) } returns false
+
+        runWorker()
+
+        assertEquals(0, server.requestCount)
+    }
+
+    @Test
+    fun emptySidSendsBothRequestsWithoutSidHeader() {
+        every { prefs.hasUsableSession(serverId) } returns true
+        every { prefs.getSid(serverId) } returns ""
+        server.enqueue(MockResponse().setResponseCode(200).setBody("""{"blocking":"enabled"}"""))
+        server.enqueue(MockResponse().setResponseCode(200).setBody("{}"))
+
+        runWorker()
+
+        assertEquals(2, server.requestCount)
+        val get = server.takeRequest()
+        assertEquals("GET", get.method)
+        assertNull(get.getHeader("X-FTL-SID"))
+        val post = server.takeRequest()
+        assertEquals("POST", post.method)
+        assertNull(post.getHeader("X-FTL-SID"))
+    }
+
+    @Test
+    fun authFailureOnTheStatusGetInvalidatesTheSession() {
+        every { prefs.hasUsableSession(serverId) } returns true
+        every { prefs.getSid(serverId) } returns ""
+        server.enqueue(MockResponse().setResponseCode(401))
+
+        runWorker()
+
+        verify { prefs.setSidValid(serverId, false) }
+    }
+
+    @Test
+    fun authFailureOnTheTogglePostInvalidatesTheSession() {
+        every { prefs.hasUsableSession(serverId) } returns true
+        every { prefs.getSid(serverId) } returns ""
+        server.enqueue(MockResponse().setResponseCode(200).setBody("""{"blocking":"enabled"}"""))
+        server.enqueue(MockResponse().setResponseCode(401))
+
+        runWorker()
+
+        verify { prefs.setSidValid(serverId, false) }
+    }
+}

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -145,6 +145,9 @@ re-authenticates and notifies Android to refresh the widget.
 
 - SID is stored in Android SharedPreferences as `sid_<serverId>` with
   `sid_valid_<serverId> = true/false`.
+- An empty `sid_<serverId>` is a real value: the server has no password, so
+  requests go out with no `X-FTL-SID` header. Only a missing key means
+  "never authenticated".
 - The widget treats HTTP 401/403 or "unauthorized/forbidden" responses as SID
   invalid.
 - The widget never calls the auth API. This prevents credential exposure and

--- a/lib/data/repositories/api/v6/auth_repository.dart
+++ b/lib/data/repositories/api/v6/auth_repository.dart
@@ -31,12 +31,10 @@ class AuthRepositoryV6 extends BaseV6SidRepository implements AuthRepository {
         // password-less v6 server answers 200 with `sid: null`.
         if (value != null && value.valid) {
           await saveSid(value.sid);
-          if (value.sid.isNotEmpty) {
-            await WidgetChannel.sendSidUpdated(
-              serverAddress: serverAddress,
-              sid: value.sid,
-            );
-          }
+          await WidgetChannel.sendSidUpdated(
+            serverAddress: serverAddress,
+            sid: value.sid,
+          );
         }
         return auth;
       },

--- a/lib/data/repositories/api/v6/v6_session_cache.dart
+++ b/lib/data/repositories/api/v6/v6_session_cache.dart
@@ -57,16 +57,19 @@ class V6SessionCache {
     }
     return _getOrLoad(() async {
       final r = await _creds.sid;
+      final String sid;
       if (r.isError()) {
         // No SID + empty password = no-auth server: use an empty SID. A failed
         // password read is a real storage error, so still throw in that case.
         final pwResult = await _creds.password;
         if (pwResult.isSuccess() && (pwResult.getOrNull() ?? '').isEmpty) {
-          return '';
+          sid = '';
+        } else {
+          throw SidNotFoundException();
         }
-        throw SidNotFoundException();
+      } else {
+        sid = r.getOrThrow();
       }
-      final sid = r.getOrThrow();
       await WidgetChannel.sendSidUpdated(
         serverAddress: serverAddress,
         sid: sid,

--- a/lib/utils/widget_channel.dart
+++ b/lib/utils/widget_channel.dart
@@ -1,5 +1,6 @@
 import 'dart:io';
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 import 'package:pi_hole_client/domain/model/server/server.dart';
 import 'package:pi_hole_client/utils/logger.dart';
@@ -7,7 +8,11 @@ import 'package:pi_hole_client/utils/logger.dart';
 class WidgetChannel {
   static const MethodChannel _channel = MethodChannel('pihole/widget');
 
-  static bool _isSupported() => Platform.isAndroid;
+  /// Test-only switch for [_isSupported]. Never set outside tests.
+  @visibleForTesting
+  static bool? debugIsSupportedOverride;
+
+  static bool _isSupported() => debugIsSupportedOverride ?? Platform.isAndroid;
 
   static Future<void> sendSidUpdated({
     required String serverAddress,

--- a/test/data/repositories/api/v6/auth_repository_test.dart
+++ b/test/data/repositories/api/v6/auth_repository_test.dart
@@ -5,6 +5,7 @@ import 'package:pi_hole_client/utils/exceptions.dart';
 
 import '../../../../../testing/fakes/services/fake_pihole_v6_api_client.dart';
 import '../../../../../testing/fakes/services/fake_session_credential_service.dart';
+import '../../../../../testing/fakes/services/fake_widget_channel.dart';
 import '../../../../../testing/helper/test_helper.dart';
 import '../../../../../testing/models/v6/auth.dart';
 
@@ -12,8 +13,10 @@ void main() {
   late AuthRepositoryV6 repository;
   late FakePiholeV6ApiClient client;
   late FakeSessionCredentialService creds;
+  late FakeWidgetChannel widgetChannel;
 
   setUp(() {
+    widgetChannel = FakeWidgetChannel()..init();
     client = FakePiholeV6ApiClient();
     creds = FakeSessionCredentialService();
     repository = AuthRepositoryV6(
@@ -22,7 +25,46 @@ void main() {
     );
   });
 
+  tearDown(() => widgetChannel.dispose());
+
   group('createSession', () {
+    test(
+      'notifies the widget with an empty sid for a password-less server',
+      () async {
+        client.shouldReturnNoPasswordSession = true;
+
+        final result = await repository.createSession('');
+
+        expect(result.isSuccess(), isTrue);
+        expect(widgetChannel.sidUpdates, ['']);
+      },
+    );
+
+    test('notifies the widget with the real sid for a normal login', () async {
+      final result = await repository.createSession('password123');
+
+      expect(result.isSuccess(), isTrue);
+      expect(widgetChannel.sidUpdates, [kRepoCreateSession.sid]);
+    });
+
+    test('does not notify the widget when the API fails', () async {
+      client.shouldFail = true;
+
+      final result = await repository.createSession('password123');
+
+      expect(result.isSuccess(), isFalse);
+      expect(widgetChannel.sidUpdates, isEmpty);
+    });
+
+    test('a failed widget notification does not fail the login', () async {
+      widgetChannel.shouldThrow = true;
+
+      final result = await repository.createSession('password123');
+
+      expect(result.isSuccess(), isTrue);
+      expect(widgetChannel.sidUpdates, [kRepoCreateSession.sid]);
+    });
+
     test('should create a session successfully', () async {
       final result = await repository.createSession('password123');
       expect(result.getOrNull(), kRepoCreateSession);

--- a/test/data/repositories/api/v6/v6_session_cache_test.dart
+++ b/test/data/repositories/api/v6/v6_session_cache_test.dart
@@ -6,17 +6,22 @@ import 'package:pi_hole_client/utils/exceptions.dart';
 
 import '../../../../../testing/fakes/services/fake_pihole_v6_api_client.dart';
 import '../../../../../testing/fakes/services/fake_session_credential_service.dart';
+import '../../../../../testing/fakes/services/fake_widget_channel.dart';
 
 void main() {
   late V6SessionCache cache;
   late FakeSessionCredentialService creds;
   late FakePiholeV6ApiClient client;
+  late FakeWidgetChannel widgetChannel;
 
   setUp(() {
+    widgetChannel = FakeWidgetChannel()..init();
     creds = FakeSessionCredentialService();
     client = FakePiholeV6ApiClient();
     cache = V6SessionCache(creds: creds, client: client);
   });
+
+  tearDown(() => widgetChannel.dispose());
 
   // ---------------------------------------------------------------------------
   // getSid
@@ -73,6 +78,7 @@ void main() {
           ..addressPassword = '';
         final sid = await cache.getSid();
         expect(sid, '');
+        expect(widgetChannel.sidUpdates, ['']);
       },
     );
 
@@ -91,6 +97,33 @@ void main() {
         ..addressPassword = 'typed-by-mistake';
       final sid = await cache.getSid();
       expect(sid, '');
+    });
+
+    test('notifies the widget with the stored sid', () async {
+      final sid = await cache.getSid();
+
+      expect(sid, 'sid123');
+      expect(widgetChannel.sidUpdates, ['sid123']);
+    });
+
+    test(
+      'does not notify the widget when the SID read is a real error',
+      () async {
+        creds
+          ..shouldFailSidRead = true
+          ..addressPassword = 'secret';
+
+        await expectLater(cache.getSid(), throwsA(isA<SidNotFoundException>()));
+        expect(widgetChannel.sidUpdates, isEmpty);
+      },
+    );
+
+    test('a cached read does not notify the widget twice', () async {
+      await cache.getSid();
+      final sid = await cache.getSid();
+
+      expect(sid, 'sid123');
+      expect(widgetChannel.sidUpdates, ['sid123']);
     });
   });
 

--- a/testing/fakes/services/fake_widget_channel.dart
+++ b/testing/fakes/services/fake_widget_channel.dart
@@ -1,0 +1,45 @@
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pi_hole_client/utils/widget_channel.dart';
+
+/// Captures the calls `WidgetChannel` makes on the `pihole/widget` channel.
+///
+/// `WidgetChannel` only sends on Android, so [init] also flips its
+/// test-only support switch. Call [dispose] in `tearDown`.
+class FakeWidgetChannel {
+  static const _channel = MethodChannel('pihole/widget');
+
+  final List<MethodCall> _calls = <MethodCall>[];
+
+  /// When true every call fails, so callers can test the error path.
+  bool shouldThrow = false;
+
+  /// The sid of every `sidUpdated` push, in order. Assert on this so every
+  /// test checks the pushes the same way.
+  List<String> get sidUpdates => _calls
+      .where((c) => c.method == 'sidUpdated')
+      .map((c) => (c.arguments as Map)['sid'] as String)
+      .toList();
+
+  void init() {
+    TestWidgetsFlutterBinding.ensureInitialized();
+    WidgetChannel.debugIsSupportedOverride = true;
+
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(_channel, (call) async {
+          _calls.add(call);
+          if (shouldThrow) {
+            throw PlatformException(code: 'fake_error');
+          }
+          return null;
+        });
+  }
+
+  void dispose() {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(_channel, null);
+    WidgetChannel.debugIsSupportedOverride = null;
+    _calls.clear();
+    shouldThrow = false;
+  }
+}


### PR DESCRIPTION
## Overview

Fixed widgets so they work correctly with passwordless Pi-hole v6 servers.

## Changes

- Treat an empty SID as a valid passwordless session.
- Use the new session check in all three widget workers.
- Notify widgets after successful v6 sessions, including passwordless sessions.
- Reject missing SID values instead of treating them as empty.
- Add Kotlin and Dart tests for the updated behavior.

## Summary by Sourcery

Enable Android widgets to display and control data for passwordless Pi-hole v6 servers while preserving correct handling of missing or invalid sessions.

Bug Fixes:
- Support widget data retrieval and controls for passwordless Pi-hole v6 servers by recognizing an empty SID as a valid session.
- Reject missing SID values in widget updates instead of silently storing them as empty sessions.

Enhancements:
- Centralize widget session validity checks so empty, valid SIDs are distinguished from missing or invalid sessions.
- Notify Android widgets after all successful Pi-hole v6 sessions, including passwordless sessions.

Documentation:
- Document empty SIDs as valid passwordless sessions and missing SIDs as unauthenticated state.

Tests:
- Add Kotlin and Dart coverage for passwordless sessions, SID validity, widget requests, authentication failures, and widget notification behavior.