### PR TITLE
chore(vscode): exclude integration tests from VS Code test runner

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,6 +4,9 @@
   "[dart]": {
     "editor.rulers": [80, 100, 120]
   },
+  "dart.analysisExcludedFolders": [
+    "integration_test"
+  ],
   "arb-editor.suppressedWarnings": [
     "missing_metadata_for_key",
     "missing_messages_from_template"


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Exclude integration tests from the VS Code test runner.