### PR TITLE
ci(workflows): drop triggers that always skip

### DIFF
--- a/.github/workflows/prepare.yaml
+++ b/.github/workflows/prepare.yaml
@@ -1,9 +1,6 @@
 name: Prepare Release
 
 on:
-  push:
-    branches:
-      - main
   pull_request:
 
 jobs:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,9 +1,6 @@
 name: Compile and release production build
 
 on:
-  push:
-    branches:
-      - main
   pull_request_target:
     types:
       - closed

--- a/.github/workflows/test-release.yaml
+++ b/.github/workflows/test-release.yaml
@@ -1,9 +1,6 @@
 name: Compile and release test build
 
 on:
-  push:
-    branches:
-      - main
   pull_request:
   workflow_dispatch:
 

--- a/.github/workflows/update-winget-submit.yaml
+++ b/.github/workflows/update-winget-submit.yaml
@@ -9,6 +9,7 @@ jobs:
   get-version:
     name: Extract Version from pubspec.yaml
     runs-on: ubuntu-latest
+    if: (github.event.pull_request.merged == true && startsWith(github.event.pull_request.head.ref, 'winget/update-v')) || github.event_name == 'workflow_dispatch'
     outputs:
       VERSION_NAME: ${{ steps.extract_version.outputs.VERSION_NAME }}
       VERSION_NUMBER: ${{ steps.extract_version.outputs.VERSION_NUMBER }}
@@ -33,7 +34,6 @@ jobs:
     name: Submit manifest to winget-pkgs
     runs-on: windows-latest
     needs: get-version
-    if: (github.event.pull_request.merged == true && startsWith(github.event.pull_request.head.ref, 'winget/update-v')) || github.event_name == 'workflow_dispatch'
     steps:
       - name: Checkout main branch
         uses: actions/checkout@v7


### PR DESCRIPTION
## Summary by Sourcery

Remove redundant main-branch push triggers and prevent unnecessary Winget submission workflow jobs from running.

Bug Fixes:
- Ensure the Winget submission workflow applies its event filter before extracting the version, avoiding unnecessary job execution.

Enhancements:
- Remove main-branch push triggers from release preparation and build workflows that were consistently skipped.
- Retain pull request, pull request target, and manual workflow triggers for the relevant automation.

CI:
- Streamline GitHub Actions triggers and job conditions to prevent redundant workflow runs.