### PR TITLE
fix(ui): close the right screen after deleting a group, client, or adlist

### DIFF
--- a/lib/ui/domains/widgets/domains_list.dart
+++ b/lib/ui/domains/widgets/domains_list.dart
@@ -15,6 +15,7 @@ import 'package:pi_hole_client/ui/core/ui/modals/process_modal.dart';
 import 'package:pi_hole_client/ui/core/view_models/app_config_viewmodel.dart';
 import 'package:pi_hole_client/ui/domains/view_models/domains_viewmodel.dart';
 import 'package:pi_hole_client/ui/domains/widgets/add_domain_modal.dart';
+import 'package:pi_hole_client/ui/domains/widgets/domain_actions.dart';
 import 'package:pi_hole_client/ui/domains/widgets/domain_tile.dart';
 import 'package:pi_hole_client/ui/settings/server_settings/group_client/view_models/groups_viewmodel.dart';
 import 'package:provider/provider.dart';
@@ -86,31 +87,14 @@ class _DomainsListState extends State<DomainsList> {
         : viewModel.filteredAllowlistDomains;
 
     Future<void> removeDomain(Domain domain) async {
-      final process = ProcessModal(context: context);
-      process.open(AppLocalizations.of(context)!.deleting);
-
-      try {
-        await viewModel.deleteDomain.runAsync(domain);
-        if (!context.mounted) return;
-        process.close();
-
-        context.pop();
-
-        showSuccessSnackBar(
-          context: context,
-          appConfigViewModel: appConfigViewModel,
-          label: AppLocalizations.of(context)!.domainRemoved,
-        );
-      } catch (_) {
-        if (!context.mounted) return;
-        process.close();
-
-        showErrorSnackBar(
-          context: context,
-          appConfigViewModel: appConfigViewModel,
-          label: AppLocalizations.of(context)!.errorRemovingDomain,
-        );
-      }
+      await deleteDomain(
+        context: context,
+        viewModel: viewModel,
+        appConfigViewModel: appConfigViewModel,
+        domain: domain,
+      );
+      // The details screen was pushed, so close it.
+      if (context.mounted) context.pop();
     }
 
     Future<void> onAddDomain(

--- a/lib/ui/settings/server_settings/adlists/widgets/adlist_actions.dart
+++ b/lib/ui/settings/server_settings/adlists/widgets/adlist_actions.dart
@@ -17,13 +17,8 @@ Future<void> deleteAdlist({
 
   try {
     await viewModel.deleteAdlist.runAsync(adlist);
-
     if (!context.mounted) return;
-    process.close();
 
-    await Navigator.maybePop(context);
-
-    if (!context.mounted) return;
     showSuccessSnackBar(
       context: context,
       appConfigViewModel: appConfigViewModel,
@@ -31,7 +26,6 @@ Future<void> deleteAdlist({
     );
   } catch (_) {
     if (!context.mounted) return;
-    process.close();
 
     showErrorSnackBar(
       context: context,

--- a/lib/ui/settings/server_settings/adlists/widgets/adlist_screen.dart
+++ b/lib/ui/settings/server_settings/adlists/widgets/adlist_screen.dart
@@ -203,9 +203,16 @@ class _AdlistScreenWidgetState extends State<AdlistScreenWidget>
             Routes.settingsServerAdlistsDetails,
             extra: AdlistDetailsExtra(
               adlist: adlist,
-              remove: (Adlist s) {
+              remove: (Adlist s) async {
                 setState(() => selectedAdlist = null);
-                remove(s);
+                await deleteAdlist(
+                  context: context,
+                  viewModel: viewModel,
+                  appConfigViewModel: appConfigViewModel,
+                  adlist: s,
+                );
+                // The details screen was pushed, so close it.
+                if (context.mounted) context.pop();
               },
               groups: groups,
               colors: appConfigViewModel.colors,

--- a/lib/ui/settings/server_settings/adlists/widgets/adlists_list.dart
+++ b/lib/ui/settings/server_settings/adlists/widgets/adlists_list.dart
@@ -14,6 +14,7 @@ import 'package:pi_hole_client/ui/core/ui/modals/process_modal.dart';
 import 'package:pi_hole_client/ui/core/view_models/app_config_viewmodel.dart';
 import 'package:pi_hole_client/ui/settings/server_settings/adlists/view_models/adlists_viewmodel.dart';
 import 'package:pi_hole_client/ui/settings/server_settings/adlists/widgets/add_adlist_modal.dart';
+import 'package:pi_hole_client/ui/settings/server_settings/adlists/widgets/adlist_actions.dart';
 import 'package:pi_hole_client/ui/settings/server_settings/adlists/widgets/adlist_tile.dart';
 import 'package:pi_hole_client/ui/settings/server_settings/group_client/view_models/groups_viewmodel.dart';
 import 'package:provider/provider.dart';
@@ -79,33 +80,14 @@ class _AdlistsListState extends State<AdlistsList> {
         : viewModel.filteredAllowlistAdlists;
 
     Future<void> removeAdlist(Adlist adlist) async {
-      final process = ProcessModal(context: context);
-      process.open(AppLocalizations.of(context)!.deleting);
-
-      try {
-        await viewModel.deleteAdlist.runAsync(adlist);
-
-        if (!context.mounted) return;
-        process.close();
-
-        context.pop();
-
-        if (!context.mounted) return;
-        showSuccessSnackBar(
-          context: context,
-          appConfigViewModel: appConfigViewModel,
-          label: AppLocalizations.of(context)!.adlistRemoved,
-        );
-      } catch (_) {
-        if (!context.mounted) return;
-        process.close();
-
-        showErrorSnackBar(
-          context: context,
-          appConfigViewModel: appConfigViewModel,
-          label: AppLocalizations.of(context)!.adlistDeleteError,
-        );
-      }
+      await deleteAdlist(
+        context: context,
+        viewModel: viewModel,
+        appConfigViewModel: appConfigViewModel,
+        adlist: adlist,
+      );
+      // The details screen was pushed, so close it.
+      if (context.mounted) context.pop();
     }
 
     Future<void> onAddAdlist(Map<String, dynamic> value) async {

--- a/lib/ui/settings/server_settings/adlists/widgets/filtered_adlists.dart
+++ b/lib/ui/settings/server_settings/adlists/widgets/filtered_adlists.dart
@@ -192,9 +192,16 @@ class _FilteredAdlistsState extends State<FilteredAdlists>
             Routes.settingsServerAdlistsDetails,
             extra: AdlistDetailsExtra(
               adlist: adlist,
-              remove: (Adlist s) {
+              remove: (Adlist s) async {
                 setState(() => selectedAdlist = null);
-                remove(s);
+                await deleteAdlist(
+                  context: context,
+                  viewModel: viewModel,
+                  appConfigViewModel: appConfigViewModel,
+                  adlist: s,
+                );
+                // The details screen was pushed, so close it.
+                if (context.mounted) context.pop();
               },
               groups: groups,
               colors: appConfigViewModel.colors,

--- a/lib/ui/settings/server_settings/adlists/widgets/gravity_update.dart
+++ b/lib/ui/settings/server_settings/adlists/widgets/gravity_update.dart
@@ -256,12 +256,16 @@ class _GravityUpdateState extends State<GravityUpdate> {
       Routes.settingsServerAdlistsDetails,
       extra: AdlistDetailsExtra(
         adlist: adlist,
-        remove: (Adlist a) => deleteAdlist(
-          context: context,
-          viewModel: viewModel,
-          appConfigViewModel: appConfigViewModel,
-          adlist: a,
-        ),
+        remove: (Adlist a) async {
+          await deleteAdlist(
+            context: context,
+            viewModel: viewModel,
+            appConfigViewModel: appConfigViewModel,
+            adlist: a,
+          );
+          // The details screen was pushed, so close it.
+          if (context.mounted) context.pop();
+        },
         groups: context.read<GroupsViewModel>().groupItems,
         colors: appConfigViewModel.colors,
         viewModel: viewModel,

--- a/lib/ui/settings/server_settings/group_client/widgets/client_actions.dart
+++ b/lib/ui/settings/server_settings/group_client/widgets/client_actions.dart
@@ -1,0 +1,38 @@
+import 'package:flutter/material.dart';
+import 'package:pi_hole_client/domain/model/client/managed_client.dart';
+import 'package:pi_hole_client/ui/core/l10n/generated/app_localizations.dart';
+import 'package:pi_hole_client/ui/core/ui/helpers/snackbar.dart';
+import 'package:pi_hole_client/ui/core/ui/modals/process_modal.dart';
+import 'package:pi_hole_client/ui/core/view_models/app_config_viewmodel.dart';
+import 'package:pi_hole_client/ui/settings/server_settings/group_client/view_models/clients_viewmodel.dart';
+
+Future<void> deleteClient({
+  required BuildContext context,
+  required ClientsViewModel viewModel,
+  required AppConfigViewModel appConfigViewModel,
+  required ManagedClient client,
+}) async {
+  final process = ProcessModal(context: context);
+  process.open(AppLocalizations.of(context)!.deleting);
+
+  try {
+    await viewModel.deleteClient.runAsync(client);
+    if (!context.mounted) return;
+
+    showSuccessSnackBar(
+      context: context,
+      appConfigViewModel: appConfigViewModel,
+      label: AppLocalizations.of(context)!.clientRemoved,
+    );
+  } catch (_) {
+    if (!context.mounted) return;
+
+    showErrorSnackBar(
+      context: context,
+      appConfigViewModel: appConfigViewModel,
+      label: AppLocalizations.of(context)!.clientRemoveFailed,
+    );
+  } finally {
+    process.close();
+  }
+}

--- a/lib/ui/settings/server_settings/group_client/widgets/client_details_screen.dart
+++ b/lib/ui/settings/server_settings/group_client/widgets/client_details_screen.dart
@@ -1,7 +1,6 @@
 import 'dart:io';
 
 import 'package:flutter/material.dart';
-import 'package:go_router/go_router.dart';
 import 'package:pi_hole_client/domain/model/client/managed_client.dart';
 import 'package:pi_hole_client/ui/core/l10n/generated/app_localizations.dart';
 import 'package:pi_hole_client/ui/core/themes/theme.dart';
@@ -84,7 +83,7 @@ class _ClientDetailsScreenState extends State<ClientDetailsScreen> {
                 message: AppLocalizations.of(context)!.clientDeleteMessage,
                 onDelete: () {
                   Navigator.maybePop(context);
-                  removeClient(_client);
+                  widget.remove(_client);
                 },
               ),
             ),
@@ -228,40 +227,6 @@ class _ClientDetailsScreenState extends State<ClientDetailsScreen> {
   bool _isMacAddress(String value) {
     final macRegex = RegExp(r'^([0-9A-Fa-f]{2}:){5}[0-9A-Fa-f]{2}$');
     return macRegex.hasMatch(value);
-  }
-
-  Future<void> removeClient(ManagedClient client) async {
-    final process = ProcessModal(context: context);
-    process.open(AppLocalizations.of(context)!.deleting);
-
-    try {
-      await clientsViewModel.deleteClient.runAsync(client);
-
-      if (!mounted) return;
-      process.close();
-
-      widget.remove(client);
-      if (!mounted) return;
-      if (MediaQuery.of(context).size.width <= ResponsiveConstants.large) {
-        context.pop();
-      }
-
-      if (!mounted) return;
-      showSuccessSnackBar(
-        context: context,
-        appConfigViewModel: appConfigViewModel,
-        label: AppLocalizations.of(context)!.clientRemoved,
-      );
-    } catch (_) {
-      if (!mounted) return;
-      process.close();
-
-      showErrorSnackBar(
-        context: context,
-        appConfigViewModel: appConfigViewModel,
-        label: AppLocalizations.of(context)!.clientRemoveFailed,
-      );
-    }
   }
 
   Future<void> onEditClient(({String? comment, List<int> groups}) value) async {

--- a/lib/ui/settings/server_settings/group_client/widgets/group_actions.dart
+++ b/lib/ui/settings/server_settings/group_client/widgets/group_actions.dart
@@ -1,0 +1,38 @@
+import 'package:flutter/material.dart';
+import 'package:pi_hole_client/domain/model/group/group.dart';
+import 'package:pi_hole_client/ui/core/l10n/generated/app_localizations.dart';
+import 'package:pi_hole_client/ui/core/ui/helpers/snackbar.dart';
+import 'package:pi_hole_client/ui/core/ui/modals/process_modal.dart';
+import 'package:pi_hole_client/ui/core/view_models/app_config_viewmodel.dart';
+import 'package:pi_hole_client/ui/settings/server_settings/group_client/view_models/groups_viewmodel.dart';
+
+Future<void> deleteGroup({
+  required BuildContext context,
+  required GroupsViewModel viewModel,
+  required AppConfigViewModel appConfigViewModel,
+  required Group group,
+}) async {
+  final process = ProcessModal(context: context);
+  process.open(AppLocalizations.of(context)!.deleting);
+
+  try {
+    await viewModel.deleteGroup.runAsync(group);
+    if (!context.mounted) return;
+
+    showSuccessSnackBar(
+      context: context,
+      appConfigViewModel: appConfigViewModel,
+      label: AppLocalizations.of(context)!.groupRemoved,
+    );
+  } catch (_) {
+    if (!context.mounted) return;
+
+    showErrorSnackBar(
+      context: context,
+      appConfigViewModel: appConfigViewModel,
+      label: AppLocalizations.of(context)!.groupRemoveFailed,
+    );
+  } finally {
+    process.close();
+  }
+}

--- a/lib/ui/settings/server_settings/group_client/widgets/group_client_screen.dart
+++ b/lib/ui/settings/server_settings/group_client/widgets/group_client_screen.dart
@@ -13,8 +13,10 @@ import 'package:pi_hole_client/ui/domains/view_models/domains_viewmodel.dart';
 import 'package:pi_hole_client/ui/settings/server_settings/adlists/view_models/adlists_viewmodel.dart';
 import 'package:pi_hole_client/ui/settings/server_settings/group_client/view_models/clients_viewmodel.dart';
 import 'package:pi_hole_client/ui/settings/server_settings/group_client/view_models/groups_viewmodel.dart';
+import 'package:pi_hole_client/ui/settings/server_settings/group_client/widgets/client_actions.dart';
 import 'package:pi_hole_client/ui/settings/server_settings/group_client/widgets/client_details_screen.dart';
 import 'package:pi_hole_client/ui/settings/server_settings/group_client/widgets/clients_list.dart';
+import 'package:pi_hole_client/ui/settings/server_settings/group_client/widgets/group_actions.dart';
 import 'package:pi_hole_client/ui/settings/server_settings/group_client/widgets/group_details_screen.dart';
 import 'package:pi_hole_client/ui/settings/server_settings/group_client/widgets/groups_list.dart';
 import 'package:provider/provider.dart';
@@ -237,9 +239,18 @@ class _GroupClientScreenWidgetState extends State<GroupClientScreenWidget>
                 ? selectedGroup != null
                       ? GroupDetailsScreen(
                           group: selectedGroup!,
-                          remove: (group) => setState(() {
-                            selectedGroup = null;
-                          }),
+                          // The detail pane stays open, so it only clears.
+                          remove: (group) {
+                            setState(() {
+                              selectedGroup = null;
+                            });
+                            deleteGroup(
+                              context: context,
+                              viewModel: context.read<GroupsViewModel>(),
+                              appConfigViewModel: appConfigViewModel,
+                              group: group,
+                            );
+                          },
                         )
                       : ColoredBox(
                           color: Theme.of(context).scaffoldBackgroundColor,
@@ -265,9 +276,18 @@ class _GroupClientScreenWidgetState extends State<GroupClientScreenWidget>
                 : selectedClient != null
                 ? ClientDetailsScreen(
                     client: selectedClient!,
-                    remove: (client) => setState(() {
-                      selectedClient = null;
-                    }),
+                    // The detail pane stays open, so it only clears.
+                    remove: (client) {
+                      setState(() {
+                        selectedClient = null;
+                      });
+                      deleteClient(
+                        context: context,
+                        viewModel: context.read<ClientsViewModel>(),
+                        appConfigViewModel: appConfigViewModel,
+                        client: client,
+                      );
+                    },
                     groups: groups,
                     colors: appConfigViewModel.colors,
                     ipToMac: ipToMac,
@@ -327,12 +347,25 @@ class _GroupClientScreenWidgetState extends State<GroupClientScreenWidget>
   }
 
   void _pushGroupDetails(BuildContext context, Group group) {
+    final appConfigViewModel = context.read<AppConfigViewModel>();
+    final groupsViewModel = context.read<GroupsViewModel>();
+
     context.pushNamed(
       Routes.settingsServerGroupDetails,
       extra: GroupDetailsExtra(
         group: group,
-        remove: (Group g) => setState(() => selectedGroup = null),
-        groupsViewModel: context.read<GroupsViewModel>(),
+        remove: (Group g) async {
+          setState(() => selectedGroup = null);
+          await deleteGroup(
+            context: context,
+            viewModel: groupsViewModel,
+            appConfigViewModel: appConfigViewModel,
+            group: g,
+          );
+          // The details screen was pushed, so close it.
+          if (context.mounted) context.pop();
+        },
+        groupsViewModel: groupsViewModel,
         clientsViewModel: context.read<ClientsViewModel>(),
         domainsViewModel: context.read<DomainsViewModel>(),
         adlistsViewModel: context.read<AdlistsViewModel>(),
@@ -349,17 +382,30 @@ class _GroupClientScreenWidgetState extends State<GroupClientScreenWidget>
     required Map<String, String> ipToHostname,
     required Map<String, String> macToIp,
   }) {
+    final appConfigViewModel = context.read<AppConfigViewModel>();
+    final clientsViewModel = context.read<ClientsViewModel>();
+
     context.pushNamed(
       Routes.settingsServerClientDetails,
       extra: ClientDetailsExtra(
         client: client,
-        remove: (ManagedClient c) => setState(() => selectedClient = null),
+        remove: (ManagedClient c) async {
+          setState(() => selectedClient = null);
+          await deleteClient(
+            context: context,
+            viewModel: clientsViewModel,
+            appConfigViewModel: appConfigViewModel,
+            client: c,
+          );
+          // The details screen was pushed, so close it.
+          if (context.mounted) context.pop();
+        },
         groups: groups,
         colors: colors,
         ipToMac: ipToMac,
         ipToHostname: ipToHostname,
         macToIp: macToIp,
-        viewModel: context.read<ClientsViewModel>(),
+        viewModel: clientsViewModel,
       ),
     );
   }

--- a/lib/ui/settings/server_settings/group_client/widgets/group_details_screen.dart
+++ b/lib/ui/settings/server_settings/group_client/widgets/group_details_screen.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:go_router/go_router.dart';
 import 'package:pi_hole_client/domain/model/group/group.dart';
 import 'package:pi_hole_client/ui/core/l10n/generated/app_localizations.dart';
 import 'package:pi_hole_client/ui/core/ui/components/section_label.dart';
@@ -82,7 +81,7 @@ class _GroupDetailsScreenState extends State<GroupDetailsScreen> {
                 message: AppLocalizations.of(context)!.groupDeleteMessage,
                 onDelete: () {
                   Navigator.maybePop(context);
-                  removeGroup(_group);
+                  widget.remove(_group);
                 },
               ),
             ),
@@ -208,40 +207,6 @@ class _GroupDetailsScreenState extends State<GroupDetailsScreen> {
         ),
       ),
     );
-  }
-
-  Future<void> removeGroup(Group group) async {
-    final process = ProcessModal(context: context);
-    process.open(AppLocalizations.of(context)!.deleting);
-
-    try {
-      await groupsViewModel.deleteGroup.runAsync(group);
-
-      if (!mounted) return;
-      process.close();
-
-      widget.remove(group);
-      if (!mounted) return;
-      if (MediaQuery.of(context).size.width <= ResponsiveConstants.large) {
-        context.pop();
-      }
-
-      if (!mounted) return;
-      showSuccessSnackBar(
-        context: context,
-        appConfigViewModel: appConfigViewModel,
-        label: AppLocalizations.of(context)!.groupRemoved,
-      );
-    } catch (_) {
-      if (!mounted) return;
-      process.close();
-
-      showErrorSnackBar(
-        context: context,
-        appConfigViewModel: appConfigViewModel,
-        label: AppLocalizations.of(context)!.groupRemoveFailed,
-      );
-    }
   }
 
   Future<void> onEditGroup(

--- a/test/ui/settings/server_settings/group_client/group_client_screen_test.dart
+++ b/test/ui/settings/server_settings/group_client/group_client_screen_test.dart
@@ -264,6 +264,100 @@ void main() async {
       expect(find.text('Edit group'), findsOneWidget);
     });
 
+    testWidgets('should close group details after delete on tablet width', (
+      WidgetTester tester,
+    ) async {
+      // Two columns: the details screen is pushed, so it must close itself.
+      tester.view.physicalSize = const Size(1000, 1400);
+      tester.view.devicePixelRatio = 1.0;
+
+      addTearDown(() {
+        tester.view.resetPhysicalSize();
+        tester.view.resetDevicePixelRatio();
+      });
+
+      final router = GoRouter(
+        initialLocation: '/group-client',
+        routes: [
+          GoRoute(
+            path: '/group-client',
+            builder: (context, state) => MultiProvider(
+              providers: [
+                ChangeNotifierProvider<ServersViewModel>.value(
+                  value: fakeServersViewModel,
+                ),
+                ChangeNotifierProvider<ClientsViewModel>.value(
+                  value: clientsViewModel,
+                ),
+                ChangeNotifierProvider<GroupsViewModel>.value(
+                  value: groupsViewModel,
+                ),
+                ChangeNotifierProvider<LocalDnsViewModel>.value(
+                  value: localDnsViewModel,
+                ),
+                ChangeNotifierProvider<DomainsViewModel>.value(
+                  value: domainsViewModel,
+                ),
+                ChangeNotifierProvider<AdlistsViewModel>.value(
+                  value: adlistsViewModel,
+                ),
+              ],
+              child: const GroupClientScreen(),
+            ),
+            routes: [
+              GoRoute(
+                path: 'group-details',
+                name: Routes.settingsServerGroupDetails,
+                builder: (context, state) {
+                  final extra = state.extra! as GroupDetailsExtra;
+                  return MultiProvider(
+                    providers: [
+                      ChangeNotifierProvider.value(
+                        value: extra.groupsViewModel,
+                      ),
+                      ChangeNotifierProvider.value(
+                        value: extra.clientsViewModel,
+                      ),
+                      ChangeNotifierProvider.value(
+                        value: extra.domainsViewModel,
+                      ),
+                      ChangeNotifierProvider.value(
+                        value: extra.adlistsViewModel,
+                      ),
+                    ],
+                    child: GroupDetailsScreen(
+                      group: extra.group,
+                      remove: extra.remove,
+                    ),
+                  );
+                },
+              ),
+            ],
+          ),
+        ],
+      );
+
+      await tester.pumpWidget(
+        buildTestApp(const SizedBox.shrink(), router: router),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('Default'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Group details'), findsOneWidget);
+
+      await tester.tap(find.byIcon(Icons.delete_rounded));
+      await tester.pumpAndSettle();
+      expect(find.byType(DeleteModal), findsOneWidget);
+
+      await tester.tap(find.text('Delete'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Group details'), findsNothing);
+      expect(find.byType(GroupClientScreen), findsOneWidget);
+    });
+
     testWidgets('should open client delete modal from details', (
       WidgetTester tester,
     ) async {
@@ -659,7 +753,7 @@ void main() async {
       },
     );
 
-    testWidgets('GroupDetailsScreen deletes group and shows success snackbar', (
+    testWidgets('GroupDetailsScreen asks the caller to delete the group', (
       WidgetTester tester,
     ) async {
       tester.view.physicalSize = const Size(1200, 900);
@@ -678,8 +772,11 @@ void main() async {
         tester.view.resetDevicePixelRatio();
       });
 
+      Group? removed;
       await tester.pumpWidget(
-        buildWidget(GroupDetailsScreen(group: group, remove: (_) {})),
+        buildWidget(
+          GroupDetailsScreen(group: group, remove: (g) => removed = g),
+        ),
       );
       await tester.pumpAndSettle();
 
@@ -690,8 +787,7 @@ void main() async {
       await tester.tap(find.text('Delete'));
       await tester.pumpAndSettle();
 
-      expect(find.byType(SnackBar), findsOneWidget);
-      expect(find.text('Group removed successfully'), findsOneWidget);
+      expect(removed, group);
     });
 
     testWidgets(
@@ -787,47 +883,46 @@ void main() async {
       },
     );
 
-    testWidgets(
-      'ClientDetailsScreen deletes client and shows success snackbar',
-      (WidgetTester tester) async {
-        tester.view.physicalSize = const Size(1200, 900);
-        tester.view.devicePixelRatio = 1.0;
+    testWidgets('ClientDetailsScreen asks the caller to delete the client', (
+      WidgetTester tester,
+    ) async {
+      tester.view.physicalSize = const Size(1200, 900);
+      tester.view.devicePixelRatio = 1.0;
 
-        final client = ManagedClient(
-          client: '192.168.1.100',
-          name: 'desktop',
-          groups: const [0],
-          id: 1,
-          dateAdded: DateTime(2024, 1, 1),
-          dateModified: DateTime(2024, 1, 1),
-        );
+      final client = ManagedClient(
+        client: '192.168.1.100',
+        name: 'desktop',
+        groups: const [0],
+        id: 1,
+        dateAdded: DateTime(2024, 1, 1),
+        dateModified: DateTime(2024, 1, 1),
+      );
 
-        addTearDown(() {
-          tester.view.resetPhysicalSize();
-          tester.view.resetDevicePixelRatio();
-        });
+      addTearDown(() {
+        tester.view.resetPhysicalSize();
+        tester.view.resetDevicePixelRatio();
+      });
 
-        await tester.pumpWidget(
-          buildWidget(
-            ClientDetailsScreen(
-              client: client,
-              remove: (_) {},
-              groups: const {0: 'Default'},
-            ),
+      ManagedClient? removed;
+      await tester.pumpWidget(
+        buildWidget(
+          ClientDetailsScreen(
+            client: client,
+            remove: (c) => removed = c,
+            groups: const {0: 'Default'},
           ),
-        );
-        await tester.pumpAndSettle();
+        ),
+      );
+      await tester.pumpAndSettle();
 
-        await tester.tap(find.byIcon(Icons.delete_rounded));
-        await tester.pumpAndSettle();
-        expect(find.byType(DeleteModal), findsOneWidget);
+      await tester.tap(find.byIcon(Icons.delete_rounded));
+      await tester.pumpAndSettle();
+      expect(find.byType(DeleteModal), findsOneWidget);
 
-        await tester.tap(find.text('Delete'));
-        await tester.pumpAndSettle();
+      await tester.tap(find.text('Delete'));
+      await tester.pumpAndSettle();
 
-        expect(find.byType(SnackBar), findsOneWidget);
-        expect(find.text('Client removed successfully'), findsOneWidget);
-      },
-    );
+      expect(removed, client);
+    });
   });
 }


### PR DESCRIPTION
## Overview
Deleting a group, a client, or an adlist now works the same way at every window size. When the details open as their own screen, the app goes back to the list after the delete. When the details sit next to the list in a wide window, only that part clears and the screen stays open.

## Changes
- Close the details screen after a delete when it was opened as its own screen, on phone and tablet widths.
- Keep the screen open when the delete starts from the details pane of a wide window. Only that pane clears.
- Run group and client deletion through one shared place, so the progress dialog and result messages match the other lists.
- Show one result message per delete, and always close the progress dialog.
- Add tests for deleting at tablet width, and for the details screens handing the delete to the caller.

## Summary by Sourcery

Make deletion navigation consistent across responsive layouts for groups, clients, and adlists.

Bug Fixes:
- Ensure deleting a group, client, or adlist closes pushed detail screens while preserving wide-layout detail panes.

Enhancements:
- Centralize group and client deletion handling and standardize progress dialogs and result notifications across deletions.
- Delegate deletion from detail views to their callers so navigation behavior is determined by the surrounding layout.

Tests:
- Add coverage for tablet-width group deletion and verify group and client detail views delegate deletion to their callers.