### PR TITLE
ci(workflow): add cache-dependency-path for Node.js setup

### DIFF
--- a/.github/workflows/deploy-docs-cloudflare.yml
+++ b/.github/workflows/deploy-docs-cloudflare.yml
@@ -33,6 +33,7 @@ jobs:
         with:
           node-version: 24
           cache: pnpm
+          cache-dependency-path: website/pnpm-lock.yaml
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Configure the documentation deployment workflow to use the website lockfile when caching pnpm dependencies.