### PR TITLE
fix(ime): close the keyboard before the app leaves the foreground

### DIFF
--- a/lib/ui/shell/base.dart
+++ b/lib/ui/shell/base.dart
@@ -162,6 +162,11 @@ class _BaseState extends State<Base>
 
   @override
   Future<void> didChangeAppLifecycleState(AppLifecycleState state) async {
+    if (state == AppLifecycleState.inactive ||
+        state == AppLifecycleState.hidden) {
+      dismissKeyboard();
+    }
+
     if (state == AppLifecycleState.resumed) {
       // Only for desktop when restored from minimized
       if (!isDesktopPlatform()) {
@@ -170,6 +175,17 @@ class _BaseState extends State<Base>
     } else if (state == AppLifecycleState.paused) {
       onPaused();
     }
+  }
+
+  /// Closes the keyboard before the app leaves the foreground.
+  void dismissKeyboard() {
+    if (!Platform.isAndroid) return;
+
+    final focus = FocusManager.instance.primaryFocus;
+    if (focus == null || !focus.hasFocus) return;
+
+    focus.unfocus();
+    SystemChannels.textInput.invokeMethod<void>('TextInput.hide');
   }
 
   @override


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Dismiss the Android keyboard when the app becomes inactive or hidden so it closes before the app leaves the foreground.