### PR TITLE
fix(ui): align group and client add and edit sheets with the other screens

### DIFF
--- a/lib/ui/settings/server_settings/adlists/widgets/adlist_details_screen.dart
+++ b/lib/ui/settings/server_settings/adlists/widgets/adlist_details_screen.dart
@@ -283,9 +283,15 @@ class _AdlistDetailsScreenState extends State<AdlistDetailsScreen> {
   }
 
   void openGroupsModal() {
+    final mediaQuery = MediaQuery.of(context);
+    final isSmallLandscape =
+        mediaQuery.size.width > mediaQuery.size.height &&
+        mediaQuery.size.height < ResponsiveConstants.medium;
+
     if (MediaQuery.of(context).size.width > ResponsiveConstants.medium) {
       showDialog(
         context: context,
+        useSafeArea: !isSmallLandscape,
         useRootNavigator:
             false, // Prevents unexpected app exit on mobile when pressing back
         builder: (ctx) => EditAdlistModal(

--- a/lib/ui/settings/server_settings/group_client/widgets/add_client_modal.dart
+++ b/lib/ui/settings/server_settings/group_client/widgets/add_client_modal.dart
@@ -38,9 +38,12 @@ class _AddClientModalState extends State<AddClientModal> {
   @override
   Widget build(BuildContext context) {
     final locale = AppLocalizations.of(context)!;
+    final mediaQuery = MediaQuery.of(context);
+    final isLandscape = mediaQuery.orientation == Orientation.landscape;
+
     Widget content() {
       return Column(
-        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+        mainAxisSize: MainAxisSize.min,
         children: [
           Flexible(
             child: SingleChildScrollView(
@@ -116,34 +119,39 @@ class _AddClientModalState extends State<AddClientModal> {
               ),
             ),
           ),
-          Row(
-            mainAxisAlignment: MainAxisAlignment.end,
-            children: [
-              TextButton(
-                onPressed: () => Navigator.maybePop(context),
-                child: Text(locale.cancel),
-              ),
-              const SizedBox(width: 14),
-              TextButton(
-                onPressed: allDataValid
-                    ? () {
-                        final comment = commentController.text.trim();
-                        widget.onConfirm((
-                          client: clientController.text.trim(),
-                          comment: comment.isEmpty ? null : comment,
-                          groups: selectedGroups,
-                        ));
-                        Navigator.maybePop(context);
-                      }
-                    : null,
-                style: ButtonStyle(
-                  foregroundColor: WidgetStateProperty.all(
-                    allDataValid ? null : Colors.grey,
-                  ),
+          Padding(
+            padding: isLandscape
+                ? EdgeInsets.zero
+                : const EdgeInsets.only(top: 20),
+            child: Row(
+              mainAxisAlignment: MainAxisAlignment.end,
+              children: [
+                TextButton(
+                  onPressed: () => Navigator.maybePop(context),
+                  child: Text(locale.cancel),
                 ),
-                child: Text(locale.add),
-              ),
-            ],
+                const SizedBox(width: 14),
+                TextButton(
+                  onPressed: allDataValid
+                      ? () {
+                          final comment = commentController.text.trim();
+                          widget.onConfirm((
+                            client: clientController.text.trim(),
+                            comment: comment.isEmpty ? null : comment,
+                            groups: selectedGroups,
+                          ));
+                          Navigator.maybePop(context);
+                        }
+                      : null,
+                  style: ButtonStyle(
+                    foregroundColor: WidgetStateProperty.all(
+                      allDataValid ? null : Colors.grey,
+                    ),
+                  ),
+                  child: Text(locale.add),
+                ),
+              ],
+            ),
           ),
         ],
       );
@@ -152,19 +160,22 @@ class _AddClientModalState extends State<AddClientModal> {
     if (widget.window) {
       return Dialog(
         child: ConstrainedBox(
-          constraints: const BoxConstraints(maxWidth: 600, maxHeight: 560),
-          child: Padding(padding: const EdgeInsets.all(16), child: content()),
+          constraints: const BoxConstraints(maxWidth: 600),
+          child: Padding(
+            padding: isLandscape
+                ? const EdgeInsets.symmetric(horizontal: 16)
+                : const EdgeInsets.all(16),
+            child: content(),
+          ),
         ),
       );
     }
 
     return Padding(
       padding: MediaQuery.of(context).viewInsets,
-      child: SafeArea(
-        child: ConstrainedBox(
-          constraints: const BoxConstraints(maxHeight: 560),
-          child: Padding(padding: const EdgeInsets.all(24), child: content()),
-        ),
+      child: Padding(
+        padding: const EdgeInsets.all(24),
+        child: SafeArea(child: content()),
       ),
     );
   }

--- a/lib/ui/settings/server_settings/group_client/widgets/add_group_modal.dart
+++ b/lib/ui/settings/server_settings/group_client/widgets/add_group_modal.dart
@@ -28,9 +28,12 @@ class _AddGroupModalState extends State<AddGroupModal> {
 
   @override
   Widget build(BuildContext context) {
+    final mediaQuery = MediaQuery.of(context);
+    final isLandscape = mediaQuery.orientation == Orientation.landscape;
+
     Widget content() {
       return Column(
-        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+        mainAxisSize: MainAxisSize.min,
         children: [
           Flexible(
             child: SingleChildScrollView(
@@ -90,34 +93,39 @@ class _AddGroupModalState extends State<AddGroupModal> {
               ),
             ),
           ),
-          Row(
-            mainAxisAlignment: MainAxisAlignment.end,
-            children: [
-              TextButton(
-                onPressed: () => Navigator.maybePop(context),
-                child: Text(AppLocalizations.of(context)!.cancel),
-              ),
-              const SizedBox(width: 14),
-              TextButton(
-                onPressed: allDataValid
-                    ? () {
-                        final comment = commentController.text.trim();
-                        widget.onConfirm((
-                          name: nameController.text.trim(),
-                          comment: comment.isEmpty ? null : comment,
-                          enabled: enabled,
-                        ));
-                        Navigator.maybePop(context);
-                      }
-                    : null,
-                style: ButtonStyle(
-                  foregroundColor: WidgetStateProperty.all(
-                    allDataValid ? null : Colors.grey,
-                  ),
+          Padding(
+            padding: isLandscape
+                ? EdgeInsets.zero
+                : const EdgeInsets.only(top: 20),
+            child: Row(
+              mainAxisAlignment: MainAxisAlignment.end,
+              children: [
+                TextButton(
+                  onPressed: () => Navigator.maybePop(context),
+                  child: Text(AppLocalizations.of(context)!.cancel),
                 ),
-                child: Text(AppLocalizations.of(context)!.add),
-              ),
-            ],
+                const SizedBox(width: 14),
+                TextButton(
+                  onPressed: allDataValid
+                      ? () {
+                          final comment = commentController.text.trim();
+                          widget.onConfirm((
+                            name: nameController.text.trim(),
+                            comment: comment.isEmpty ? null : comment,
+                            enabled: enabled,
+                          ));
+                          Navigator.maybePop(context);
+                        }
+                      : null,
+                  style: ButtonStyle(
+                    foregroundColor: WidgetStateProperty.all(
+                      allDataValid ? null : Colors.grey,
+                    ),
+                  ),
+                  child: Text(AppLocalizations.of(context)!.add),
+                ),
+              ],
+            ),
           ),
         ],
       );
@@ -126,19 +134,22 @@ class _AddGroupModalState extends State<AddGroupModal> {
     if (widget.window) {
       return Dialog(
         child: ConstrainedBox(
-          constraints: const BoxConstraints(maxWidth: 600, maxHeight: 520),
-          child: Padding(padding: const EdgeInsets.all(16), child: content()),
+          constraints: const BoxConstraints(maxWidth: 600),
+          child: Padding(
+            padding: isLandscape
+                ? const EdgeInsets.symmetric(horizontal: 16)
+                : const EdgeInsets.all(16),
+            child: content(),
+          ),
         ),
       );
     }
 
     return Padding(
       padding: MediaQuery.of(context).viewInsets,
-      child: SafeArea(
-        child: ConstrainedBox(
-          constraints: const BoxConstraints(maxHeight: 520),
-          child: Padding(padding: const EdgeInsets.all(24), child: content()),
-        ),
+      child: Padding(
+        padding: const EdgeInsets.all(24),
+        child: SafeArea(child: content()),
       ),
     );
   }

--- a/lib/ui/settings/server_settings/group_client/widgets/client_details_screen.dart
+++ b/lib/ui/settings/server_settings/group_client/widgets/client_details_screen.dart
@@ -272,11 +272,16 @@ class _ClientDetailsScreenState extends State<ClientDetailsScreen> {
   }
 
   void openCommentModal() {
-    final isLarge =
-        MediaQuery.of(context).size.width > ResponsiveConstants.medium;
+    final mediaQuery = MediaQuery.of(context);
+    final isLarge = mediaQuery.size.width > ResponsiveConstants.medium;
+    final isSmallLandscape =
+        mediaQuery.size.width > mediaQuery.size.height &&
+        mediaQuery.size.height < ResponsiveConstants.medium;
+
     if (isLarge) {
       showDialog(
         context: context,
+        useSafeArea: !isSmallLandscape,
         useRootNavigator: false,
         builder: (ctx) => EditClientModal(
           client: _client,
@@ -306,9 +311,15 @@ class _ClientDetailsScreenState extends State<ClientDetailsScreen> {
   }
 
   void openGroupsModal() {
+    final mediaQuery = MediaQuery.of(context);
+    final isSmallLandscape =
+        mediaQuery.size.width > mediaQuery.size.height &&
+        mediaQuery.size.height < ResponsiveConstants.medium;
+
     if (MediaQuery.of(context).size.width > ResponsiveConstants.medium) {
       showDialog(
         context: context,
+        useSafeArea: !isSmallLandscape,
         useRootNavigator: false,
         builder: (ctx) => EditClientModal(
           client: _client,

--- a/lib/ui/settings/server_settings/group_client/widgets/edit_client_modal.dart
+++ b/lib/ui/settings/server_settings/group_client/widgets/edit_client_modal.dart
@@ -57,95 +57,113 @@ class _EditClientModalState extends State<EditClientModal> {
 
   @override
   Widget build(BuildContext context) {
+    final mediaQuery = MediaQuery.of(context);
+    final isLandscape = mediaQuery.orientation == Orientation.landscape;
+
     Widget content() {
-      return Column(
-        mainAxisAlignment: MainAxisAlignment.spaceBetween,
-        children: [
-          Flexible(
-            child: SingleChildScrollView(
-              child: Column(
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  Icon(
-                    widget.icon,
-                    size: 24,
-                    color: Theme.of(context).colorScheme.secondary,
-                  ),
-                  Padding(
-                    padding: const EdgeInsets.all(20),
-                    child: Text(
-                      widget.title,
-                      style: const TextStyle(fontSize: 24),
-                    ),
-                  ),
-                  if (widget.keyItem == 'comment')
-                    TextField(
-                      controller: commentController,
-                      onChanged: validateComment,
-                      decoration: InputDecoration(
-                        prefixIcon: const Icon(Icons.comment_rounded),
-                        border: const OutlineInputBorder(
-                          borderRadius: BorderRadius.all(Radius.circular(10)),
+      return Container(
+        constraints: const BoxConstraints(minHeight: 360),
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          children: [
+            Flexible(
+              child: Center(
+                child: SingleChildScrollView(
+                  child: Column(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      Icon(
+                        widget.icon,
+                        size: 24,
+                        color: Theme.of(context).colorScheme.secondary,
+                      ),
+                      Padding(
+                        padding: const EdgeInsets.all(20),
+                        child: Text(
+                          widget.title,
+                          style: const TextStyle(fontSize: 24),
                         ),
-                        labelText: AppLocalizations.of(context)!.comment,
+                      ),
+                      if (widget.keyItem == 'comment')
+                        SizedBox(
+                          width: double.infinity,
+                          child: TextField(
+                            controller: commentController,
+                            onChanged: validateComment,
+                            decoration: InputDecoration(
+                              prefixIcon: const Icon(Icons.comment_rounded),
+                              border: const OutlineInputBorder(
+                                borderRadius: BorderRadius.all(
+                                  Radius.circular(10),
+                                ),
+                              ),
+                              labelText: AppLocalizations.of(context)!.comment,
+                            ),
+                          ),
+                        ),
+                      if (widget.keyItem == 'groups')
+                        LabeledMultiSelectTile(
+                          isExpanded: true,
+                          initiallySelectedItems: widget.client.groups,
+                          labelText: AppLocalizations.of(context)!.groups,
+                          hintText: AppLocalizations.of(
+                            context,
+                          )!.selectGroupsMessage,
+                          icon: Icons.group_rounded,
+                          options: widget.groups,
+                          onSelectionChanged: (list) {
+                            selectedGroups = list;
+                            validateGroups();
+                          },
+                        ),
+                    ],
+                  ),
+                ),
+              ),
+            ),
+            Padding(
+              padding: isLandscape
+                  ? EdgeInsets.zero
+                  : const EdgeInsets.only(top: 20),
+              child: Row(
+                mainAxisAlignment: MainAxisAlignment.end,
+                children: [
+                  TextButton(
+                    onPressed: () => Navigator.maybePop(context),
+                    child: Text(AppLocalizations.of(context)!.cancel),
+                  ),
+                  const SizedBox(width: 14),
+                  TextButton(
+                    onPressed: allDataValid
+                        ? () {
+                            if (widget.keyItem == 'comment') {
+                              final comment = commentController.text.trim();
+                              widget.onConfirm((
+                                comment: comment.isEmpty ? null : comment,
+                                groups: widget.client.groups,
+                              ));
+                            }
+                            if (widget.keyItem == 'groups') {
+                              widget.onConfirm((
+                                comment: widget.client.comment,
+                                groups: selectedGroups,
+                              ));
+                            }
+                            Navigator.maybePop(context);
+                          }
+                        : null,
+                    style: ButtonStyle(
+                      foregroundColor: WidgetStateProperty.all(
+                        allDataValid ? null : Colors.grey,
                       ),
                     ),
-                  if (widget.keyItem == 'groups')
-                    LabeledMultiSelectTile(
-                      isExpanded: true,
-                      initiallySelectedItems: widget.client.groups,
-                      labelText: AppLocalizations.of(context)!.groups,
-                      hintText: AppLocalizations.of(
-                        context,
-                      )!.selectGroupsMessage,
-                      icon: Icons.group_rounded,
-                      options: widget.groups,
-                      onSelectionChanged: (list) {
-                        selectedGroups = list;
-                        validateGroups();
-                      },
-                    ),
+                    child: Text(AppLocalizations.of(context)!.edit),
+                  ),
                 ],
               ),
             ),
-          ),
-          Row(
-            mainAxisAlignment: MainAxisAlignment.end,
-            children: [
-              TextButton(
-                onPressed: () => Navigator.maybePop(context),
-                child: Text(AppLocalizations.of(context)!.cancel),
-              ),
-              const SizedBox(width: 14),
-              TextButton(
-                onPressed: allDataValid
-                    ? () {
-                        if (widget.keyItem == 'comment') {
-                          final comment = commentController.text.trim();
-                          widget.onConfirm((
-                            comment: comment.isEmpty ? null : comment,
-                            groups: widget.client.groups,
-                          ));
-                        }
-                        if (widget.keyItem == 'groups') {
-                          widget.onConfirm((
-                            comment: widget.client.comment,
-                            groups: selectedGroups,
-                          ));
-                        }
-                        Navigator.maybePop(context);
-                      }
-                    : null,
-                style: ButtonStyle(
-                  foregroundColor: WidgetStateProperty.all(
-                    allDataValid ? null : Colors.grey,
-                  ),
-                ),
-                child: Text(AppLocalizations.of(context)!.edit),
-              ),
-            ],
-          ),
-        ],
+          ],
+        ),
       );
     }
 
@@ -153,7 +171,12 @@ class _EditClientModalState extends State<EditClientModal> {
       return Dialog(
         child: ConstrainedBox(
           constraints: const BoxConstraints(maxWidth: 600, maxHeight: 480),
-          child: Padding(padding: const EdgeInsets.all(16), child: content()),
+          child: Padding(
+            padding: isLandscape
+                ? const EdgeInsets.symmetric(horizontal: 16)
+                : const EdgeInsets.all(16),
+            child: content(),
+          ),
         ),
       );
     }

--- a/lib/ui/settings/server_settings/group_client/widgets/edit_group_modal.dart
+++ b/lib/ui/settings/server_settings/group_client/widgets/edit_group_modal.dart
@@ -5,12 +5,18 @@ import 'package:pi_hole_client/ui/core/l10n/generated/app_localizations.dart';
 class EditGroupModal extends StatefulWidget {
   const EditGroupModal({
     required this.group,
+    required this.keyItem,
+    required this.title,
+    required this.icon,
     required this.onConfirm,
     required this.window,
     super.key,
   });
 
   final Group group;
+  final String keyItem;
+  final String title;
+  final IconData icon;
   final void Function(({String name, String? comment, bool? enabled}))
   onConfirm;
   final bool window;
@@ -27,112 +33,155 @@ class _EditGroupModalState extends State<EditGroupModal> {
   @override
   void initState() {
     super.initState();
-    nameController.text = widget.group.name;
-    commentController.text = widget.group.comment ?? '';
+    if (widget.keyItem == 'name') {
+      nameController.text = widget.group.name;
+    }
+    if (widget.keyItem == 'comment') {
+      commentController.text = widget.group.comment ?? '';
+    }
   }
 
-  void validateForm() {
-    final name = nameController.text.trim();
-    final comment = commentController.text.trim();
-
-    final hasChanges =
-        name != widget.group.name || comment != (widget.group.comment ?? '');
-    final nameValid = name.isNotEmpty;
-
+  void validateName(String value) {
+    final name = value.trim();
     setState(() {
-      allDataValid = nameValid && hasChanges;
+      allDataValid = name.isNotEmpty && name != widget.group.name;
+    });
+  }
+
+  void validateComment(String value) {
+    setState(() {
+      allDataValid = value.trim() != (widget.group.comment ?? '');
     });
   }
 
   @override
   Widget build(BuildContext context) {
+    final mediaQuery = MediaQuery.of(context);
+    final isLandscape = mediaQuery.orientation == Orientation.landscape;
+
     Widget content() {
-      return Column(
-        mainAxisAlignment: MainAxisAlignment.spaceBetween,
-        children: [
-          Flexible(
-            child: SingleChildScrollView(
-              child: Column(
-                mainAxisSize: MainAxisSize.min,
+      return Container(
+        constraints: const BoxConstraints(minHeight: 360),
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          children: [
+            Flexible(
+              child: Center(
+                child: SingleChildScrollView(
+                  child: Column(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      Icon(
+                        widget.icon,
+                        size: 24,
+                        color: Theme.of(context).colorScheme.secondary,
+                      ),
+                      Padding(
+                        padding: const EdgeInsets.all(20),
+                        child: Text(
+                          widget.title,
+                          style: const TextStyle(fontSize: 24),
+                        ),
+                      ),
+                      if (widget.keyItem == 'name')
+                        SizedBox(
+                          width: double.infinity,
+                          child: TextField(
+                            controller: nameController,
+                            onChanged: validateName,
+                            decoration: InputDecoration(
+                              prefixIcon: const Icon(Icons.group_rounded),
+                              border: const OutlineInputBorder(
+                                borderRadius: BorderRadius.all(
+                                  Radius.circular(10),
+                                ),
+                              ),
+                              labelText: AppLocalizations.of(
+                                context,
+                              )!.groupName,
+                            ),
+                          ),
+                        ),
+                      if (widget.keyItem == 'comment')
+                        SizedBox(
+                          width: double.infinity,
+                          child: TextField(
+                            controller: commentController,
+                            onChanged: validateComment,
+                            decoration: InputDecoration(
+                              prefixIcon: const Icon(Icons.comment_rounded),
+                              border: const OutlineInputBorder(
+                                borderRadius: BorderRadius.all(
+                                  Radius.circular(10),
+                                ),
+                              ),
+                              labelText: AppLocalizations.of(context)!.comment,
+                            ),
+                          ),
+                        ),
+                    ],
+                  ),
+                ),
+              ),
+            ),
+            Padding(
+              padding: isLandscape
+                  ? EdgeInsets.zero
+                  : const EdgeInsets.only(top: 20),
+              child: Row(
+                mainAxisAlignment: MainAxisAlignment.end,
                 children: [
-                  Icon(
-                    Icons.edit_rounded,
-                    size: 24,
-                    color: Theme.of(context).colorScheme.secondary,
+                  TextButton(
+                    onPressed: () => Navigator.maybePop(context),
+                    child: Text(AppLocalizations.of(context)!.cancel),
                   ),
-                  Padding(
-                    padding: const EdgeInsets.all(20),
-                    child: Text(
-                      AppLocalizations.of(context)!.groupEdit,
-                      style: const TextStyle(fontSize: 24),
-                    ),
-                  ),
-                  TextField(
-                    controller: nameController,
-                    onChanged: (_) => validateForm(),
-                    decoration: InputDecoration(
-                      prefixIcon: const Icon(Icons.group_rounded),
-                      border: const OutlineInputBorder(
-                        borderRadius: BorderRadius.all(Radius.circular(10)),
+                  const SizedBox(width: 14),
+                  TextButton(
+                    onPressed: allDataValid
+                        ? () {
+                            if (widget.keyItem == 'name') {
+                              widget.onConfirm((
+                                name: nameController.text.trim(),
+                                comment: widget.group.comment,
+                                enabled: widget.group.enabled,
+                              ));
+                            }
+                            if (widget.keyItem == 'comment') {
+                              final comment = commentController.text.trim();
+                              widget.onConfirm((
+                                name: widget.group.name,
+                                comment: comment.isEmpty ? null : comment,
+                                enabled: widget.group.enabled,
+                              ));
+                            }
+                            Navigator.maybePop(context);
+                          }
+                        : null,
+                    style: ButtonStyle(
+                      foregroundColor: WidgetStateProperty.all(
+                        allDataValid ? null : Colors.grey,
                       ),
-                      labelText: AppLocalizations.of(context)!.groupName,
                     ),
-                  ),
-                  const SizedBox(height: 16),
-                  TextField(
-                    controller: commentController,
-                    onChanged: (_) => validateForm(),
-                    decoration: InputDecoration(
-                      prefixIcon: const Icon(Icons.comment_rounded),
-                      border: const OutlineInputBorder(
-                        borderRadius: BorderRadius.all(Radius.circular(10)),
-                      ),
-                      labelText: AppLocalizations.of(context)!.comment,
-                    ),
+                    child: Text(AppLocalizations.of(context)!.edit),
                   ),
                 ],
               ),
             ),
-          ),
-          Row(
-            mainAxisAlignment: MainAxisAlignment.end,
-            children: [
-              TextButton(
-                onPressed: () => Navigator.maybePop(context),
-                child: Text(AppLocalizations.of(context)!.cancel),
-              ),
-              const SizedBox(width: 14),
-              TextButton(
-                onPressed: allDataValid
-                    ? () {
-                        final name = nameController.text.trim();
-                        final comment = commentController.text.trim();
-                        widget.onConfirm((
-                          name: name,
-                          comment: comment.isEmpty ? null : comment,
-                          enabled: widget.group.enabled,
-                        ));
-                        Navigator.maybePop(context);
-                      }
-                    : null,
-                style: ButtonStyle(
-                  foregroundColor: WidgetStateProperty.all(
-                    allDataValid ? null : Colors.grey,
-                  ),
-                ),
-                child: Text(AppLocalizations.of(context)!.edit),
-              ),
-            ],
-          ),
-        ],
+          ],
+        ),
       );
     }
 
     if (widget.window) {
       return Dialog(
         child: ConstrainedBox(
-          constraints: const BoxConstraints(maxWidth: 600, maxHeight: 520),
-          child: Padding(padding: const EdgeInsets.all(16), child: content()),
+          constraints: const BoxConstraints(maxWidth: 600, maxHeight: 480),
+          child: Padding(
+            padding: isLandscape
+                ? const EdgeInsets.symmetric(horizontal: 16)
+                : const EdgeInsets.all(16),
+            child: content(),
+          ),
         ),
       );
     }
@@ -141,7 +190,7 @@ class _EditGroupModalState extends State<EditGroupModal> {
       padding: MediaQuery.of(context).viewInsets,
       child: SafeArea(
         child: ConstrainedBox(
-          constraints: const BoxConstraints(maxHeight: 520),
+          constraints: const BoxConstraints(maxHeight: 480),
           child: Padding(padding: const EdgeInsets.all(24), child: content()),
         ),
       ),

--- a/lib/ui/settings/server_settings/group_client/widgets/group_details_screen.dart
+++ b/lib/ui/settings/server_settings/group_client/widgets/group_details_screen.dart
@@ -253,9 +253,15 @@ class _GroupDetailsScreenState extends State<GroupDetailsScreen> {
   }
 
   void openNameModal() {
+    final mediaQuery = MediaQuery.of(context);
+    final isSmallLandscape =
+        mediaQuery.size.width > mediaQuery.size.height &&
+        mediaQuery.size.height < ResponsiveConstants.medium;
+
     if (MediaQuery.of(context).size.width > ResponsiveConstants.medium) {
       showDialog(
         context: context,
+        useSafeArea: !isSmallLandscape,
         useRootNavigator: false,
         builder: (ctx) => EditGroupModal(
           group: _group,
@@ -293,9 +299,15 @@ class _GroupDetailsScreenState extends State<GroupDetailsScreen> {
   }
 
   void openCommentModal() {
+    final mediaQuery = MediaQuery.of(context);
+    final isSmallLandscape =
+        mediaQuery.size.width > mediaQuery.size.height &&
+        mediaQuery.size.height < ResponsiveConstants.medium;
+
     if (MediaQuery.of(context).size.width > ResponsiveConstants.medium) {
       showDialog(
         context: context,
+        useSafeArea: !isSmallLandscape,
         useRootNavigator: false,
         builder: (ctx) => EditGroupModal(
           group: _group,

--- a/lib/ui/settings/server_settings/group_client/widgets/group_details_screen.dart
+++ b/lib/ui/settings/server_settings/group_client/widgets/group_details_screen.dart
@@ -127,7 +127,7 @@ class _GroupDetailsScreenState extends State<GroupDetailsScreen> {
                 Icons.edit_rounded,
                 color: Theme.of(context).colorScheme.onSurfaceVariant,
               ),
-              onTap: openEditGroupModal,
+              onTap: openNameModal,
             ),
             ListTile(
               leading: const Icon(Icons.comment_rounded),
@@ -141,7 +141,7 @@ class _GroupDetailsScreenState extends State<GroupDetailsScreen> {
                 Icons.edit_rounded,
                 color: Theme.of(context).colorScheme.onSurfaceVariant,
               ),
-              onTap: openEditGroupModal,
+              onTap: openCommentModal,
             ),
             SectionLabel(label: AppLocalizations.of(context)!.groupInfo),
             ListTile(
@@ -252,13 +252,16 @@ class _GroupDetailsScreenState extends State<GroupDetailsScreen> {
     }
   }
 
-  void openEditGroupModal() {
+  void openNameModal() {
     if (MediaQuery.of(context).size.width > ResponsiveConstants.medium) {
       showDialog(
         context: context,
         useRootNavigator: false,
         builder: (ctx) => EditGroupModal(
           group: _group,
+          keyItem: 'name',
+          title: AppLocalizations.of(context)!.groupEdit,
+          icon: Icons.group_rounded,
           onConfirm: (request) => onEditGroup((
             name: _group.name,
             newName: request.name,
@@ -273,9 +276,52 @@ class _GroupDetailsScreenState extends State<GroupDetailsScreen> {
         context: context,
         builder: (ctx) => EditGroupModal(
           group: _group,
+          keyItem: 'name',
+          title: AppLocalizations.of(context)!.groupEdit,
+          icon: Icons.group_rounded,
           onConfirm: (request) => onEditGroup((
             name: _group.name,
             newName: request.name,
+            comment: request.comment,
+            enabled: request.enabled,
+          )),
+          window: false,
+        ),
+        isScrollControlled: true,
+      );
+    }
+  }
+
+  void openCommentModal() {
+    if (MediaQuery.of(context).size.width > ResponsiveConstants.medium) {
+      showDialog(
+        context: context,
+        useRootNavigator: false,
+        builder: (ctx) => EditGroupModal(
+          group: _group,
+          keyItem: 'comment',
+          title: AppLocalizations.of(context)!.editComment,
+          icon: Icons.comment_rounded,
+          onConfirm: (request) => onEditGroup((
+            name: _group.name,
+            newName: null,
+            comment: request.comment,
+            enabled: request.enabled,
+          )),
+          window: true,
+        ),
+      );
+    } else {
+      showModalBottomSheet(
+        context: context,
+        builder: (ctx) => EditGroupModal(
+          group: _group,
+          keyItem: 'comment',
+          title: AppLocalizations.of(context)!.editComment,
+          icon: Icons.comment_rounded,
+          onConfirm: (request) => onEditGroup((
+            name: _group.name,
+            newName: null,
             comment: request.comment,
             enabled: request.enabled,
           )),

--- a/test/ui/settings/server_settings/group_client/group_client_screen_test.dart
+++ b/test/ui/settings/server_settings/group_client/group_client_screen_test.dart
@@ -624,6 +624,17 @@ void main() async {
       await tester.tap(find.text('Group name'));
       await tester.pumpAndSettle();
       expect(find.byType(EditGroupModal), findsOneWidget);
+      expect(find.text('Edit group'), findsOneWidget);
+      expect(find.byType(TextField), findsOneWidget);
+
+      await tester.tap(find.text('Cancel'));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('Comment'));
+      await tester.pumpAndSettle();
+      expect(find.byType(EditGroupModal), findsOneWidget);
+      expect(find.text('Edit comment'), findsOneWidget);
+      expect(find.byType(TextField), findsOneWidget);
 
       await tester.tap(find.text('Cancel'));
       await tester.pumpAndSettle();


### PR DESCRIPTION
## Overview
The add and edit sheets for groups and clients now match the ones used by adlists, domains and local DNS. On a phone the content no longer sits at the top of the sheet with a large empty gap below it. 

Editing a group now opens one sheet per field, so the name and the comment are changed separately.

## Changes
- Group and client edit sheets use the same layout, height and spacing as the other screens.
- Group and client add sheets size themselves to their content instead of a fixed height.
- The group details screen opens a separate sheet for the group name and for the comment.
- Widget tests check that each field opens its own sheet with a single input.

## Summary by Sourcery

Standardize group and client sheets across responsive layouts and split group editing into focused field-specific sheets.

Bug Fixes:
- Align group and client add and edit sheets across phone, desktop, and small-landscape layouts to eliminate excessive empty space and improve safe-area handling.
- Separate group name and comment editing into independent sheets, each focused on a single field.

Enhancements:
- Make add sheets size to their content and standardize modal spacing, sizing, and landscape presentation.
- Apply consistent modal behavior to related group and client editing flows.

Tests:
- Verify that group name and comment editing open separate single-input sheets.