### PR TITLE
chore(website): finish the move to the custom domain

### DIFF
--- a/.github/workflows/deploy-docs.yaml
+++ b/.github/workflows/deploy-docs.yaml
@@ -11,6 +11,7 @@ jobs:
   deploy:
     # Grant GITHUB_TOKEN the permissions required to make a Pages deployment
     permissions:
+      contents: read
       pages: write # to deploy to Pages
       id-token: write # to verify the deployment originates from an appropriate source
 

--- a/.github/workflows/deploy-docs.yaml
+++ b/.github/workflows/deploy-docs.yaml
@@ -9,6 +9,11 @@ concurrency:
 
 jobs:
   deploy:
+    # Grant GITHUB_TOKEN the permissions required to make a Pages deployment
+    permissions:
+      pages: write # to deploy to Pages
+      id-token: write # to verify the deployment originates from an appropriate source
+
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ The Pi-hole client features a beautiful and modern user interface.
 
 Easily view statistics, enable or disable the server, access logs, and much more.
 
-👉 [Pi-hole client website](https://tsutsu3.github.io/pi-hole-client/)
+👉 [Pi-hole client website](https://pi-hole-client.tsutsu3.com/)
 
 ## 💡 Main features
 

--- a/lib/ui/core/ui/helpers/urls.dart
+++ b/lib/ui/core/ui/helpers/urls.dart
@@ -4,7 +4,7 @@ class Urls {
 
   static const String gitHub = 'https://github.com/tsutsu3/pi-hole-client';
 
-  static const String appWebSite = 'https://tsutsu3.github.io/pi-hole-client/';
+  static const String appWebSite = 'https://pi-hole-client.tsutsu3.com/';
 
   static const String support =
       'https://docs.google.com/forms/d/e/1FAIpQLSdNm7H2iDUaQ0q-JA6hvrUSsGe50_iL5NVK6fR_2hkCsyrA-A/viewform?hl=en';

--- a/website/README.md
+++ b/website/README.md
@@ -3,7 +3,7 @@
 This is the source for the **Pi-hole Client Website**, built with
 [Astro](https://astro.build/) and [Starlight](https://starlight.astro.build/).
 
-🌐 [https://tsutsu3.github.io/pi-hole-client/](https://tsutsu3.github.io/pi-hole-client/)
+🌐 [https://pi-hole-client.tsutsu3.com/](https://pi-hole-client.tsutsu3.com/)
 
 ## Installation
 

--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -135,15 +135,6 @@ const head = [
   },
   { tag: "meta", attrs: { name: "twitter:image", content: ogImageUrl } },
   { tag: "meta", attrs: { name: "twitter:creator", content: "@_tsutsu3" } },
-
-  // Google Search Console
-  {
-    tag: "meta",
-    attrs: {
-      name: "google-site-verification",
-      content: "QcUHWbCbOodhUhP5h_PSpMNELHwN8H9_ATs9MfvWbSo",
-    },
-  },
 ];
 
 /** @type {import("@astrojs/starlight/types").StarlightUserConfig["sidebar"]} */

--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -14,26 +14,6 @@ const ogImageUrl = `${websiteUrl}/img/feature-image-og.png`;
 const description = meta.description.en;
 
 /**
- * Docusaurus published the sitemap at /sitemap.xml and that URL is registered in
- * Google Search Console. Astro writes sitemap-index.xml, so mirror it back.
- * @type {import("astro").AstroIntegration}
- */
-const legacySitemap = {
-  name: "legacy-sitemap",
-  hooks: {
-    "astro:build:done": ({ dir, logger }) => {
-      const source = new URL("./sitemap-index.xml", dir);
-      if (!fs.existsSync(source)) {
-        logger.warn("sitemap-index.xml not found; /sitemap.xml was not created");
-        return;
-      }
-      fs.copyFileSync(source, new URL("./sitemap.xml", dir));
-      logger.info("copied sitemap-index.xml to sitemap.xml");
-    },
-  },
-};
-
-/**
  * Astro emits unused original images alongside optimized variants.
  * Remove unreferenced images from _astro/ to reduce the Pages artifact size.
  * @type {import("astro").AstroIntegration}
@@ -218,7 +198,6 @@ export default defineConfig({
       // Rewrites the language-dependent `head` entries above on Japanese routes.
       routeMiddleware: "./src/starlightRouteData.ts",
     }),
-    legacySitemap,
     pruneUnusedAssets,
   ],
   vite: {

--- a/website/public/robots.txt
+++ b/website/public/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://pi-hole-client.tsutsu3.com/sitemap-index.xml

--- a/website/scripts/verify-urls.mjs
+++ b/website/scripts/verify-urls.mjs
@@ -42,7 +42,7 @@ const DEEP_LINKS = [
   },
 ];
 
-const OTHER_FILES = ["index.html", "404.html", "sitemap.xml", "sitemap-index.xml"];
+const OTHER_FILES = ["index.html", "404.html", "robots.txt", "sitemap-index.xml"];
 
 const errors = [];
 


### PR DESCRIPTION
## Summary by Sourcery

Configure the documentation workflow for GitHub Pages deployment and migrate website references and metadata to the custom domain.

Enhancements:
- Update the application and website references to use the custom Pi-hole Client domain.
- Align website SEO assets and configuration with the Astro deployment by adding robots.txt and removing obsolete sitemap and verification handling.

CI:
- Grant the documentation deployment workflow the permissions required for GitHub Pages deployments.

Documentation:
- Update README links to point to the custom website domain.

Tests:
- Update website URL verification to validate robots.txt instead of the legacy sitemap path.