### PR TITLE
fix(widget): prevent R8 from breaking widget actions

### DIFF
--- a/android/app/proguard-rules.pro
+++ b/android/app/proguard-rules.pro
@@ -1,0 +1,19 @@
+# R8 optimization can remove or rename classes used indirectly by Room, WorkManager, and Glance.
+#
+# Without these rules, release builds may fail with:
+#   Failed to create an instance of class androidx.work.impl.WorkDatabase.canonicalName
+# or Glance widget actions may stop working.
+#
+# Keep the required classes to ensure WorkManager initialization and widget
+# actions continue to work in minified release builds.
+
+# Room / WorkManager
+-keep class * extends androidx.room.RoomDatabase { *; }
+-keep class * extends androidx.work.ListenableWorker { *; }
+-keep class * extends androidx.work.InputMerger { *; }
+-keep class androidx.work.WorkerParameters { *; }
+
+# App's Glance widgets only
+-keep class io.github.tsutsu3.pi_hole_client.widget.ui.** extends androidx.glance.appwidget.GlanceAppWidget { *; }
+-keep class io.github.tsutsu3.pi_hole_client.widget.ui.** extends androidx.glance.appwidget.GlanceAppWidgetReceiver { *; }
+-keep class io.github.tsutsu3.pi_hole_client.widget.ui.** implements androidx.glance.appwidget.action.ActionCallback { *; }


### PR DESCRIPTION
## Summary by Sourcery

Preserve indirectly referenced Android classes so widget actions and WorkManager continue working in release builds.

Bug Fixes:
- Prevent R8 from removing or renaming classes required for WorkManager initialization and Glance widget actions in minified release builds.

Build:
- Add Android ProGuard/R8 rules preserving Room, WorkManager, and the app’s Glance widget classes.