### PR TITLE
fix(server): preserve explicit default ports in endpoint comparison

### DIFF
--- a/lib/ui/servers/widgets/add_server_fullscreen.dart
+++ b/lib/ui/servers/widgets/add_server_fullscreen.dart
@@ -87,14 +87,21 @@ class _AddServerFullscreenState extends State<AddServerFullscreen> {
   void initState() {
     super.initState();
     if (widget.server != null) {
-      // Parse the stored URL with Uri so multi-segment subroutes (e.g.
-      // `/api/v1`) survive and the host/port are extracted reliably instead of
-      // via fragile manual `split` calls.
-      final uri = Uri.parse(widget.server!.address);
+      final address = widget.server!.address;
+      final uri = Uri.parse(address);
+      final splitted = address.split(':');
+
+      // Use Uri for the host and path so multi-segment subroutes such as
+      // `/api/v1` are handled correctly.
       addressFieldController.text = uri.host;
-      portFieldController.text = uri.hasPort ? '${uri.port}' : '';
-      // A bare '/' carries no routing info and trips the subroute validator, so
-      // normalise it to empty; otherwise keep the full path.
+
+      // Uri normalizes explicit default ports such as :80 and :443, so preserve
+      // the port from the original URL instead.
+      portFieldController.text = splitted.length > 2
+          ? splitted[2].split('/')[0]
+          : '';
+
+      // A bare '/' carries no routing information, so normalize it to empty.
       subrouteFieldController.text = uri.path == '/' ? '' : uri.path;
       aliasFieldController.text = widget.server!.alias;
       connectionType = uri.scheme == 'https'

--- a/lib/utils/url.dart
+++ b/lib/utils/url.dart
@@ -9,24 +9,30 @@ String buildServerUrl({
   return '$scheme://$host$portSegment$subroute';
 }
 
-/// Compares two server URLs ignoring scheme/host case, a trailing slash and a
-/// scheme's default port.
+/// Compares two server URLs ignoring scheme/host case and a trailing slash.
 ///
 /// Re-deriving the URL from the form fields lower-cases the host (via
-/// [Uri.parse]), so a plain string compare against the stored address would
+/// [Uri.parse]), so a plain string comparison against the stored address would
 /// report a false "address changed" for an alias-only edit and wrongly take the
-/// destructive replace path. This normalises both sides.
+/// destructive replace path.
+///
+/// Explicit ports are preserved, including scheme defaults such as :80 and
+/// :443.
 bool isSameEndpoint(String a, String b) {
   String normalize(String url) {
     final uri = Uri.parse(url);
+    final splitted = url.split(':');
+
     var path = uri.path == '/' ? '' : uri.path;
     if (path.endsWith('/')) {
       path = path.substring(0, path.length - 1);
     }
-    // [Uri.port] resolves the scheme's default (80/443), so an explicit default
-    // port and an omitted one normalise to the same endpoint.
-    // (e.g. https://pi.hole == https://pi.hole:443).
-    final port = uri.port != 0 ? ':${uri.port}' : '';
+
+    // Uri normalizes explicit default ports such as :80 and :443, so preserve
+    // the port from the original URL instead.
+    // e.g.) http://localhost != http://localhost:80
+    final port = splitted.length > 2 ? ':${splitted[2].split('/')[0]}' : '';
+
     return '${uri.scheme.toLowerCase()}://${uri.host.toLowerCase()}$port$path';
   }
 

--- a/test/utils/url_test.dart
+++ b/test/utils/url_test.dart
@@ -91,18 +91,27 @@ void main() {
       );
     });
 
-    test('treats the default https port as equal to an omitted port', () {
-      expect(isSameEndpoint('https://pi.hole', 'https://pi.hole:443'), isTrue);
-    });
+    test(
+      'distinguishes an explicit default https port from an omitted port',
+      () {
+        expect(
+          isSameEndpoint('https://pi.hole', 'https://pi.hole:443'),
+          isFalse,
+        );
+      },
+    );
 
-    test('treats the default http port as equal to an omitted port', () {
-      expect(isSameEndpoint('http://pi.hole', 'http://pi.hole:80'), isTrue);
-    });
+    test(
+      'distinguishes an explicit default http port from an omitted port',
+      () {
+        expect(isSameEndpoint('http://pi.hole', 'http://pi.hole:80'), isFalse);
+      },
+    );
 
-    test('normalises the default port alongside a subroute', () {
+    test('distinguishes an explicit default port on the same subroute', () {
       expect(
         isSameEndpoint('https://pi.hole/admin', 'https://pi.hole:443/admin'),
-        isTrue,
+        isFalse,
       );
     });
 


### PR DESCRIPTION
## Overview

This fixes an unintended behavior change on `main` for the upcoming v1.10.0 release.

In v1.9.x, server URLs with and without an explicitly specified default port were treated as different endpoints, for example:

- `http://localhost` != `http://localhost:80`
- `https://pi.hole` !=  `https://pi.hole:443`

A change on `main` unintentionally made these URLs compare as the same endpoint.

This PR restores the v1.9.x behavior by preserving explicitly specified ports when comparing server endpoints.

Note: IPv6 addresses are not supported by this comparison logic.

## Summary by Sourcery

Preserve explicitly specified server ports when comparing and editing endpoint URLs.

Bug Fixes:
- Restore endpoint comparison behavior so explicitly specified ports remain distinct from omitted default ports.
- Preserve explicitly specified ports when loading existing server addresses in the server form.

Tests:
- Update URL comparison tests to verify explicit default HTTP and HTTPS ports are distinguished, including on subroutes.