### PR TITLE
fix(tests): add error handling for HTTPS on a plain HTTP port

### DIFF
--- a/docs/server-connection-flow.md
+++ b/docs/server-connection-flow.md
@@ -289,7 +289,10 @@ sequenceDiagram
   is attempted.
 - The view model never shows UI itself. The certificate pin dialog and SSL-error
   snackbar live in the widget and are reached via the `resolveCertificate`
-  callback passed in the request.
+  callback passed in the request. Every path that blocks on a certificate must
+  show its own message there, including the one where the fingerprint cannot be
+  fetched at all (e.g. HTTPS picked for a plain HTTP port) - otherwise the
+  `Cancelled` outcome maps to a silent no-op and the user sees nothing.
 - **TOTP (2FA) is v6-only and handled inside login** (`_loginWithTotp`, shared by
   `createServer` and `_authenticate`). The view model never shows the prompt; it
   calls the injected `resolveTotp` callback, which the widget backs with the TOTP

--- a/integration_test/real/add_real_test.dart
+++ b/integration_test/real/add_real_test.dart
@@ -229,6 +229,36 @@ void main() {
     });
   });
 
+  group('add (v6, HTTPS against a plain HTTP port)', () {
+    testWidgets(
+      '(C24) selecting HTTPS for a plain HTTP port shows an error instead of failing silently',
+      (tester) async {
+        final app = AppHarness(tester);
+        await app.boot();
+
+        final uri = Uri.parse(RealPiholeEnv.v6Base);
+
+        await app.openAddServer();
+        await app.addV6ServerHttpsViaUi(
+          host: uri.host,
+          port: uri.hasPort ? '${uri.port}' : '',
+          password: RealPiholeEnv.v6Password,
+          alias: 'https-on-http-port',
+        );
+
+        expect(
+          find.text(app.l10n.serverCertificateHandshakeFailed),
+          findsOneWidget,
+          reason:
+              'a blocked certificate must explain itself; returning to an '
+              'idle form with no message at all is the #670 bug',
+        );
+        expect(app.servers.getServersList, isEmpty);
+        expect(find.byType(AddServerFullscreen), findsOneWidget);
+      },
+    );
+  });
+
   group('add (v5, HTTP)', () {
     testWidgets('(C3) add + connect a real v5 server saves it to the list', (
       tester,

--- a/lib/ui/core/l10n/app_de.arb
+++ b/lib/ui/core/l10n/app_de.arb
@@ -728,6 +728,7 @@
   "serverCertificateUpdatePinTitle": "Angepinnter Fingerabdruck aktualisieren",
   "serverCertificateUpdatePinHelp": "Dies ersetzt den angepinnten SHA-256-Fingerabdruck, der bei unzuverlässigen Zertifikaten verwendet wird. Nur fortfahren, wenn das Zertifikat anderweitig geprüft wurde.",
   "serverCertificateFetchFailed": "Zertifikatsinformationen konnten nicht abgerufen werden.",
+  "serverCertificateHandshakeFailed": "Sichere Verbindung konnte nicht hergestellt werden. Prüfen Sie, ob der Server auf diesem Port HTTPS verwendet.",
   "unverifiedCertificatesBannerTitle": "{count, plural, =1{1 Server erlaubt nicht verifizierte Zertifikate} other{{count} Server erlauben nicht verifizierte Zertifikate}}",
   "@unverifiedCertificatesBannerTitle": {
     "placeholders": {

--- a/lib/ui/core/l10n/app_en.arb
+++ b/lib/ui/core/l10n/app_en.arb
@@ -733,6 +733,7 @@
   "serverCertificateUpdatePinTitle": "Update pinned fingerprint",
   "serverCertificateUpdatePinHelp": "This will replace the pinned SHA-256 fingerprint used when allowing untrusted certificates. Only proceed if you verified the certificate out of band.",
   "serverCertificateFetchFailed": "Could not fetch certificate information.",
+  "serverCertificateHandshakeFailed": "Couldn't establish a secure connection. Check that the server uses HTTPS on this port.",
   "unverifiedCertificatesBannerTitle": "{count, plural, =1{1 server has unverified certificates allowed} other{{count} servers have unverified certificates allowed}}",
   "@unverifiedCertificatesBannerTitle": {
     "placeholders": {

--- a/lib/ui/core/l10n/app_es.arb
+++ b/lib/ui/core/l10n/app_es.arb
@@ -729,6 +729,7 @@
   "serverCertificateUpdatePinTitle": "Actualizar huella fijada",
   "serverCertificateUpdatePinHelp": "Esto reemplazará la huella SHA-256 fijada usada al permitir certificados no confiables. Continúa solo si verificaste el certificado por otro medio.",
   "serverCertificateFetchFailed": "No se pudo obtener la información del certificado.",
+  "serverCertificateHandshakeFailed": "No se pudo establecer una conexión segura. Comprueba que el servidor use HTTPS en este puerto.",
   "unverifiedCertificatesBannerTitle": "{count, plural, =1{1 servidor permite certificados no verificados} other{{count} servidores permiten certificados no verificados}}",
   "@unverifiedCertificatesBannerTitle": {
     "placeholders": {

--- a/lib/ui/core/l10n/app_ja.arb
+++ b/lib/ui/core/l10n/app_ja.arb
@@ -735,6 +735,7 @@
   "serverCertificateUpdatePinTitle": "ピン留めを更新",
   "serverCertificateUpdatePinHelp": "未検証の証明書を許可する際に使う SHA-256 のピン留めを更新します。証明書を別手段で確認した場合のみ続行してください。",
   "serverCertificateFetchFailed": "証明書情報を取得できませんでした。",
+  "serverCertificateHandshakeFailed": "セキュア接続を確立できませんでした。このポートでHTTPSが有効か確認してください。",
   "unverifiedCertificatesBannerTitle": "{count, plural, =1{未検証の証明書が許可されているサーバーが1件あります} other{未検証の証明書が許可されているサーバーが{count}件あります}}",
   "@unverifiedCertificatesBannerTitle": {
     "placeholders": {

--- a/lib/ui/core/l10n/app_pl.arb
+++ b/lib/ui/core/l10n/app_pl.arb
@@ -728,6 +728,7 @@
   "serverCertificateUpdatePinTitle": "Zaktualizuj przypięty odcisk",
   "serverCertificateUpdatePinHelp": "Spowoduje to zastąpienie przypiętego odcisku SHA-256 używanego przy zezwalaniu na niezaufane certyfikaty. Kontynuuj tylko, jeśli zweryfikowałeś certyfikat inną metodą.",
   "serverCertificateFetchFailed": "Nie udało się pobrać informacji o certyfikacie.",
+  "serverCertificateHandshakeFailed": "Nie udało się nawiązać bezpiecznego połączenia. Sprawdź, czy serwer używa HTTPS na tym porcie.",
   "unverifiedCertificatesBannerTitle": "{count, plural, =1{1 serwer dopuszcza niezweryfikowane certyfikaty} other{{count} serwery dopuszczają niezweryfikowane certyfikaty}}",
   "@unverifiedCertificatesBannerTitle": {
     "placeholders": {

--- a/lib/ui/core/l10n/generated/app_localizations.dart
+++ b/lib/ui/core/l10n/generated/app_localizations.dart
@@ -4442,6 +4442,12 @@ abstract class AppLocalizations {
   /// **'Could not fetch certificate information.'**
   String get serverCertificateFetchFailed;
 
+  /// No description provided for @serverCertificateHandshakeFailed.
+  ///
+  /// In en, this message translates to:
+  /// **'Couldn\'t establish a secure connection. Check that the server uses HTTPS on this port.'**
+  String get serverCertificateHandshakeFailed;
+
   /// No description provided for @unverifiedCertificatesBannerTitle.
   ///
   /// In en, this message translates to:

--- a/lib/ui/core/l10n/generated/app_localizations_de.dart
+++ b/lib/ui/core/l10n/generated/app_localizations_de.dart
@@ -2324,6 +2324,10 @@ class AppLocalizationsDe extends AppLocalizations {
       'Zertifikatsinformationen konnten nicht abgerufen werden.';
 
   @override
+  String get serverCertificateHandshakeFailed =>
+      'Sichere Verbindung konnte nicht hergestellt werden. Prüfen Sie, ob der Server auf diesem Port HTTPS verwendet.';
+
+  @override
   String unverifiedCertificatesBannerTitle(num count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,

--- a/lib/ui/core/l10n/generated/app_localizations_en.dart
+++ b/lib/ui/core/l10n/generated/app_localizations_en.dart
@@ -2287,6 +2287,10 @@ class AppLocalizationsEn extends AppLocalizations {
       'Could not fetch certificate information.';
 
   @override
+  String get serverCertificateHandshakeFailed =>
+      'Couldn\'t establish a secure connection. Check that the server uses HTTPS on this port.';
+
+  @override
   String unverifiedCertificatesBannerTitle(num count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,

--- a/lib/ui/core/l10n/generated/app_localizations_es.dart
+++ b/lib/ui/core/l10n/generated/app_localizations_es.dart
@@ -2319,6 +2319,10 @@ class AppLocalizationsEs extends AppLocalizations {
       'No se pudo obtener la información del certificado.';
 
   @override
+  String get serverCertificateHandshakeFailed =>
+      'No se pudo establecer una conexión segura. Comprueba que el servidor use HTTPS en este puerto.';
+
+  @override
   String unverifiedCertificatesBannerTitle(num count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,

--- a/lib/ui/core/l10n/generated/app_localizations_ja.dart
+++ b/lib/ui/core/l10n/generated/app_localizations_ja.dart
@@ -2224,6 +2224,10 @@ class AppLocalizationsJa extends AppLocalizations {
   String get serverCertificateFetchFailed => '証明書情報を取得できませんでした。';
 
   @override
+  String get serverCertificateHandshakeFailed =>
+      'セキュア接続を確立できませんでした。このポートでHTTPSが有効か確認してください。';
+
+  @override
   String unverifiedCertificatesBannerTitle(num count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,

--- a/lib/ui/core/l10n/generated/app_localizations_pl.dart
+++ b/lib/ui/core/l10n/generated/app_localizations_pl.dart
@@ -2304,6 +2304,10 @@ class AppLocalizationsPl extends AppLocalizations {
       'Nie udało się pobrać informacji o certyfikacie.';
 
   @override
+  String get serverCertificateHandshakeFailed =>
+      'Nie udało się nawiązać bezpiecznego połączenia. Sprawdź, czy serwer używa HTTPS na tym porcie.';
+
+  @override
   String unverifiedCertificatesBannerTitle(num count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,

--- a/lib/ui/servers/widgets/add_server_fullscreen.dart
+++ b/lib/ui/servers/widgets/add_server_fullscreen.dart
@@ -397,6 +397,7 @@ class _AddServerFullscreenState extends State<AddServerFullscreen> {
 
   Future<String?> ensurePinnedFingerprint({
     required BuildContext context,
+    required AppConfigViewModel appConfigViewModel,
     required Uri uri,
     required String? existingPin,
   }) async {
@@ -428,12 +429,22 @@ class _AddServerFullscreenState extends State<AddServerFullscreen> {
         allowBadCertificates: true,
       );
     } catch (_) {
-      // If we cannot obtain the fingerprint, block the connection.
-      // This typically happens with reverse proxies where certificate
-      // pinning cannot work reliably.
+      certificateInfo = null;
+    }
+    if (!context.mounted) {
       return null;
     }
-    if (!context.mounted || certificateInfo == null) {
+    if (certificateInfo == null) {
+      // Bad certificates are accepted here, so a failure means the port is not
+      // speaking TLS at all (e.g. HTTPS picked for a plain HTTP port), or a
+      // reverse proxy blocks the socket and pinning cannot work reliably.
+      // Either way the connection is blocked, so say why instead of returning
+      // to an idle form with no message.
+      showErrorSnackBar(
+        context: context,
+        appConfigViewModel: appConfigViewModel,
+        label: AppLocalizations.of(context)!.serverCertificateHandshakeFailed,
+      );
       return null;
     }
 
@@ -489,6 +500,7 @@ class _AddServerFullscreenState extends State<AddServerFullscreen> {
       if (!mounted) return null;
       final pin = await ensurePinnedFingerprint(
         context: context,
+        appConfigViewModel: appConfigViewModel,
         uri: uri,
         existingPin: serverObj.pinnedCertificateSha256,
       );

--- a/test/ui/servers/add_server_fullscreen_test.dart
+++ b/test/ui/servers/add_server_fullscreen_test.dart
@@ -72,6 +72,10 @@ const _serverHttpsNoPin = Server(
   ignoreCertificateErrors: false,
 );
 
+const _handshakeFailedMessage =
+    "Couldn't establish a secure connection. "
+    'Check that the server uses HTTPS on this port.';
+
 TlsCertificateInfo _certInfo({String sha256 = 'new:fingerprint'}) {
   return TlsCertificateInfo(
     sha256: sha256,
@@ -84,11 +88,17 @@ TlsCertificateInfo _certInfo({String sha256 = 'new:fingerprint'}) {
 
 /// A recording [TlsCertificateFetcher] for the certificate-flow tests.
 class _FakeFetcher {
-  _FakeFetcher({this.onStrict, this.strictError, this.onAllowBad});
+  _FakeFetcher({
+    this.onStrict,
+    this.strictError,
+    this.onAllowBad,
+    this.allowBadError,
+  });
 
   final TlsCertificateInfo? onStrict;
   final Exception? strictError;
   final TlsCertificateInfo? onAllowBad;
+  final Exception? allowBadError;
   int callCount = 0;
 
   Future<TlsCertificateInfo?> call(
@@ -101,6 +111,7 @@ class _FakeFetcher {
       if (strictError != null) throw strictError!;
       return onStrict;
     }
+    if (allowBadError != null) throw allowBadError!;
     return onAllowBad;
   }
 }
@@ -1189,6 +1200,7 @@ void main() async {
       expect(serversViewModel.replaceServerCallCount, 0);
       expect(serversViewModel.editServerCallCount, 0);
       expect(find.text('Server settings updated successfully.'), findsNothing);
+      expect(find.byType(SnackBar), findsNothing);
       // No secret may be persisted for the new address: cancelling the
       // certificate dialog must not leave orphaned credentials behind.
       expect(serversViewModel.savePasswordCallCount, 0);
@@ -1242,6 +1254,7 @@ void main() async {
         expect(serversViewModel.editServerCallCount, 0);
         expect(serversViewModel.savePasswordCallCount, 0);
         expect(serversViewModel.saveTokenCallCount, 0);
+        expect(find.byType(SnackBar), findsNothing);
       },
     );
 
@@ -1282,6 +1295,79 @@ void main() async {
           serversViewModel.lastReplacedNewServer?.pinnedCertificateSha256,
           isNull,
         );
+      },
+    );
+
+    testWidgets(
+      'HTTPS against a plain HTTP port shows an error and does not save',
+      (WidgetTester tester) async {
+        useLargeView(tester);
+
+        // Both probes fail.
+        final fetcher = _FakeFetcher(
+          strictError: const HandshakeException(),
+          allowBadError: const HandshakeException(),
+        );
+
+        await tester.pumpWidget(
+          buildWidget(
+            AddServerFullscreen(
+              window: false,
+              title: 'test',
+              fetchTlsCertificate: fetcher.call,
+            ),
+          ),
+        );
+
+        await tester.tap(find.text('HTTPS'));
+        await tester.pump();
+
+        await tester.enterText(find.byType(TextField).at(0), 'v6'); // Alias
+        await tester.enterText(find.byType(TextField).at(1), 'localhost');
+        await tester.enterText(find.byType(TextField).at(2), '8080');
+        await tester.tap(find.byIcon(Icons.login_rounded));
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 1000));
+
+        expect(fetcher.callCount, 2);
+        expect(find.byType(CertificateDetailsDialog), findsNothing);
+        expect(find.text(_handshakeFailedMessage), findsOneWidget);
+        expect(serversViewModel.addServerCallCount, 0);
+        expect(serversViewModel.savePasswordCallCount, 0);
+      },
+    );
+
+    testWidgets(
+      'HTTPS address change to a plain HTTP port shows an error and does not replace',
+      (WidgetTester tester) async {
+        useLargeView(tester);
+
+        final fetcher = _FakeFetcher(
+          strictError: const HandshakeException(),
+          allowBadError: const HandshakeException(),
+        );
+
+        await tester.pumpWidget(
+          buildWidget(
+            AddServerFullscreen(
+              window: false,
+              title: 'test',
+              server: _serverHttpsPinned,
+              fetchTlsCertificate: fetcher.call,
+            ),
+          ),
+        );
+
+        await tester.enterText(find.byType(TextField).at(1), 'pi.hole.new');
+        await tester.tap(find.byIcon(Icons.save_rounded));
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 1000));
+
+        expect(find.byType(CertificateDetailsDialog), findsNothing);
+        expect(find.text(_handshakeFailedMessage), findsOneWidget);
+        expect(serversViewModel.replaceServerCallCount, 0);
+        expect(serversViewModel.editServerCallCount, 0);
+        expect(serversViewModel.savePasswordCallCount, 0);
       },
     );
 


### PR DESCRIPTION
|https connect with http port|http connect with https port|
|---|---|
| <img width="672" height="1496" alt="Screenshot_1788081903" src="https://github.com/user-attachments/assets/2ea24120-a675-405d-9df2-3777252d23de" />|<img width="672" height="1496" alt="Screenshot_1788081917" src="https://github.com/user-attachments/assets/fc2c5e5b-ba32-4fa6-9b33-da706dbf18ae" />|



## Summary by Sourcery

Report secure connection handshake failures to users and prevent unsuccessful HTTPS server operations from completing.

Bug Fixes:
- Show a localized error when HTTPS certificate negotiation fails, including when HTTPS is selected for a plain HTTP port, instead of silently returning to the form.
- Prevent server creation or replacement when the secure connection handshake cannot be established.

Documentation:
- Document that every certificate-blocking path must provide user feedback, including failures to retrieve the certificate fingerprint.

Tests:
- Add unit and integration coverage for HTTPS connections to plain HTTP ports during server creation and address changes, including assertions that no server data is saved.