### PR TITLE
fix(settings): show error when server settings screens fail to load

### DIFF
--- a/lib/ui/settings/server_settings/advanced_settings/dhcp/view_models/dhcp_viewmodel.dart
+++ b/lib/ui/settings/server_settings/advanced_settings/dhcp/view_models/dhcp_viewmodel.dart
@@ -25,6 +25,8 @@ class DhcpViewModel extends ChangeNotifier {
     deleteLease = Command.createAsyncNoResult<String>(_deleteLease);
 
     loadLeases.addListener(notifyListeners);
+    loadLeases.isRunning.addListener(notifyListeners);
+    loadLeases.errors.addListener(notifyListeners);
     deleteLease.addListener(notifyListeners);
   }
 
@@ -72,6 +74,8 @@ class DhcpViewModel extends ChangeNotifier {
   @override
   void dispose() {
     loadLeases.removeListener(notifyListeners);
+    loadLeases.isRunning.removeListener(notifyListeners);
+    loadLeases.errors.removeListener(notifyListeners);
     deleteLease.removeListener(notifyListeners);
     loadLeases.dispose();
     deleteLease.dispose();

--- a/lib/ui/settings/server_settings/advanced_settings/interface/view_models/interface_viewmodel.dart
+++ b/lib/ui/settings/server_settings/advanced_settings/interface/view_models/interface_viewmodel.dart
@@ -13,6 +13,8 @@ class InterfaceViewModel extends ChangeNotifier {
     );
 
     loadInterfaces.addListener(notifyListeners);
+    loadInterfaces.isRunning.addListener(notifyListeners);
+    loadInterfaces.errors.addListener(notifyListeners);
   }
 
   final NetworkRepository _networkRepository;
@@ -32,6 +34,8 @@ class InterfaceViewModel extends ChangeNotifier {
   @override
   void dispose() {
     loadInterfaces.removeListener(notifyListeners);
+    loadInterfaces.isRunning.removeListener(notifyListeners);
+    loadInterfaces.errors.removeListener(notifyListeners);
     loadInterfaces.dispose();
     super.dispose();
   }

--- a/lib/ui/settings/server_settings/advanced_settings/local_dns/view_models/local_dns_viewmodel.dart
+++ b/lib/ui/settings/server_settings/advanced_settings/local_dns/view_models/local_dns_viewmodel.dart
@@ -33,6 +33,8 @@ class LocalDnsViewModel extends ChangeNotifier {
     deleteRecord = Command.createAsyncNoResult<LocalDns>(_deleteRecord);
 
     loadRecords.addListener(notifyListeners);
+    loadRecords.isRunning.addListener(notifyListeners);
+    loadRecords.errors.addListener(notifyListeners);
     addRecord.addListener(notifyListeners);
     updateRecord.addListener(notifyListeners);
     deleteRecord.addListener(notifyListeners);
@@ -167,6 +169,8 @@ class LocalDnsViewModel extends ChangeNotifier {
   @override
   void dispose() {
     loadRecords.removeListener(notifyListeners);
+    loadRecords.isRunning.removeListener(notifyListeners);
+    loadRecords.errors.removeListener(notifyListeners);
     addRecord.removeListener(notifyListeners);
     updateRecord.removeListener(notifyListeners);
     deleteRecord.removeListener(notifyListeners);

--- a/lib/ui/settings/server_settings/advanced_settings/network/view_models/network_viewmodel.dart
+++ b/lib/ui/settings/server_settings/advanced_settings/network/view_models/network_viewmodel.dart
@@ -25,6 +25,8 @@ class NetworkViewModel extends ChangeNotifier {
     deleteDevice = Command.createAsyncNoResult<int>(_deleteDevice);
 
     loadDevices.addListener(notifyListeners);
+    loadDevices.isRunning.addListener(notifyListeners);
+    loadDevices.errors.addListener(notifyListeners);
     deleteDevice.addListener(notifyListeners);
   }
 
@@ -72,6 +74,8 @@ class NetworkViewModel extends ChangeNotifier {
   @override
   void dispose() {
     loadDevices.removeListener(notifyListeners);
+    loadDevices.isRunning.removeListener(notifyListeners);
+    loadDevices.errors.removeListener(notifyListeners);
     deleteDevice.removeListener(notifyListeners);
     loadDevices.dispose();
     deleteDevice.dispose();

--- a/lib/ui/settings/server_settings/advanced_settings/sessions/view_models/sessions_viewmodel.dart
+++ b/lib/ui/settings/server_settings/advanced_settings/sessions/view_models/sessions_viewmodel.dart
@@ -14,6 +14,8 @@ class SessionsViewModel extends ChangeNotifier {
     deleteSession = Command.createAsyncNoResult<int>(_deleteSession);
 
     loadSessions.addListener(notifyListeners);
+    loadSessions.isRunning.addListener(notifyListeners);
+    loadSessions.errors.addListener(notifyListeners);
     deleteSession.addListener(notifyListeners);
   }
 
@@ -53,6 +55,8 @@ class SessionsViewModel extends ChangeNotifier {
   @override
   void dispose() {
     loadSessions.removeListener(notifyListeners);
+    loadSessions.isRunning.removeListener(notifyListeners);
+    loadSessions.errors.removeListener(notifyListeners);
     deleteSession.removeListener(notifyListeners);
     loadSessions.dispose();
     deleteSession.dispose();

--- a/lib/ui/settings/server_settings/server_info/view_models/server_info_viewmodel.dart
+++ b/lib/ui/settings/server_settings/server_info/view_models/server_info_viewmodel.dart
@@ -17,6 +17,8 @@ class ServerInfoViewModel extends ChangeNotifier {
     );
 
     loadServerInfo.addListener(notifyListeners);
+    loadServerInfo.isRunning.addListener(notifyListeners);
+    loadServerInfo.errors.addListener(notifyListeners);
   }
 
   final FtlRepository _ftlRepository;
@@ -48,6 +50,8 @@ class ServerInfoViewModel extends ChangeNotifier {
   @override
   void dispose() {
     loadServerInfo.removeListener(notifyListeners);
+    loadServerInfo.isRunning.removeListener(notifyListeners);
+    loadServerInfo.errors.removeListener(notifyListeners);
     loadServerInfo.dispose();
     super.dispose();
   }

--- a/test/ui/settings/server_settings/advanced_settings/dhcp/view_models/dhcp_viewmodel_test.dart
+++ b/test/ui/settings/server_settings/advanced_settings/dhcp/view_models/dhcp_viewmodel_test.dart
@@ -51,6 +51,25 @@ void main() {
       expect(viewModel.loadLeases.errors.value, isNotNull);
     });
 
+    test('loadLeases failure notifies listeners with error state', () async {
+      fakeDhcpRepository.shouldFail = true;
+
+      final completer = Completer<void>();
+      viewModel.addListener(() {
+        if (!viewModel.loadLeases.isRunning.value &&
+            viewModel.loadLeases.errors.value != null &&
+            !completer.isCompleted) {
+          completer.complete();
+        }
+      });
+      viewModel.loadLeases.run();
+
+      await expectLater(
+        completer.future.timeout(const Duration(seconds: 1)),
+        completes,
+      );
+    });
+
     test('deleteLease success removes lease locally', () async {
       await viewModel.loadLeases.runAsync();
       expect(fakeDhcpRepository.fetchDhcpLeasesCallCount, 1);

--- a/test/ui/settings/server_settings/advanced_settings/interface/view_models/interface_viewmodel_test.dart
+++ b/test/ui/settings/server_settings/advanced_settings/interface/view_models/interface_viewmodel_test.dart
@@ -47,6 +47,28 @@ void main() {
       expect(viewModel.loadInterfaces.errors.value, isNotNull);
     });
 
+    test(
+      'loadInterfaces failure notifies listeners with error state',
+      () async {
+        fakeNetworkRepository.shouldFail = true;
+
+        final completer = Completer<void>();
+        viewModel.addListener(() {
+          if (!viewModel.loadInterfaces.isRunning.value &&
+              viewModel.loadInterfaces.errors.value != null &&
+              !completer.isCompleted) {
+            completer.complete();
+          }
+        });
+        viewModel.loadInterfaces.run();
+
+        await expectLater(
+          completer.future.timeout(const Duration(seconds: 1)),
+          completes,
+        );
+      },
+    );
+
     test('isRunning is true while loading', () async {
       final future = viewModel.loadInterfaces.runAsync();
 

--- a/test/ui/settings/server_settings/advanced_settings/local_dns/view_models/local_dns_viewmodel_test.dart
+++ b/test/ui/settings/server_settings/advanced_settings/local_dns/view_models/local_dns_viewmodel_test.dart
@@ -51,6 +51,25 @@ void main() {
       expect(viewModel.loadRecords.errors.value, isNotNull);
     });
 
+    test('loadRecords failure notifies listeners with error state', () async {
+      fakeLocalDnsRepository.shouldFail = true;
+
+      final completer = Completer<void>();
+      viewModel.addListener(() {
+        if (!viewModel.loadRecords.isRunning.value &&
+            viewModel.loadRecords.errors.value != null &&
+            !completer.isCompleted) {
+          completer.complete();
+        }
+      });
+      viewModel.loadRecords.run();
+
+      await expectLater(
+        completer.future.timeout(const Duration(seconds: 1)),
+        completes,
+      );
+    });
+
     test('addRecord success appends record locally', () async {
       await viewModel.loadRecords.runAsync();
 

--- a/test/ui/settings/server_settings/advanced_settings/network/view_models/network_viewmodel_test.dart
+++ b/test/ui/settings/server_settings/advanced_settings/network/view_models/network_viewmodel_test.dart
@@ -51,6 +51,25 @@ void main() {
       expect(viewModel.loadDevices.errors.value, isNotNull);
     });
 
+    test('loadDevices failure notifies listeners with error state', () async {
+      fakeNetworkRepository.shouldFail = true;
+
+      final completer = Completer<void>();
+      viewModel.addListener(() {
+        if (!viewModel.loadDevices.isRunning.value &&
+            viewModel.loadDevices.errors.value != null &&
+            !completer.isCompleted) {
+          completer.complete();
+        }
+      });
+      viewModel.loadDevices.run();
+
+      await expectLater(
+        completer.future.timeout(const Duration(seconds: 1)),
+        completes,
+      );
+    });
+
     test('deleteDevice success removes device locally', () async {
       await viewModel.loadDevices.runAsync();
       expect(fakeNetworkRepository.fetchDevicesCallCount, 1);

--- a/test/ui/settings/server_settings/advanced_settings/sessions/view_models/sessions_viewmodel_test.dart
+++ b/test/ui/settings/server_settings/advanced_settings/sessions/view_models/sessions_viewmodel_test.dart
@@ -43,6 +43,25 @@ void main() {
       expect(viewModel.loadSessions.errors.value, isNotNull);
     });
 
+    test('loadSessions failure notifies listeners with error state', () async {
+      fakeAuthRepository.shouldFail = true;
+
+      final completer = Completer<void>();
+      viewModel.addListener(() {
+        if (!viewModel.loadSessions.isRunning.value &&
+            viewModel.loadSessions.errors.value != null &&
+            !completer.isCompleted) {
+          completer.complete();
+        }
+      });
+      viewModel.loadSessions.run();
+
+      await expectLater(
+        completer.future.timeout(const Duration(seconds: 1)),
+        completes,
+      );
+    });
+
     test('deleteSession success removes session locally', () async {
       await viewModel.loadSessions.runAsync();
       expect(fakeAuthRepository.getAllSessionsCallCount, 1);

--- a/test/ui/settings/server_settings/server_info/view_models/server_info_viewmodel_test.dart
+++ b/test/ui/settings/server_settings/server_info/view_models/server_info_viewmodel_test.dart
@@ -50,6 +50,28 @@ void main() {
       expect(viewModel.loadServerInfo.errors.value, isNotNull);
     });
 
+    test(
+      'loadServerInfo failure notifies listeners with error state',
+      () async {
+        fakeFtlRepository.shouldFail = true;
+
+        final completer = Completer<void>();
+        viewModel.addListener(() {
+          if (!viewModel.loadServerInfo.isRunning.value &&
+              viewModel.loadServerInfo.errors.value != null &&
+              !completer.isCompleted) {
+            completer.complete();
+          }
+        });
+        viewModel.loadServerInfo.run();
+
+        await expectLater(
+          completer.future.timeout(const Duration(seconds: 1)),
+          completes,
+        );
+      },
+    );
+
     test('isRunning is true while loading', () async {
       final future = viewModel.loadServerInfo.runAsync();
 


### PR DESCRIPTION
## Overview
The DHCP, Network, Interface, Local DNS, Server info and Sessions screens show an error message when their data fails to load. Users can see that loading failed and try again with the swipe-refresh. The loading animation appears again while the screen reloads.

## Changes
- Rebuild these six screens when loading starts, fails, or finishes.
- Listen to the loading state and errors of each load command, the same way as the Groups, Clients, Adlists and Domains view models.
- Load errors on these screens are shown on the screen and are not sent to Sentry, like all other load errors in the app.
- Add view model tests that check the screen is notified with the error state when loading fails.

## Summary by Sourcery

Expose loading and error states for server settings screens so failed data loads are visible and retryable.

Bug Fixes:
- Surface loading failures on the DHCP, Network, Interface, Local DNS, Server Info, and Sessions settings screens so users can retry failed loads.

Enhancements:
- Update the affected settings view models when loading state or errors change, allowing screens to refresh during loading and display failures without routing them through the global error handler.

Tests:
- Add view model coverage verifying that failed loads notify listeners with the completed error state across all six settings screens.