### PR TITLE
ci(windows): fix STL1011 build error on the new MSVC toolchain

### DIFF
--- a/windows/CMakeLists.txt
+++ b/windows/CMakeLists.txt
@@ -32,6 +32,11 @@ set(CMAKE_CXX_FLAGS_PROFILE "${CMAKE_CXX_FLAGS_RELEASE}")
 # Use Unicode for all projects.
 add_definitions(-DUNICODE -D_UNICODE)
 
+# MSVC 14.51+ makes <experimental/coroutine> a hard error (STL1011).
+# Avoid: MSVC\14.51.36231\include\experimental\coroutine(37,1): error C2338: static assertion failed: 'error STL1011:
+add_definitions(-D_SILENCE_EXPERIMENTAL_COROUTINE_DEPRECATION_WARNINGS)
+
+
 # Compilation settings that should be applied to most targets.
 #
 # Be cautious about adding new options here, as plugins use this function by


### PR DESCRIPTION
## Summary by Sourcery

Restore Windows builds with newer MSVC toolchains by handling the experimental coroutine diagnostic.

Bug Fixes:
- Fix Windows builds with MSVC 14.51 and newer by suppressing the experimental coroutine deprecation error STL1011.

Build:
- Update Windows CMake configuration to support the new MSVC toolchain.