### PR TITLE
fix(groups): save the new name when a group is renamed

### DIFF
--- a/lib/data/repositories/api/interfaces/group_repository.dart
+++ b/lib/data/repositories/api/interfaces/group_repository.dart
@@ -12,6 +12,7 @@ abstract interface class GroupRepository {
 
   Future<Result<Group>> updateGroup(
     String name, {
+    String? newName,
     String? comment,
     bool? enabled = true,
   });

--- a/lib/data/repositories/api/v5/group_repository.dart
+++ b/lib/data/repositories/api/v5/group_repository.dart
@@ -38,6 +38,7 @@ class GroupRepositoryV5 extends BaseV5TokenRepository
   @override
   Future<Result<Group>> updateGroup(
     String name, {
+    String? newName,
     String? comment,
     bool? enabled = true,
   }) async {

--- a/lib/data/repositories/api/v6/group_repository.dart
+++ b/lib/data/repositories/api/v6/group_repository.dart
@@ -50,6 +50,7 @@ class GroupRepositoryV6 extends BaseV6SidRepository implements GroupRepository {
   @override
   Future<Result<Group>> updateGroup(
     String name, {
+    String? newName,
     String? comment,
     bool? enabled = true,
   }) async {
@@ -59,10 +60,29 @@ class GroupRepositoryV6 extends BaseV6SidRepository implements GroupRepository {
         final result = await _client.putGroups(
           sid,
           name: name,
+          newName: newName,
           comment: comment,
           enabled: enabled,
         );
-        return result.map((e) => e.toSingleDomain());
+
+        // Comment or enabled status updates return the updated group immediately, so no re-fetch is needed.
+        final groups = result.getOrThrow();
+        if (groups.groups.isNotEmpty) {
+          return Success(groups.toSingleDomain());
+        }
+
+        // Pi-hole returns an empty group list after a rename, so the group must be fetched again.
+        if (newName == null) {
+          throw Exception('Group $name was updated but not returned');
+        }
+
+        final all = (await _client.getGroups(sid)).getOrThrow().toDomain();
+        return Success(
+          all.firstWhere(
+            (g) => g.name == newName,
+            orElse: () => throw Exception('Group $newName not found'),
+          ),
+        );
       },
       onRetry: (_, e) => renewSidIfExpired(e),
     );

--- a/lib/data/services/api/pihole_v6_api_client.dart
+++ b/lib/data/services/api/pihole_v6_api_client.dart
@@ -429,6 +429,7 @@ class PiholeV6ApiClient {
   Future<Result<Groups>> putGroups(
     String sid, {
     required String name,
+    String? newName,
     String? comment,
     bool? enabled = true,
   }) async {
@@ -437,7 +438,7 @@ class PiholeV6ApiClient {
         method: HttpMethod.put,
         path: '/api/groups/${Uri.encodeComponent(name)}',
         sid: sid,
-        body: {'comment': comment, 'enabled': enabled},
+        body: {'name': newName ?? name, 'comment': comment, 'enabled': enabled},
       );
 
       if (resp.statusCode == 200) {

--- a/lib/ui/settings/server_settings/group_client/view_models/groups_viewmodel.dart
+++ b/lib/ui/settings/server_settings/group_client/view_models/groups_viewmodel.dart
@@ -33,7 +33,10 @@ class GroupsViewModel extends ChangeNotifier {
   late final Command<void, void> loadGroups;
   late final Command<({String name, String? comment, bool? enabled}), void>
   addGroup;
-  late final Command<({String name, String? comment, bool? enabled}), void>
+  late final Command<
+    ({String name, String? newName, String? comment, bool? enabled}),
+    void
+  >
   updateGroup;
   late final Command<Group, void> deleteGroup;
 
@@ -91,10 +94,11 @@ class GroupsViewModel extends ChangeNotifier {
   }
 
   Future<void> _updateGroup(
-    ({String name, String? comment, bool? enabled}) params,
+    ({String name, String? newName, String? comment, bool? enabled}) params,
   ) async {
     final result = await _groupRepository.updateGroup(
       params.name,
+      newName: params.newName,
       comment: params.comment,
       enabled: params.enabled,
     );

--- a/lib/ui/settings/server_settings/group_client/widgets/group_details_screen.dart
+++ b/lib/ui/settings/server_settings/group_client/widgets/group_details_screen.dart
@@ -106,6 +106,7 @@ class _GroupDetailsScreenState extends State<GroupDetailsScreen> {
               ),
               onTap: () => onEditGroup((
                 name: _group.name,
+                newName: null,
                 comment: _group.comment,
                 enabled: !_group.enabled,
               )),
@@ -113,6 +114,7 @@ class _GroupDetailsScreenState extends State<GroupDetailsScreen> {
                 value: _group.enabled,
                 onChanged: (value) => onEditGroup((
                   name: _group.name,
+                  newName: null,
                   comment: _group.comment,
                   enabled: value,
                 )),
@@ -243,7 +245,7 @@ class _GroupDetailsScreenState extends State<GroupDetailsScreen> {
   }
 
   Future<void> onEditGroup(
-    ({String name, String? comment, bool? enabled}) params,
+    ({String name, String? newName, String? comment, bool? enabled}) params,
   ) async {
     final process = ProcessModal(context: context);
     process.open(AppLocalizations.of(context)!.groupUpdating);
@@ -255,8 +257,9 @@ class _GroupDetailsScreenState extends State<GroupDetailsScreen> {
       process.close();
 
       final updatedGroup = groupsViewModel.groups.firstWhere(
-        (g) => g.name == params.name,
+        (g) => g.id == _group.id,
         orElse: () => _group.copyWith(
+          name: params.newName ?? _group.name,
           comment: params.comment,
           enabled: params.enabled ?? _group.enabled,
         ),
@@ -293,6 +296,7 @@ class _GroupDetailsScreenState extends State<GroupDetailsScreen> {
           group: _group,
           onConfirm: (request) => onEditGroup((
             name: _group.name,
+            newName: request.name,
             comment: request.comment,
             enabled: request.enabled,
           )),
@@ -306,6 +310,7 @@ class _GroupDetailsScreenState extends State<GroupDetailsScreen> {
           group: _group,
           onConfirm: (request) => onEditGroup((
             name: _group.name,
+            newName: request.name,
             comment: request.comment,
             enabled: request.enabled,
           )),

--- a/lib/ui/settings/server_settings/group_client/widgets/groups_list.dart
+++ b/lib/ui/settings/server_settings/group_client/widgets/groups_list.dart
@@ -128,6 +128,7 @@ class _GroupsListState extends State<GroupsList> {
       try {
         await groupsViewModel.updateGroup.runAsync((
           name: group.name,
+          newName: null,
           comment: group.comment,
           enabled: enabled,
         ));

--- a/test/data/repositories/api/v6/group_repository_test.dart
+++ b/test/data/repositories/api/v6/group_repository_test.dart
@@ -50,7 +50,7 @@ void main() {
   });
 
   group('updateGroup', () {
-    test('should update group successfully', () async {
+    test('should update comment and enabled without re-fetching', () async {
       final result = await repository.updateGroup(
         'test',
         comment: 'updated',
@@ -58,6 +58,36 @@ void main() {
       );
       expect(result.isSuccess(), true);
     });
+
+    test('should re-fetch and return the renamed group', () async {
+      client.getGroupsResponse = kSrvGetGroupsAfterRename;
+
+      final result = await repository.updateGroup('test', newName: 'renamed');
+
+      expect(client.lastPutGroupsNewName, 'renamed');
+      expect(result.getOrNull()?.name, 'renamed');
+      expect(result.getOrNull()?.id, 5);
+    });
+
+    // Unexpected: the Pi-hole server renamed the group but does not list it.
+    test(
+      'should fail when the renamed group is not found after re-fetching',
+      () async {
+        final result = await repository.updateGroup('test', newName: 'missing');
+        expectError(result, messageContains: 'Group missing not found');
+      },
+    );
+
+    // Unexpected: the Pi-hole server returned no group without a rename.
+    test(
+      'should fail when an empty group list is returned without a rename',
+      () async {
+        client.shouldPutGroupsReturnEmpty = true;
+
+        final result = await repository.updateGroup('test', comment: 'updated');
+        expectError(result, messageContains: 'was updated but not returned');
+      },
+    );
 
     test('should fail when updating group', () async {
       client.shouldFail = true;

--- a/test/ui/settings/server_settings/group_client/view_models/groups_viewmodel_test.dart
+++ b/test/ui/settings/server_settings/group_client/view_models/groups_viewmodel_test.dart
@@ -125,6 +125,7 @@ void main() {
 
       await viewModel.updateGroup.runAsync((
         name: 'test',
+        newName: null,
         comment: 'updated comment',
         enabled: false,
       ));
@@ -136,6 +137,22 @@ void main() {
       expect(viewModel.groups.length, 2);
       expect(viewModel.loadingStatus, LoadStatus.loaded);
       expect(listenerCalled, true);
+    });
+
+    test('updateGroup renames group when newName is given', () async {
+      await viewModel.loadGroups.runAsync();
+
+      await viewModel.updateGroup.runAsync((
+        name: 'test',
+        newName: 'renamed',
+        comment: null,
+        enabled: true,
+      ));
+
+      final updated = viewModel.groups.firstWhere((g) => g.id == 5);
+      expect(updated.name, 'renamed');
+      expect(viewModel.groups.any((g) => g.name == 'test'), isFalse);
+      expect(viewModel.groups.length, 2);
     });
 
     test('deleteGroup sets error on failure', () async {

--- a/test/widgets/helpers.dart
+++ b/test/widgets/helpers.dart
@@ -1982,7 +1982,7 @@ class TestSetupHelper {
     );
     when(mockGroupsViewModel.updateGroup).thenReturn(
       Command.createAsyncNoResult<
-        ({String name, String? comment, bool? enabled})
+        ({String name, String? newName, String? comment, bool? enabled})
       >((_) async {}),
     );
     when(

--- a/test/widgets/helpers.mocks.dart
+++ b/test/widgets/helpers.mocks.dart
@@ -2094,18 +2094,26 @@ class MockGroupsViewModel extends _i1.Mock implements _i33.GroupsViewModel {
           >);
 
   @override
-  _i3.Command<({String? comment, bool? enabled, String name}), void>
+  _i3.Command<
+    ({String? comment, bool? enabled, String name, String? newName}),
+    void
+  >
   get updateGroup =>
       (super.noSuchMethod(
             Invocation.getter(#updateGroup),
             returnValue:
                 _FakeCommand_1<
-                  ({String? comment, bool? enabled, String name}),
+                  ({
+                    String? comment,
+                    bool? enabled,
+                    String name,
+                    String? newName,
+                  }),
                   void
                 >(this, Invocation.getter(#updateGroup)),
           )
           as _i3.Command<
-            ({String? comment, bool? enabled, String name}),
+            ({String? comment, bool? enabled, String name, String? newName}),
             void
           >);
 
@@ -2184,7 +2192,11 @@ class MockGroupsViewModel extends _i1.Mock implements _i33.GroupsViewModel {
 
   @override
   set updateGroup(
-    _i3.Command<({String? comment, bool? enabled, String name}), void>? value,
+    _i3.Command<
+      ({String? comment, bool? enabled, String name, String? newName}),
+      void
+    >?
+    value,
   ) => super.noSuchMethod(
     Invocation.setter(#updateGroup, value),
     returnValueForMissingStub: null,

--- a/testing/fakes/repositories/api/fake_group_repository.dart
+++ b/testing/fakes/repositories/api/fake_group_repository.dart
@@ -55,6 +55,7 @@ class FakeGroupRepository implements GroupRepository {
   @override
   Future<Result<Group>> updateGroup(
     String name, {
+    String? newName,
     String? comment,
     bool? enabled = true,
   }) async {
@@ -64,7 +65,7 @@ class FakeGroupRepository implements GroupRepository {
     return Success(
       Group(
         id: 5,
-        name: name,
+        name: newName ?? name,
         comment: comment,
         enabled: enabled ?? true,
         dateAdded: _now,

--- a/testing/fakes/services/fake_pihole_v6_api_client.dart
+++ b/testing/fakes/services/fake_pihole_v6_api_client.dart
@@ -77,6 +77,12 @@ class FakePiholeV6ApiClient implements PiholeV6ApiClient {
   bool shouldGetInfoVersionWithDocker = false;
   bool shouldGetInfoSystemOld = false;
   bool shouldGetInfoFtlV63 = false;
+  Groups getGroupsResponse = kSrvGetGroups;
+
+  String? lastPutGroupsNewName;
+
+  /// Returns an empty group list even when no rename was requested.
+  bool shouldPutGroupsReturnEmpty = false;
 
   @override
   void close() {}
@@ -267,7 +273,7 @@ class FakePiholeV6ApiClient implements PiholeV6ApiClient {
     if (shouldFail) {
       return Failure(Exception('Forced getGroups failure'));
     }
-    return const Success(kSrvGetGroups);
+    return Success(getGroupsResponse);
   }
 
   @override
@@ -287,11 +293,16 @@ class FakePiholeV6ApiClient implements PiholeV6ApiClient {
   Future<Result<Groups>> putGroups(
     String sid, {
     required String name,
+    String? newName,
     String? comment,
     bool? enabled = true,
   }) async {
     if (shouldFail) {
       return Failure(Exception('Forced putGroups failure'));
+    }
+    lastPutGroupsNewName = newName;
+    if (shouldPutGroupsReturnEmpty || newName != null) {
+      return const Success(kSrvPutGroupsRenamed);
     }
     return const Success(kSrvPutGroups);
   }

--- a/testing/models/v6/group.dart
+++ b/testing/models/v6/group.dart
@@ -49,6 +49,30 @@ const kSrvPutGroups = srv.Groups(
   took: 0.003,
 );
 
+/// Pi-hole returns an empty group list when a group is renamed.
+const kSrvPutGroupsRenamed = srv.Groups(groups: [], took: 0.003);
+
+const kSrvGetGroupsAfterRename = srv.Groups(
+  groups: [
+    srv.Group(
+      id: 0,
+      name: 'Default',
+      comment: 'The default group',
+      enabled: true,
+      dateAdded: 1594670974,
+      dateModified: 1611157897,
+    ),
+    srv.Group(
+      id: 5,
+      name: 'renamed',
+      enabled: false,
+      dateAdded: 1604871899,
+      dateModified: 1604871899,
+    ),
+  ],
+  took: 0.003,
+);
+
 final kRepoFetchGroups = [
   Group(
     id: 0,


### PR DESCRIPTION
## Overview
Changing a group name in the edit sheet now saves the new name on the Pi-hole server. The group details screen and the group list show the new name right away. If the server does not apply the change, the app shows an error instead of a success message.

## Changes
- Send the group name in the update request so the server renames the group.
- Pass the name typed in the edit sheet to the update, and follow the group by id after the name changes.
- Read the group back from the server after a rename, because Pi-hole returns an empty group list in that case.
- Fail with a clear message when the group is missing after a rename, or when an empty list comes back without a rename.
- Add tests for a rename, for a group missing after a rename, and for an unexpected empty response.

## Summary by Sourcery

Persist renamed group names reliably and surface failures when the server does not return the updated group.

Bug Fixes:
- Persist group renames on the Pi-hole server and update the group details and list using the renamed group.
- Report an error when a group update returns no group unexpectedly or when a renamed group cannot be found afterward.

Enhancements:
- Track groups by ID after updates so renamed groups remain associated with their existing details.

Tests:
- Add coverage for successful renames, missing renamed groups, and unexpected empty update responses.